### PR TITLE
ALS-4237: Upgrade mysql connector version for security scans

### DIFF
--- a/pic-sure-api-war/pom.xml
+++ b/pic-sure-api-war/pom.xml
@@ -91,9 +91,9 @@
 						<configuration>
 							<artifactItems>
 								<artifactItem>
-									<groupId>mysql</groupId>
-									<artifactId>mysql-connector-java</artifactId>
-									<version>5.1.38</version>
+									<groupId>com.mysql</groupId>
+									<artifactId>mysql-connector-j</artifactId>
+									<version>8.0.32</version>
 									<type>jar</type>
 									<overWrite>true</overWrite>
 									<outputDirectory>${project.build.directory}/modules/system/layers/base/com/sql/mysql/main/</outputDirectory>

--- a/pic-sure-api-wildfly/pom.xml
+++ b/pic-sure-api-wildfly/pom.xml
@@ -154,9 +154,9 @@
 						<configuration>
 							<artifactItems>
 								<artifactItem>
-									<groupId>mysql</groupId>
-									<artifactId>mysql-connector-java</artifactId>
-									<version>5.1.38</version>
+									<groupId>com.mysql</groupId>
+									<artifactId>mysql-connector-j</artifactId>
+									<version>8.0.32</version>
 									<type>jar</type>
 									<overWrite>true</overWrite>
 									<outputDirectory>${jboss.home}/modules/system/layers/base/com/sql/mysql/main/</outputDirectory>


### PR DESCRIPTION
I tested this on BDC integration, and the upgraded driver seems to work fine.