### PR TITLE
[ALS-6080] Info/resource returns both stacks resource UUIDs

### DIFF
--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/JAXRSConfiguration.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/JAXRSConfiguration.java
@@ -41,6 +41,7 @@ public class JAXRSConfiguration extends Application {
             ctx.close();
         } catch (NamingException e) {
             // Currently, this parameter is optional and only used if there is more than one application stack.
+            logger.info("No application stack found. This is only a problem if there is more than one application stack.");
             application_stack = null;
         }
     }

--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/JAXRSConfiguration.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/JAXRSConfiguration.java
@@ -19,6 +19,8 @@ public class JAXRSConfiguration extends Application {
 
     public static String rolesClaim;
 
+    public static String application_stack;
+
     @PostConstruct
     public void init() {
         logger.info("Starting pic-sure core app.");
@@ -27,10 +29,24 @@ public class JAXRSConfiguration extends Application {
         initializeRolesClaim();
         logger.info("Finished initializing roles claim.");
 
+        logger.info("Load optional properties.");
+        initializeApplicationStack();
+        logger.info("Finished loading optional properties.");
     }
 
-    private void initializeRolesClaim(){
-        try{
+    private void initializeApplicationStack() {
+        try {
+            Context ctx = new InitialContext();
+            application_stack = (String) ctx.lookup("global/application_stack");
+            ctx.close();
+        } catch (NamingException e) {
+            // Currently, this parameter is optional and only used if there is more than one application stack.
+            application_stack = null;
+        }
+    }
+
+    private void initializeRolesClaim() {
+        try {
             Context ctx = new InitialContext();
             rolesClaim = (String) ctx.lookup("global/roles_claim");
             ctx.close();
@@ -39,7 +55,6 @@ public class JAXRSConfiguration extends Application {
         }
     }
 
-    public JAXRSConfiguration(){
-    }
+    public JAXRSConfiguration() {}
 
 }

--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/service/PicsureInfoService.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/service/PicsureInfoService.java
@@ -72,14 +72,7 @@ public class PicsureInfoService {
     public Map<UUID, String> resources(HttpHeaders headers) {
         logger.info("path=/info/resources, requestSource={}", Utilities.getRequestSourceFromHeader(headers));
 
-        // We need a way to only return resources for this stack.
-        // Going to create an optional property in the standalone.xml
         if (StringUtils.isNotBlank(JAXRSConfiguration.application_stack)) {
-            // The resource resourceRSPath will contain the stack value
-            // http://dictionary.b.${env_private_dns_name}:8080/dictionary/pic-sure
-            // The application stack is a, b, c, etc.
-            // I will look for %.${application_stack}.% in the url
-            // Or the resource domain is localhost.
             return resourceRepo.list().stream()
                 .filter(
                     resource -> resource.getResourceRSPath().contains("." + JAXRSConfiguration.application_stack + ".")

--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/service/PicsureInfoService.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/service/PicsureInfoService.java
@@ -76,7 +76,7 @@ public class PicsureInfoService {
             return resourceRepo.list().stream()
                 .filter(
                     resource -> resource.getResourceRSPath().contains("." + JAXRSConfiguration.application_stack + ".")
-                        || resource.getResourceRSPath().contains("localhost")
+                        || resource.getResourceRSPath().contains("localhost") || resource.getHidden()
                 ).collect(Collectors.toMap(Resource::getUuid, Resource::getName));
         }
 

--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/service/PicsureInfoService.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/service/PicsureInfoService.java
@@ -75,8 +75,8 @@ public class PicsureInfoService {
         if (StringUtils.isNotBlank(JAXRSConfiguration.application_stack)) {
             return resourceRepo.list().stream()
                 .filter(
-                    resource -> resource.getResourceRSPath().contains("." + JAXRSConfiguration.application_stack + ".")
-                        || resource.getResourceRSPath().contains("localhost") || resource.getHidden()
+                    resource -> (resource.getResourceRSPath().contains("." + JAXRSConfiguration.application_stack + ".")
+                        || resource.getResourceRSPath().contains("localhost")) && !resource.getHidden()
                 ).collect(Collectors.toMap(Resource::getUuid, Resource::getName));
         }
 

--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/service/PicsureInfoService.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/service/PicsureInfoService.java
@@ -1,6 +1,7 @@
 package edu.harvard.dbmi.avillach.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.harvard.dbmi.avillach.JAXRSConfiguration;
 import edu.harvard.dbmi.avillach.data.entity.Resource;
 import edu.harvard.dbmi.avillach.data.repository.ResourceRepository;
 import edu.harvard.dbmi.avillach.domain.GeneralQueryRequest;
@@ -9,6 +10,7 @@ import edu.harvard.dbmi.avillach.domain.ResourceInfo;
 import edu.harvard.dbmi.avillach.util.Utilities;
 import edu.harvard.dbmi.avillach.util.exception.ApplicationException;
 import edu.harvard.dbmi.avillach.util.exception.ProtocolException;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,55 +23,67 @@ import java.util.stream.Collectors;
 
 public class PicsureInfoService {
 
-	private final Logger logger = LoggerFactory.getLogger(PicsureQueryService.class);
+    private final Logger logger = LoggerFactory.getLogger(PicsureQueryService.class);
 
-	private final static ObjectMapper mapper = new ObjectMapper();
+    private final static ObjectMapper mapper = new ObjectMapper();
 
-	@Inject
-	ResourceRepository resourceRepo;
+    @Inject
+    ResourceRepository resourceRepo;
 
-	@Inject
-	ResourceWebClient resourceWebClient;
+    @Inject
+    ResourceWebClient resourceWebClient;
 
-	/**
-	 * Retrieve resource info for a specific resource.
-	 *
-	 * @param resourceId - Resource UUID
-	 * @param credentialsQueryRequest - Contains resource specific credentials map
-	 * @return a {@link edu.harvard.dbmi.avillach.domain.ResourceInfo ResourceInfo}
-	 */
-	public ResourceInfo info(UUID resourceId, QueryRequest credentialsQueryRequest, HttpHeaders headers) {
-		Resource resource = resourceRepo.getById(resourceId);
-		if (resource == null){
-			throw new ProtocolException(ProtocolException.RESOURCE_NOT_FOUND + resourceId.toString());
-		}
-		if (resource.getResourceRSPath() == null){
-			throw new ApplicationException(ApplicationException.MISSING_RESOURCE_PATH);
-		}
-		if (credentialsQueryRequest == null){
-			credentialsQueryRequest = new GeneralQueryRequest();
-		}
-		if (credentialsQueryRequest.getResourceCredentials() == null){
-			credentialsQueryRequest.setResourceCredentials(new HashMap<String, String>());
-		}
+    /**
+     * Retrieve resource info for a specific resource.
+     *
+     * @param resourceId - Resource UUID
+     * @param credentialsQueryRequest - Contains resource specific credentials map
+     * @return a {@link edu.harvard.dbmi.avillach.domain.ResourceInfo ResourceInfo}
+     */
+    public ResourceInfo info(UUID resourceId, QueryRequest credentialsQueryRequest, HttpHeaders headers) {
+        Resource resource = resourceRepo.getById(resourceId);
+        if (resource == null) {
+            throw new ProtocolException(ProtocolException.RESOURCE_NOT_FOUND + resourceId.toString());
+        }
+        if (resource.getResourceRSPath() == null) {
+            throw new ApplicationException(ApplicationException.MISSING_RESOURCE_PATH);
+        }
+        if (credentialsQueryRequest == null) {
+            credentialsQueryRequest = new GeneralQueryRequest();
+        }
+        if (credentialsQueryRequest.getResourceCredentials() == null) {
+            credentialsQueryRequest.setResourceCredentials(new HashMap<String, String>());
+        }
 
-		logger.info("path=/info/{resourceId}, resourceId={}, requestSource={}, credentialsQueryRequest={}",
-				resourceId,
-				Utilities.getRequestSourceFromHeader(headers),
-				Utilities.convertQueryRequestToString(mapper, credentialsQueryRequest)
-		);
+        logger.info(
+            "path=/info/{resourceId}, resourceId={}, requestSource={}, credentialsQueryRequest={}", resourceId,
+            Utilities.getRequestSourceFromHeader(headers), Utilities.convertQueryRequestToString(mapper, credentialsQueryRequest)
+        );
 
-		credentialsQueryRequest.getResourceCredentials().put(ResourceWebClient.BEARER_TOKEN_KEY, resource.getToken());
-		return resourceWebClient.info(resource.getResourceRSPath(), credentialsQueryRequest);
-	}
+        credentialsQueryRequest.getResourceCredentials().put(ResourceWebClient.BEARER_TOKEN_KEY, resource.getToken());
+        return resourceWebClient.info(resource.getResourceRSPath(), credentialsQueryRequest);
+    }
 
-	/**
-	 * Retrieve a list of all available resources.
-	 *
-	 * @return List containing limited metadata about all available resources and ids.
-	 */
-	public Map<UUID, String> resources(HttpHeaders headers) {
-		logger.info("path=/info/resources, requestSource={}", Utilities.getRequestSourceFromHeader(headers));
-		return resourceRepo.list().stream().collect(Collectors.toMap(Resource::getUuid, Resource::getName));
-	}
+    /**
+     * Retrieve a list of all available resources.
+     *
+     * @return List containing limited metadata about all available resources and ids.
+     */
+    public Map<UUID, String> resources(HttpHeaders headers) {
+        logger.info("path=/info/resources, requestSource={}", Utilities.getRequestSourceFromHeader(headers));
+
+        // We need a way to only return resources for this stack.
+        // Going to create an optional property in the standalone.xml
+        if (StringUtils.isNotBlank(JAXRSConfiguration.application_stack)) {
+            // The resource resourceRSPath will contain the stack value
+            // http://dictionary.b.${env_private_dns_name}:8080/dictionary/pic-sure
+            // The application stack is a, b, c, etc.
+            // I will look for %.${application_stack}.% in the url
+            return resourceRepo.list().stream()
+                .filter(resource -> resource.getResourceRSPath().contains("." + JAXRSConfiguration.application_stack + "."))
+                .collect(Collectors.toMap(Resource::getUuid, Resource::getName));
+        }
+
+        return resourceRepo.list().stream().collect(Collectors.toMap(Resource::getUuid, Resource::getName));
+    }
 }

--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/service/PicsureInfoService.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/service/PicsureInfoService.java
@@ -79,9 +79,12 @@ public class PicsureInfoService {
             // http://dictionary.b.${env_private_dns_name}:8080/dictionary/pic-sure
             // The application stack is a, b, c, etc.
             // I will look for %.${application_stack}.% in the url
+            // Or the resource domain is localhost.
             return resourceRepo.list().stream()
-                .filter(resource -> resource.getResourceRSPath().contains("." + JAXRSConfiguration.application_stack + "."))
-                .collect(Collectors.toMap(Resource::getUuid, Resource::getName));
+                .filter(
+                    resource -> resource.getResourceRSPath().contains("." + JAXRSConfiguration.application_stack + ".")
+                        || resource.getResourceRSPath().contains("localhost")
+                ).collect(Collectors.toMap(Resource::getUuid, Resource::getName));
         }
 
         return resourceRepo.list().stream().collect(Collectors.toMap(Resource::getUuid, Resource::getName));


### PR DESCRIPTION
[ALS-6080] Info/resource returns both stacks resource UUIDs. This issue is only present in AIM-AHEAD or BDC environments because there are two stacks.