### PR TITLE
[ALS-5056] Get Query Site of Origin

### DIFF
--- a/pic-sure-api-data/src/main/java/edu/harvard/dbmi/avillach/data/entity/DataSharingStatus.java
+++ b/pic-sure-api-data/src/main/java/edu/harvard/dbmi/avillach/data/entity/DataSharingStatus.java
@@ -1,0 +1,5 @@
+package edu.harvard.dbmi.avillach.data.entity;
+
+public enum DataSharingStatus {
+    Unknown, Pending, Error, Complete, NotShared
+}

--- a/pic-sure-api-data/src/main/java/edu/harvard/dbmi/avillach/data/entity/Site.java
+++ b/pic-sure-api-data/src/main/java/edu/harvard/dbmi/avillach/data/entity/Site.java
@@ -1,0 +1,53 @@
+package edu.harvard.dbmi.avillach.data.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+
+@Schema(description = "A site that contains a PIC-SURE installation that we can send data to")
+@Table(uniqueConstraints = {
+    @UniqueConstraint(name = "unique_code", columnNames = { "code" }),
+    @UniqueConstraint(name = "unique_email", columnNames = { "domain" })
+})
+@Entity(name = "site")
+public class Site extends BaseEntity {
+
+    @Schema(description = "The site code. Ex: BCH")
+    @Column(length = 15)
+    private String code;
+
+    @Schema(description = "The site name. Ex: Boston Children's")
+    @Column(length = 255)
+    private String name;
+
+    @Schema(description = "The email domain of users for this site. Ex: childrens.harvard.edu")
+    @Column(length = 255)
+    private String domain;
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public void setDomain(String domain) {
+        this.domain = domain;
+    }
+}

--- a/pic-sure-api-data/src/main/java/edu/harvard/dbmi/avillach/data/repository/SiteRepository.java
+++ b/pic-sure-api-data/src/main/java/edu/harvard/dbmi/avillach/data/repository/SiteRepository.java
@@ -1,0 +1,14 @@
+package edu.harvard.dbmi.avillach.data.repository;
+
+import edu.harvard.dbmi.avillach.data.entity.NamedDataset;
+import edu.harvard.dbmi.avillach.data.entity.Site;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.transaction.Transactional;
+import java.util.UUID;
+
+@Transactional
+@ApplicationScoped
+public class SiteRepository extends BaseRepository<Site, UUID>{
+    protected SiteRepository() {super(Site.class);}
+}

--- a/pic-sure-api-data/src/main/resources/db/sql/V6__ADD_SITE_TABLE.sql
+++ b/pic-sure-api-data/src/main/resources/db/sql/V6__ADD_SITE_TABLE.sql
@@ -1,0 +1,11 @@
+USE `picsure`;
+
+CREATE TABLE `site` (
+    `uuid` binary(16) NOT NULL,
+    `code` varchar(15) COLLATE utf8_bin DEFAULT NULL,
+    `name` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+    `domain` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+    PRIMARY KEY (`uuid`),
+    CONSTRAINT `unique_code` UNIQUE (`code`),
+    CONSTRAINT `unique_domain` UNIQUE (`domain`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;

--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/PicsureRS.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/PicsureRS.java
@@ -8,12 +8,10 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
 
 import edu.harvard.dbmi.avillach.domain.*;
-import edu.harvard.dbmi.avillach.service.FormatService;
-import edu.harvard.dbmi.avillach.service.PicsureInfoService;
-import edu.harvard.dbmi.avillach.service.PicsureQueryService;
-import edu.harvard.dbmi.avillach.service.PicsureSearchService;
+import edu.harvard.dbmi.avillach.service.*;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.info.Info;
@@ -153,11 +151,15 @@ public class PicsureRS {
 
 		@Parameter
 		@QueryParam("isInstitute")
-		Boolean isInstitutionQuery
+		Boolean isInstitutionQuery,
+
+		@Context SecurityContext context
 	) {
-		return isInstitutionQuery == null || !isInstitutionQuery ?
-			queryService.query(dataQueryRequest, headers) :
-			queryService.institutionalQuery(dataQueryRequest, headers);
+		if (isInstitutionQuery == null || !isInstitutionQuery) {
+			return queryService.query(dataQueryRequest, headers);
+		} else {
+			return queryService.institutionalQuery(dataQueryRequest, headers, context.getUserPrincipal().getName());
+		}
 	}
 	
 	@POST

--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/service/SiteParsingService.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/service/SiteParsingService.java
@@ -1,0 +1,41 @@
+package edu.harvard.dbmi.avillach.service;
+
+import edu.harvard.dbmi.avillach.data.entity.Site;
+import edu.harvard.dbmi.avillach.data.repository.SiteRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SiteParsingService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SiteParsingService.class);
+
+    private static final Pattern emailRegex = Pattern.compile("^([^@]+)(@)(.*)$");
+
+    @Inject
+    SiteRepository repository;
+
+    public Optional<String> parseSiteOfOrigin(String email) {
+        Matcher matcher = emailRegex.matcher(email);
+        if (!matcher.find()) {
+            LOG.warn("Unable to parse domain for email: {}", email);
+            return Optional.empty();
+        }
+
+        List<Site> matchingDomains = repository.getByColumn("domain", matcher.group(3));
+        if (matchingDomains.isEmpty()) {
+            LOG.warn("Unable to match domain for email: {}, looked for domain: {}", email, matcher.group(3));
+            return Optional.empty();
+        }
+        if (matchingDomains.size() > 1) {
+            LOG.warn("Multiple domains match email. This should never happen! Email: {}", email);
+            return Optional.empty();
+        }
+        return Optional.of(matchingDomains.get(0).getCode());
+    }
+}

