### PR TITLE
Query result metadata field decoding fix

### DIFF
--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/service/PicsureQueryService.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/service/PicsureQueryService.java
@@ -19,6 +19,7 @@ import javax.inject.Inject;
 import javax.transaction.Transactional;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
+import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.util.*;
 
@@ -258,8 +259,8 @@ public class PicsureQueryService {
         Map<String, Object> metadata = new HashMap<String, Object>();
         try {
 			metadata.put(QUERY_JSON_FIELD, new ObjectMapper().readValue(query.getQuery(), Object.class));
-			metadata.put(QUERY_RESULT_METADATA_FIELD, String.valueOf(query.getMetadata()));
-		} catch (JsonProcessingException e) {
+			metadata.put(QUERY_RESULT_METADATA_FIELD, new String(query.getMetadata(), StandardCharsets.UTF_8));
+		} catch (JsonProcessingException | NullPointerException e) {
 			logger.warn("Unable to use object mapper", e);
 		}
 

--- a/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/PicsureQueryServiceTest.java
+++ b/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/PicsureQueryServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import javax.ws.rs.core.HttpHeaders;
@@ -16,11 +17,13 @@ import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
@@ -413,6 +416,31 @@ public class PicsureQueryServiceTest extends BaseServiceTest {
 		assertEquals("Resource result id and Picsure result id should match in case of no resource result id",
 				queryId.toString(), queryEntity.getResourceResultId());
 
+	}
+
+	@Test
+	public void testShouldQueryMetadata() {
+		Resource resource = new Resource();
+		resource.setUuid(resourceId);
+		String resultId = UUID.randomUUID().toString();
+		Query query = new Query();
+		query.setQuery("{}");
+		query.setResource(resource);
+		query.setStatus(PicSureStatus.AVAILABLE);
+		query.setStartTime(new java.sql.Date(System.currentTimeMillis()));
+		query.setResourceResultId(resultId);
+
+		String metaData = "{\\\"picsureQueryId\\\":\\\"b9e6cea7-142e-5859-8e98-1245c959fc0b\\\"," +
+			"\\\"commonAreaId\\\":\\\"290a9d2e-1a20-4407-b351-499185f5554e\\\"}";
+
+		query.setMetadata(metaData.getBytes(StandardCharsets.UTF_8));
+
+		Mockito.when(queryRepo.getById(query.getUuid()))
+			.thenReturn(query);
+
+		QueryStatus status = queryService.queryMetadata(query.getUuid(), null);
+		String actual = (String) status.getResultMetadata().get("queryResultMetadata");
+		Assert.assertEquals(metaData, actual);
 	}
 	
 	@Test


### PR DESCRIPTION
- in the metadata of QueryStatus, the query result metadata field was always gibberish
- This fixes that