### PR TITLE
[ALS-0000] Checkmarx Fix - Check domain of proxy request

### DIFF
--- a/pic-sure-resources/pic-sure-resource-api/pom.xml
+++ b/pic-sure-resources/pic-sure-resource-api/pom.xml
@@ -67,6 +67,11 @@
           <version>5.9.3</version>
           <scope>test</scope>
       </dependency>
+      <dependency>
+          <groupId>edu.harvard.hms.dbmi.avillach</groupId>
+          <artifactId>pic-sure-api-data</artifactId>
+          <version>2.1.0-SNAPSHOT</version>
+      </dependency>
 
   </dependencies>
 </project>

--- a/pic-sure-resources/pic-sure-resource-api/src/test/java/edu/harvard/dbmi/avillach/service/ProxyWebClientTest.java
+++ b/pic-sure-resources/pic-sure-resource-api/src/test/java/edu/harvard/dbmi/avillach/service/ProxyWebClientTest.java
@@ -1,5 +1,7 @@
 package edu.harvard.dbmi.avillach.service;
 
+import edu.harvard.dbmi.avillach.data.entity.Resource;
+import edu.harvard.dbmi.avillach.data.repository.ResourceRepository;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -16,6 +18,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import javax.ws.rs.core.Response;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -31,6 +34,9 @@ public class ProxyWebClientTest {
     @Mock
     private HttpEntity entity;
 
+    @Mock
+    private ResourceRepository resourceRepository;
+
     @InjectMocks
     private ProxyWebClient subject;
 
@@ -42,6 +48,8 @@ public class ProxyWebClientTest {
             .thenReturn(entity);
         Mockito.when(entity.getContent())
             .thenReturn(new ByteArrayInputStream("{}".getBytes()));
+        Mockito.when(resourceRepository.getByColumn("name", "foo"))
+            .thenReturn(List.of(new Resource()));
         subject.client = client;
 
         Response actual = subject.postProxy("foo", "/my/cool/path", "{}");
@@ -57,10 +65,24 @@ public class ProxyWebClientTest {
             .thenReturn(entity);
         Mockito.when(entity.getContent())
             .thenReturn(new ByteArrayInputStream("{}".getBytes()));
+        Mockito.when(resourceRepository.getByColumn("name", "bar"))
+            .thenReturn(List.of(new Resource()));
         subject.client = client;
 
         Response actual = subject.getProxy("bar", "/my/cool/path");
 
         Assert.assertEquals(200, actual.getStatus());
+    }
+
+    @Test
+    public void shouldRejectNastyHost() {
+        Mockito.when(resourceRepository.getByColumn("name", "an.evil.domain"))
+            .thenReturn(List.of());
+
+        Response actual = subject.postProxy("an.evil.domain", "hax", null);
+        assertEquals(400, actual.getStatus());
+
+        actual = subject.getProxy("an.evil.domain", "hax");
+        assertEquals(400, actual.getStatus());
     }
 }


### PR DESCRIPTION
- We don't want an attacker leveraging the proxy client to make requests to 3rd party domains
- At the moment, this is just intended for docker containers in the same network, so I just made a regex that restricts the host to reasonable container names