--- a/pic-sure-api-war/src/main/resources/META-INF/persistence.xml
+++ b/pic-sure-api-war/src/main/resources/META-INF/persistence.xml
@@ -7,6 +7,7 @@
 		<class>edu.harvard.dbmi.avillach.data.entity.Query</class>
 		<class>edu.harvard.dbmi.avillach.data.entity.Resource</class>
 		<class>edu.harvard.dbmi.avillach.data.entity.NamedDataset</class>
+		<class>edu.harvard.dbmi.avillach.data.entity.Site</class>
 
 		<properties>
 			<property name="hibernate.archive.autodetection" value="class" />

--- a/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/service/SiteParsingServiceTest.java
+++ b/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/service/SiteParsingServiceTest.java
@@ -1,0 +1,74 @@
+package edu.harvard.dbmi.avillach.service;
+
+import edu.harvard.dbmi.avillach.data.entity.Site;
+import edu.harvard.dbmi.avillach.data.repository.SiteRepository;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SiteParsingServiceTest {
+
+    @InjectMocks
+    private SiteParsingService subject;
+
+    @Mock
+    private SiteRepository repository;
+
+    @Test
+    public void shouldParse() {
+        Site site = new Site();
+        site.setCode("BCH");
+        site.setName("Bowston Children's Hospital");
+        site.setDomain("childrens.harvard.edu");
+        Mockito
+            .when(repository.getByColumn("domain", "childrens.harvard.edu"))
+            .thenReturn(List.of(site));
+
+        Optional<String> actual = subject.parseSiteOfOrigin("aaaaaaah@childrens.harvard.edu");
+        Optional<String> expected = Optional.of("BCH");
+
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldFailWhenNoSite() {
+        Mockito
+            .when(repository.getByColumn("domain", "childrens.harvard.edu"))
+            .thenReturn(List.of());
+
+        Optional<String> actual = subject.parseSiteOfOrigin("aaaaaaah@childrens.harvard.edu");
+        Optional<String> expected = Optional.empty();
+
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldFailWhenManySites() {
+        Site siteA = new Site();
+        siteA.setCode("BCH");
+        siteA.setName("Bowston Children's Hospital");
+        siteA.setDomain("edu");
+        Site siteB = new Site();
+        siteB.setCode("CHOP");
+        siteB.setName("Children's Hospital of Philly");
+        siteB.setDomain("edu");
+        Mockito
+            .when(repository.getByColumn("domain", "edu"))
+            .thenReturn(List.of(siteA, siteB));
+
+        Optional<String> actual = subject.parseSiteOfOrigin("aaaaaaah@edu");
+        Optional<String> expected = Optional.empty();
+
+        Assert.assertEquals(expected, actual);
+    }
+}

--- a/pic-sure-resources/pic-sure-passthrough-resource/src/main/java/edu/harvard/hms/dbmi/avillach/resource/passthru/PassThroughResourceRS.java
+++ b/pic-sure-resources/pic-sure-passthrough-resource/src/main/java/edu/harvard/hms/dbmi/avillach/resource/passthru/PassThroughResourceRS.java
@@ -5,8 +5,10 @@ import java.util.UUID;
 
 import javax.inject.Inject;
 import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
 
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
@@ -102,6 +104,7 @@ public class PassThroughResourceRS implements IResourceRS {
 			chainRequest.setResourceCredentials(queryRequest.getResourceCredentials());
 			chainRequest.setResourceUUID(UUID.fromString(properties.getTargetResourceId()));
 			chainRequest.setCommonAreaUUID(queryRequest.getCommonAreaUUID());
+			chainRequest.setInstitutionOfOrigin(queryRequest.getInstitutionOfOrigin());
 
 			String payload = objectMapper.writeValueAsString(chainRequest);
 			HttpResponse response = httpClient.retrievePostResponse(

--- a/pic-sure-resources/pic-sure-resource-api/src/main/java/edu/harvard/dbmi/avillach/domain/QueryRequest.java
+++ b/pic-sure-resources/pic-sure-resource-api/src/main/java/edu/harvard/dbmi/avillach/domain/QueryRequest.java
@@ -56,6 +56,9 @@ public class QueryRequest {
 	@Schema(hidden = true)
 	private UUID commonAreaUUID;
 
+	@Schema(hidden = true)
+	private String institutionOfOrigin;
+
 	public Map<String, String> getResourceCredentials() {
 		return resourceCredentials;
 	}
@@ -86,5 +89,13 @@ public class QueryRequest {
 
 	public void setCommonAreaUUID(UUID commonAreaUUID) {
 		this.commonAreaUUID = commonAreaUUID;
+	}
+
+	public String getInstitutionOfOrigin() {
+		return institutionOfOrigin;
+	}
+
+	public void setInstitutionOfOrigin(String institutionOfOrigin) {
+		this.institutionOfOrigin = institutionOfOrigin;
 	}
 }


### PR DESCRIPTION
- Requirement: in order to know where to send data, we need to associate each query with the requester's site
- Create table of site code, site name, site email domain
- When an institutional query request is made:
  - Parse the site code from the email of the requesting user
  - Add that site code to the query request
- When persisting a query object after starting a query request
  - Check for a site code in the query request
  - Add it to the query meta if it exists
- S3 status start
  - status enum
  - add to query meta during copy