### PR TITLE
[ALS-5422] Add persistence.xml to visualization resource

### DIFF
--- a/pic-sure-resources/pic-sure-visualization-resource/src/main/resources/META-INF/persistence.xml
+++ b/pic-sure-resources/pic-sure-visualization-resource/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.1"
+             xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
+    <persistence-unit name="picsure">
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
The visualization resource is failing to start due to an error injecting persistence unit into CDI managed bean. It is unable to find a persistence unit named ''.