### PR TITLE
ALS-4392: Add resteasy jackson provider

### DIFF
--- a/pic-sure-api-war/pom.xml
+++ b/pic-sure-api-war/pom.xml
@@ -44,7 +44,6 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>javax.xml.bind</groupId>
 			<artifactId>jaxb-api</artifactId>
@@ -72,6 +71,10 @@
 			<artifactId>cxf-rt-frontend-jaxrs</artifactId>
 			<version>3.4.1</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.resteasy</groupId>
+			<artifactId>resteasy-jackson2-provider</artifactId>
 		</dependency>
 	</dependencies>
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -202,9 +202,10 @@
 			</dependency>
 			<dependency>
 				<groupId>org.jboss.resteasy</groupId>
-				<artifactId>resteasy-jackson-provider</artifactId>
-				<version>3.15.1</version>
+				<artifactId>resteasy-jackson2-provider</artifactId>
+				<version>3.15.6.Final</version>
 			</dependency>
+
 		</dependencies>
 
 	</dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -192,13 +192,18 @@
 			<dependency>
 				<groupId>org.jboss.resteasy</groupId>
 				<artifactId>resteasy-jaxb-provider</artifactId>
-				<version>3.0.8.Final</version>
+				<version>3.15.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
 				<version>2.23.4</version>
 				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.jboss.resteasy</groupId>
+				<artifactId>resteasy-jackson-provider</artifactId>
+				<version>3.15.1</version>
 			</dependency>
 		</dependencies>
 


### PR DESCRIPTION
This adds a jackson provider for resteasy, to fix the serialization issues we are having in jboss. This library should not affect wildfly environments.