### PR TITLE
[ALS-4771] Add common area UUID to query

### DIFF
--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/service/PicsureQueryService.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/service/PicsureQueryService.java
@@ -308,11 +308,17 @@ public class PicsureQueryService {
 			}
 		}
 
+		Map<String, Object> metaData = response.getResultMetadata();
+		metaData = metaData == null ? new HashMap<>() : metaData;
+		if (dataQueryRequest.getCommonAreaUUID() != null) {
+			metaData.put("commonAreaUUID", dataQueryRequest.getCommonAreaUUID());
+		}
+
 		queryEntity.setQuery(queryJson);
 
-		if (response.getResultMetadata() != null) {
+		if (!metaData.isEmpty()) {
 			try {
-				queryEntity.setMetadata(mapper.writeValueAsString(response.getResultMetadata()).getBytes());
+				queryEntity.setMetadata(mapper.writeValueAsString(metaData).getBytes());
 			} catch (JsonProcessingException e) {
 				logger.warn("Unable to parse metadata ", e);
 			}

--- a/pic-sure-resources/pic-sure-passthrough-resource/src/main/java/edu/harvard/hms/dbmi/avillach/resource/passthru/PassThroughResourceRS.java
+++ b/pic-sure-resources/pic-sure-passthrough-resource/src/main/java/edu/harvard/hms/dbmi/avillach/resource/passthru/PassThroughResourceRS.java
@@ -101,6 +101,7 @@ public class PassThroughResourceRS implements IResourceRS {
 			chainRequest.setQuery(queryRequest.getQuery());
 			chainRequest.setResourceCredentials(queryRequest.getResourceCredentials());
 			chainRequest.setResourceUUID(UUID.fromString(properties.getTargetResourceId()));
+			chainRequest.setCommonAreaUUID(queryRequest.getCommonAreaUUID());
 
 			String payload = objectMapper.writeValueAsString(chainRequest);
 			HttpResponse response = httpClient.retrievePostResponse(

--- a/pic-sure-resources/pic-sure-resource-api/src/main/java/edu/harvard/dbmi/avillach/domain/QueryRequest.java
+++ b/pic-sure-resources/pic-sure-resource-api/src/main/java/edu/harvard/dbmi/avillach/domain/QueryRequest.java
@@ -1,9 +1,11 @@
 package edu.harvard.dbmi.avillach.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 @Schema(name = "QueryRequest", description = "Object containing credentials map under 'resourceCredentials' and query" +
@@ -38,6 +40,8 @@ import java.util.UUID;
 				"        \"fields\": []\n" +
 				"    }\n" +
 				"}")
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class QueryRequest {
 
 	@Schema(hidden = true)
@@ -48,6 +52,9 @@ public class QueryRequest {
 
 	@Schema(hidden = true)
 	private UUID resourceUUID;
+
+	@Schema(hidden = true)
+	private UUID commonAreaUUID;
 
 	public Map<String, String> getResourceCredentials() {
 		return resourceCredentials;
@@ -71,5 +78,13 @@ public class QueryRequest {
 
 	public void setResourceUUID(UUID resourceUUID) {
 		this.resourceUUID = resourceUUID;
+	}
+
+	public UUID getCommonAreaUUID() {
+		return commonAreaUUID;
+	}
+
+	public void setCommonAreaUUID(UUID commonAreaUUID) {
+		this.commonAreaUUID = commonAreaUUID;
 	}
 }

--- a/pic-sure-resources/pic-sure-resource-api/src/test/java/edu/harvard/dbmi/avillach/domain/QueryRequestTest.java
+++ b/pic-sure-resources/pic-sure-resource-api/src/test/java/edu/harvard/dbmi/avillach/domain/QueryRequestTest.java
@@ -1,0 +1,45 @@
+package edu.harvard.dbmi.avillach.domain;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import junit.framework.TestCase;
+
+import java.util.HashMap;
+import java.util.Objects;
+import java.util.UUID;
+
+public class QueryRequestTest extends TestCase {
+
+    public void testShouldIgnoreMissingQueryId() throws JsonProcessingException {
+        QueryRequest expected = new QueryRequestWithEq();
+        expected.setQuery("{}");
+        expected.setResourceCredentials(new HashMap<>());
+        expected.setResourceUUID(UUID.fromString("364c958e-53bb-4be7-bd5b-44fcda1592bc"));
+        expected.setCommonAreaUUID(null);
+
+        ObjectMapper mapper = new ObjectMapper();
+        String jsonWithNoCUUID =
+            "{\"resourceCredentials\":{},\"query\":\"{}\",\"resourceUUID\":\"364c958e-53bb-4be7-bd5b-44fcda1592bc\"}";
+        QueryRequest actual = mapper.readValue(jsonWithNoCUUID, QueryRequestWithEq.class);
+
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * This is just to get comparison to work for the test.
+     */
+    private static final class QueryRequestWithEq extends QueryRequest {
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof QueryRequestWithEq)) return false;
+            QueryRequestWithEq that = (QueryRequestWithEq) o;
+            return Objects.equals(getResourceCredentials(), that.getResourceCredentials()) && Objects.equals(getQuery(), that.getQuery()) && Objects.equals(getResourceUUID(), that.getResourceUUID()) && Objects.equals(getCommonAreaUUID(), that.getCommonAreaUUID());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getResourceCredentials(), getQuery(), getResourceUUID(), getCommonAreaUUID());
+        }
+    }
+}


### PR DESCRIPTION
- When the GIC common area makes a federated query request to
the institute nodes, it passes a UUID for the query
- This UUID is to be used in later development as a unifying,
interinstitutional identifier for stuff like data sharing

- Add query UUID to QueryRequest
  - Make QueryRequest ignore unknown fields for backwards compatability
- Add UUID to query meta in passthrough
- Sanity test for missing UUID jackson stuff