### PR TITLE
[ALS-6665] Add JWTResponseFilter to handle refreshed tokens

### DIFF
--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/JWTFilter.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/JWTFilter.java
@@ -261,7 +261,7 @@ public class JWTFilter implements ContainerRequestFilter {
                 throw new NotAuthorizedException("Token invalid or expired");
             }
 
-            if (responseContent.get("tokenRefreshed").asBoolean()) {
+            if (responseContent.has("tokenRefreshed") && responseContent.get("tokenRefreshed").asBoolean()) {
                 requestContext.setProperty("refreshedToken", responseContent.get("token"));
             }
 

--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/JWTFilter.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/JWTFilter.java
@@ -42,242 +42,249 @@ import static edu.harvard.dbmi.avillach.util.Utilities.buildHttpClientContext;
 @Provider
 public class JWTFilter implements ContainerRequestFilter {
 
-	private final Logger logger = LoggerFactory.getLogger(JWTFilter.class);
+    private final Logger logger = LoggerFactory.getLogger(JWTFilter.class);
 
-	@Context
-	UriInfo uriInfo;
+    @Context
+    UriInfo uriInfo;
 
-	@Context
-	ResourceInfo resourceInfo;
+    @Context
+    ResourceInfo resourceInfo;
 
-	@Inject
-	ResourceRepository resourceRepo;
+    @Inject
+    ResourceRepository resourceRepo;
 
-	@Inject
-	ResourceWebClient resourceWebClient;
+    @Inject
+    ResourceWebClient resourceWebClient;
 
-	@Resource(mappedName = "java:global/user_id_claim")
-	private String userIdClaim;
+    @Resource(mappedName = "java:global/user_id_claim")
+    private String userIdClaim;
 
-	ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = new ObjectMapper();
 
-	@Inject
-	PicSureWarInit picSureWarInit;
+    @Inject
+    PicSureWarInit picSureWarInit;
 
-	@Inject
-	QueryRepository queryRepo;
+    @Inject
+    QueryRepository queryRepo;
 
-	@Override
-	public void filter(ContainerRequestContext requestContext) throws IOException {
-		logger.debug("Entered jwtfilter.filter()...");
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        logger.debug("Entered jwtfilter.filter()...");
 
-		if (uriInfo.getPath().endsWith("/openapi.json")) {
-			return;
-		}
+        if (uriInfo.getPath().endsWith("/openapi.json")) {
+            return;
+        }
 
-		if(requestContext.getUriInfo().getPath().contentEquals("/system/status") 
-				&& requestContext.getRequest().getMethod().contentEquals(HttpMethod.GET)) {
-			// GET calls to /system/status do not require authentication or authorization
-			requestContext.setProperty("username", "SYSTEM_MONITOR");
-		}else {
-			// Everything else goes through PSAMA token introspection
-			String authorizationHeader = requestContext.getHeaderString(HttpHeaders.AUTHORIZATION);
-			if (authorizationHeader == null || authorizationHeader.isEmpty()) {
-				throw new NotAuthorizedException("No authorization header found.");
-			}
-			String token = authorizationHeader.substring(6).trim();
+        if (
+            requestContext.getUriInfo().getPath().contentEquals("/system/status")
+                && requestContext.getRequest().getMethod().contentEquals(HttpMethod.GET)
+        ) {
+            // GET calls to /system/status do not require authentication or authorization
+            requestContext.setProperty("username", "SYSTEM_MONITOR");
+        } else {
+            // Everything else goes through PSAMA token introspection
+            String authorizationHeader = requestContext.getHeaderString(HttpHeaders.AUTHORIZATION);
+            if (authorizationHeader == null || authorizationHeader.isEmpty()) {
+                throw new NotAuthorizedException("No authorization header found.");
+            }
+            String token = authorizationHeader.substring(6).trim();
 
-			String userForLogging = null;
+            String userForLogging = null;
 
-			try {
-				AuthUser authenticatedUser = null;
+            try {
+                AuthUser authenticatedUser = null;
 
-				authenticatedUser = callTokenIntroEndpoint(requestContext, token, userIdClaim);
+                authenticatedUser = callTokenIntroEndpoint(requestContext, token, userIdClaim);
+                if (authenticatedUser == null) {
+                    logger.error("Cannot extract a user from token: " + token);
+                    throw new NotAuthorizedException("Cannot find or create a user");
+                }
 
-				if (authenticatedUser == null) {
-					logger.error("Cannot extract a user from token: " + token);
-					throw new NotAuthorizedException("Cannot find or create a user");
-				}
+                userForLogging = authenticatedUser.getUserId();
 
-				userForLogging = authenticatedUser.getUserId();
+                // The request context wants to remember who the user is
+                requestContext.setProperty("username", userForLogging);
+                requestContext.setSecurityContext(new AuthSecurityContext(authenticatedUser, uriInfo.getRequestUri().getScheme()));
+                logger.info("User - " + userForLogging + " - has just passed all the authentication and authorization layers.");
+            } catch (NotAuthorizedException e) {
+                // the detail of this exception should be logged right before the exception thrown out
+                // logger.error("User - " + userForLogging + " - is not authorized. " + e.getChallenges());
+                // we should show different response based on role
+                requestContext.abortWith(PICSUREResponse.unauthorizedError("User is not authorized. " + e.getChallenges()));
+            } catch (Exception e) {
+                // we should show different response based on role
+                e.printStackTrace();
+                requestContext.abortWith(PICSUREResponse.applicationError("Inner application error, please contact system admin"));
+            }
+        }
+    }
 
-				//The request context wants to remember who the user is
-				requestContext.setProperty("username", userForLogging);
-				requestContext.setSecurityContext(new AuthSecurityContext(authenticatedUser, uriInfo.getRequestUri().getScheme()));
+    /**
+     *
+     * @param token
+     * @param userIdClaim
+     * @return
+     * @throws IOException
+     */
 
-				logger.info("User - " + userForLogging + " - has just passed all the authentication and authorization layers.");
+    private AuthUser callTokenIntroEndpoint(ContainerRequestContext requestContext, String token, String userIdClaim) {
+        logger.debug("TokenIntrospection - extractUserFromTokenIntrospection() starting...");
 
-			} catch (NotAuthorizedException e) {
-				// the detail of this exception should be logged right before the exception thrown out
-				//			logger.error("User - " + userForLogging + " - is not authorized. " + e.getChallenges());
-				// we should show different response based on role
-				requestContext.abortWith(PICSUREResponse.unauthorizedError("User is not authorized. " + e.getChallenges()));
-			} catch (Exception e){
-				// we should show different response based on role
-				e.printStackTrace();
-				requestContext.abortWith(PICSUREResponse.applicationError("Inner application error, please contact system admin"));
-			}
-		}
-	}
+        String token_introspection_url = picSureWarInit.getToken_introspection_url();
+        String token_introspection_token = picSureWarInit.getToken_introspection_token();
 
-	/**
-	 *
-	 * @param token
-	 * @param userIdClaim
-	 * @return
-	 * @throws IOException
-	 */
+        if (token_introspection_url.isEmpty()) throw new ApplicationException("token_introspection_url is empty");
 
-	private AuthUser callTokenIntroEndpoint(ContainerRequestContext requestContext, String token, String userIdClaim) {
-		logger.debug("TokenIntrospection - extractUserFromTokenIntrospection() starting...");
+        if (token_introspection_token.isEmpty()) {
+            throw new ApplicationException("token_introspection_token is empty");
+        }
 
-		String token_introspection_url = picSureWarInit.getToken_introspection_url();
-		String token_introspection_token = picSureWarInit.getToken_introspection_token();
+        ObjectMapper json = PicSureWarInit.objectMapper;
+        CloseableHttpClient client = PicSureWarInit.CLOSEABLE_HTTP_CLIENT;
 
-		if (token_introspection_url.isEmpty())
-			throw new ApplicationException("token_introspection_url is empty");
+        HttpPost post = new HttpPost(token_introspection_url);
 
-		if (token_introspection_token.isEmpty()){
-			throw new ApplicationException("token_introspection_token is empty");
-		}
-
-		ObjectMapper json = PicSureWarInit.objectMapper;
-		CloseableHttpClient client = PicSureWarInit.CLOSEABLE_HTTP_CLIENT;
-
-		HttpPost post = new HttpPost(token_introspection_url);
-
-		Map<String, Object> tokenMap = new HashMap<>();
-		tokenMap.put("token", token);
+        Map<String, Object> tokenMap = new HashMap<>();
+        tokenMap.put("token", token);
 
 
-		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-		HashMap<String, Object> requestMap = new HashMap<String, Object>();
-		try {
-			String requestPath = requestContext.getUriInfo().getPath();
-			requestMap.put("Target Service", requestPath);
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        HashMap<String, Object> requestMap = new HashMap<String, Object>();
+        try {
+            String requestPath = requestContext.getUriInfo().getPath();
+            requestMap.put("Target Service", requestPath);
 
-			Query initialQuery = null;
-			//Read the query from the backing store if we are getting the results (full query may not be specified in request)
-			if(requestPath.startsWith("/query/") && (requestPath.endsWith("result") || requestPath.endsWith("result/"))) {
-				//Path:   /query/{queryId}/result
-				String[] pathParts = requestPath.split("/");
-				UUID uuid = UUID.fromString(pathParts[2]);
-				initialQuery = queryRepo.getById(uuid);
-			}
+            Query initialQuery = null;
+            // Read the query from the backing store if we are getting the results (full query may not be specified in request)
+            if (requestPath.startsWith("/query/") && (requestPath.endsWith("result") || requestPath.endsWith("result/"))) {
+                // Path: /query/{queryId}/result
+                String[] pathParts = requestPath.split("/");
+                UUID uuid = UUID.fromString(pathParts[2]);
+                initialQuery = queryRepo.getById(uuid);
+            }
 
-			if(initialQuery != null) {
-				IOUtils.copy(new ByteArrayInputStream(initialQuery.getQuery().getBytes()), buffer);
-			} else {
-				//This stream is only consumable once, so we need to save & reset it.
-				InputStream entityStream = requestContext.getEntityStream();
-				IOUtils.copy(entityStream, buffer);
-				requestContext.setEntityStream(new ByteArrayInputStream(buffer.toByteArray()));
-			}
+            if (initialQuery != null) {
+                IOUtils.copy(new ByteArrayInputStream(initialQuery.getQuery().getBytes()), buffer);
+            } else {
+                // This stream is only consumable once, so we need to save & reset it.
+                InputStream entityStream = requestContext.getEntityStream();
+                IOUtils.copy(entityStream, buffer);
+                requestContext.setEntityStream(new ByteArrayInputStream(buffer.toByteArray()));
+            }
 
-			if(buffer.size()>0) {
-				/*
-				 * We remove the resourceCredentials from the token introspection copy of the query to prevent logging them as 
-				 * part of token introspection. These credentials are between the backing resource and the user, PIC-SURE should
-				 * do its best to keep them confidential.
-				 */
-				Object queryObject = new ObjectMapper().readValue(new ByteArrayInputStream(buffer.toByteArray()), Object.class);
-				if (queryObject instanceof Collection) {
-					for (Object query: (Collection)queryObject) {
-						if (query instanceof Map) {
-							((Map) query).remove("resourceCredentials");
-						}
-					}
-				} else if (queryObject instanceof Map){
-					((Map) queryObject).remove("resourceCredentials");
-				}
-				requestMap.put("query", queryObject);
+            if (buffer.size() > 0) {
+                /*
+                 * We remove the resourceCredentials from the token introspection copy of the query to prevent logging them as part of token
+                 * introspection. These credentials are between the backing resource and the user, PIC-SURE should do its best to keep them
+                 * confidential.
+                 */
+                Object queryObject = new ObjectMapper().readValue(new ByteArrayInputStream(buffer.toByteArray()), Object.class);
+                if (queryObject instanceof Collection) {
+                    for (Object query : (Collection) queryObject) {
+                        if (query instanceof Map) {
+                            ((Map) query).remove("resourceCredentials");
+                        }
+                    }
+                } else if (queryObject instanceof Map) {
+                    ((Map) queryObject).remove("resourceCredentials");
+                }
+                requestMap.put("query", queryObject);
 
-				if(requestPath.startsWith("/query/")) {
+                if (requestPath.startsWith("/query/")) {
 
-					UUID resourceUUID = null;
-					String resourceUUIDStr = (String) ((Map)queryObject).get("resourceUUID");
-					if(resourceUUIDStr != null) {
-						resourceUUID = UUID.fromString(resourceUUIDStr);
-					}
+                    UUID resourceUUID = null;
+                    String resourceUUIDStr = (String) ((Map) queryObject).get("resourceUUID");
+                    if (resourceUUIDStr != null) {
+                        resourceUUID = UUID.fromString(resourceUUIDStr);
+                    }
 
-					if(resourceUUID != null) {
-						edu.harvard.dbmi.avillach.data.entity.Resource resource = resourceRepo.getById(resourceUUID);
-						//logger.info("resource obj: " + resource + "    path: " + resource.getResourceRSPath());
-						if (resource != null && resource.getResourceRSPath() != null){
-							GeneralQueryRequest queryRequest = new GeneralQueryRequest();
-							queryRequest.getResourceCredentials().put(ResourceWebClient.BEARER_TOKEN_KEY, resource.getToken());
-							queryRequest.setResourceUUID(resourceUUID);
-							queryRequest.setQuery(((Map)queryObject).get("query"));
+                    if (resourceUUID != null) {
+                        edu.harvard.dbmi.avillach.data.entity.Resource resource = resourceRepo.getById(resourceUUID);
+                        // logger.info("resource obj: " + resource + " path: " + resource.getResourceRSPath());
+                        if (resource != null && resource.getResourceRSPath() != null) {
+                            GeneralQueryRequest queryRequest = new GeneralQueryRequest();
+                            queryRequest.getResourceCredentials().put(ResourceWebClient.BEARER_TOKEN_KEY, resource.getToken());
+                            queryRequest.setResourceUUID(resourceUUID);
+                            queryRequest.setQuery(((Map) queryObject).get("query"));
 
-							Response formatResponse = resourceWebClient.queryFormat(resource.getResourceRSPath(), queryRequest);
-							if(formatResponse.getStatus() == 200) {
-								//add the formatted query if available
-								String formattedQuery = IOUtils.toString((InputStream)formatResponse.getEntity(), "UTF-8");
-								logger.debug("Formatted response: " + formattedQuery); 
-								requestMap.put("formattedQuery", formattedQuery);
-							}
-						}
-					}
-				}
-			}
-			tokenMap.put("request", requestMap);
-		} catch (JsonParseException ex) {
-			requestMap.put("query",buffer.toString());
-			tokenMap.put("request", requestMap);
-		} catch (IOException e1) {
-			logger.error("IOException caught trying to build requestMap for auditing.", e1);
-			throw new NotAuthorizedException("The request could not be properly audited. If you recieve this error multiple times, please contact an administrator.");
-		}
-		StringEntity entity = null;
-		try {
-			entity = new StringEntity(json.writeValueAsString(tokenMap));
-		} catch (IOException e) {
-			logger.error("callTokenIntroEndpoint() - " + e.getClass().getSimpleName() + " when composing post");
-			return null;
-		}
-		post.setEntity(entity);
-		post.setHeader("Content-Type", "application/json");
-		//Authorize into the token introspection endpoint
-		post.setHeader("Authorization", "Bearer " + token_introspection_token);
-		CloseableHttpResponse response = null;
-		try {
-			response = client.execute(post, buildHttpClientContext());
-			if (response.getStatusLine().getStatusCode() != 200){
-				logger.error("callTokenIntroEndpoint() error back from token intro host server ["
-						+ token_introspection_url + "]: " + EntityUtils.toString(response.getEntity()));
-				logger.info("This callTokenIntroEndpoint error can happen when your introspection token has expired. " +
-					"You can fix this by running the Configure PIC-SURE Token Introspection Token job in Jenkins.");
-				throw new ApplicationException("Token Introspection host server return " + response.getStatusLine().getStatusCode() +
-						". Please see the log");
-			}
-			JsonNode responseContent = json.readTree(response.getEntity().getContent());
-			if (!responseContent.get("active").asBoolean()){
-				logger.error("callTokenIntroEndpoint() Token intro endpoint return invalid token, content: " + responseContent);
-				throw new NotAuthorizedException("Token invalid or expired");
-			}
+                            Response formatResponse = resourceWebClient.queryFormat(resource.getResourceRSPath(), queryRequest);
+                            if (formatResponse.getStatus() == 200) {
+                                // add the formatted query if available
+                                String formattedQuery = IOUtils.toString((InputStream) formatResponse.getEntity(), "UTF-8");
+                                logger.debug("Formatted response: " + formattedQuery);
+                                requestMap.put("formattedQuery", formattedQuery);
+                            }
+                        }
+                    }
+                }
+            }
+            tokenMap.put("request", requestMap);
+        } catch (JsonParseException ex) {
+            requestMap.put("query", buffer.toString());
+            tokenMap.put("request", requestMap);
+        } catch (IOException e1) {
+            logger.error("IOException caught trying to build requestMap for auditing.", e1);
+            throw new NotAuthorizedException(
+                "The request could not be properly audited. If you recieve this error multiple times, please contact an administrator."
+            );
+        }
+        StringEntity entity = null;
+        try {
+            entity = new StringEntity(json.writeValueAsString(tokenMap));
+        } catch (IOException e) {
+            logger.error("callTokenIntroEndpoint() - " + e.getClass().getSimpleName() + " when composing post");
+            return null;
+        }
+        post.setEntity(entity);
+        post.setHeader("Content-Type", "application/json");
+        // Authorize into the token introspection endpoint
+        post.setHeader("Authorization", "Bearer " + token_introspection_token);
+        CloseableHttpResponse response = null;
+        try {
+            response = client.execute(post, buildHttpClientContext());
+            if (response.getStatusLine().getStatusCode() != 200) {
+                logger.error(
+                    "callTokenIntroEndpoint() error back from token intro host server [" + token_introspection_url + "]: "
+                        + EntityUtils.toString(response.getEntity())
+                );
+                logger.info(
+                    "This callTokenIntroEndpoint error can happen when your introspection token has expired. "
+                        + "You can fix this by running the Configure PIC-SURE Token Introspection Token job in Jenkins."
+                );
+                throw new ApplicationException(
+                    "Token Introspection host server return " + response.getStatusLine().getStatusCode() + ". Please see the log"
+                );
+            }
+            JsonNode responseContent = json.readTree(response.getEntity().getContent());
+            if (!responseContent.get("active").asBoolean()) {
+                logger.error("callTokenIntroEndpoint() Token intro endpoint return invalid token, content: " + responseContent);
+                throw new NotAuthorizedException("Token invalid or expired");
+            }
 
-			String userId = responseContent.get(userIdClaim) != null ? responseContent.get(userIdClaim).asText() : null;
-			String sub = responseContent.get("sub") != null ? responseContent.get("sub").asText() : null;
-			String email = responseContent.get("email") != null ? responseContent.get("email").asText() : null;
-			String roles = responseContent.get("roles") != null ? responseContent.get("roles").asText() : null;
-			AuthUser user = new AuthUser().setUserId(userId).setSubject(sub).setEmail(email).setRoles(roles);
-			return user;
-		} catch (IOException ex){
-			logger.error("callTokenIntroEndpoint() IOException when hitting url: " + post
-					+ " with exception msg: " + ex.getMessage());
-		} finally {
-			try {
-				if (response != null)
-					response.close();
-			} catch (IOException ex) {
-				logger.error("callTokenIntroEndpoint() IOExcpetion when closing http response: " + ex.getMessage());
-			}
-		}
+            if (responseContent.get("tokenRefreshed").asBoolean()) {
+                requestContext.setProperty("refreshedToken", responseContent.get("token"));
+            }
 
-		return null;
-	}
+            String userId = responseContent.get(userIdClaim) != null ? responseContent.get(userIdClaim).asText() : null;
+            String sub = responseContent.get("sub") != null ? responseContent.get("sub").asText() : null;
+            String email = responseContent.get("email") != null ? responseContent.get("email").asText() : null;
+            String roles = responseContent.get("roles") != null ? responseContent.get("roles").asText() : null;
+            AuthUser user = new AuthUser().setUserId(userId).setSubject(sub).setEmail(email).setRoles(roles);
+            return user;
+        } catch (IOException ex) {
+            logger.error("callTokenIntroEndpoint() IOException when hitting url: " + post + " with exception msg: " + ex.getMessage());
+        } finally {
+            try {
+                if (response != null) response.close();
+            } catch (IOException ex) {
+                logger.error("callTokenIntroEndpoint() IOExcpetion when closing http response: " + ex.getMessage());
+            }
+        }
 
-	void setUserIdClaim(String userIdClaim) {
-		this.userIdClaim = userIdClaim;
-	}
+        return null;
+    }
+
+    void setUserIdClaim(String userIdClaim) {
+        this.userIdClaim = userIdClaim;
+    }
 }

--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/JWTResponseFilter.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/JWTResponseFilter.java
@@ -1,5 +1,7 @@
 package edu.harvard.dbmi.avillach.security;
 
+import com.fasterxml.jackson.databind.node.TextNode;
+
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
@@ -13,8 +15,13 @@ public class JWTResponseFilter implements ContainerResponseFilter {
     @Override
     public void filter(ContainerRequestContext containerRequestContext, ContainerResponseContext containerResponseContext)
         throws IOException {
-        String newToken = (String) containerRequestContext.getProperty("refreshedToken");
-        if (newToken != null) {
+        Object tokenObject = containerRequestContext.getProperty("refreshedToken");
+
+        if (tokenObject instanceof TextNode) {
+            String newToken = ((TextNode) tokenObject).asText();
+            containerResponseContext.getHeaders().add(HttpHeaders.AUTHORIZATION, "Bearer " + newToken);
+        } else if (tokenObject instanceof String) {
+            String newToken = (String) tokenObject;
             containerResponseContext.getHeaders().add(HttpHeaders.AUTHORIZATION, "Bearer " + newToken);
         }
     }

--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/JWTResponseFilter.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/JWTResponseFilter.java
@@ -1,0 +1,21 @@
+package edu.harvard.dbmi.avillach.security;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+
+@Provider
+public class JWTResponseFilter implements ContainerResponseFilter {
+
+    @Override
+    public void filter(ContainerRequestContext containerRequestContext, ContainerResponseContext containerResponseContext)
+        throws IOException {
+        String newToken = (String) containerRequestContext.getProperty("refreshedToken");
+        if (newToken != null) {
+            containerResponseContext.getHeaders().add(HttpHeaders.AUTHORIZATION, "Bearer " + newToken);
+        }
+    }
+}

--- a/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/security/JWTFilterTest.java
+++ b/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/security/JWTFilterTest.java
@@ -34,262 +34,249 @@ import edu.harvard.dbmi.avillach.util.response.PICSUREResponseError;
 
 public class JWTFilterTest {
 
-	private static final UUID QUERY_UUID = UUID.fromString("e830138f-2943-4661-90ae-da053bd94a18");
+    private static final UUID QUERY_UUID = UUID.fromString("e830138f-2943-4661-90ae-da053bd94a18");
 
-	private static final UUID RESOURCE_UUID = UUID.fromString("30ef4941-9656-4b47-af80-528f2b98cf17");
+    private static final UUID RESOURCE_UUID = UUID.fromString("30ef4941-9656-4b47-af80-528f2b98cf17");
 
-	@Rule
-	public WireMockRule wireMockRule = new WireMockRule(0);
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(0);
 
-	private int port;
+    private int port;
 
-	private PicSureWarInit picSureWarInit;
+    private PicSureWarInit picSureWarInit;
 
-	private JWTFilter filter;
+    private JWTFilter filter;
 
-	@Before
-	public void setup() {
-		port = wireMockRule.port();
-		picSureWarInit = mock(PicSureWarInit.class);
-		when(picSureWarInit.getToken_introspection_token()).thenReturn("INTROSPECTION_TOKEN");
-		when(picSureWarInit.getToken_introspection_url()).thenReturn("http://localhost:" + port + "/introspection_endpoint");
-		filter = new JWTFilter();
-		filter.setUserIdClaim("sub");
-		filter.picSureWarInit = picSureWarInit;
-		filter.resourceWebClient = new ResourceWebClient();
-		filter.queryRepo = mock(QueryRepository.class);
-		filter.resourceRepo = mock(ResourceRepository.class);
-		filter.uriInfo = mock(UriInfo.class);
-		when(filter.uriInfo.getPath()).thenReturn("/test");
-	}
+    @Before
+    public void setup() {
+        port = wireMockRule.port();
+        picSureWarInit = mock(PicSureWarInit.class);
+        when(picSureWarInit.getToken_introspection_token()).thenReturn("INTROSPECTION_TOKEN");
+        when(picSureWarInit.getToken_introspection_url()).thenReturn("http://localhost:" + port + "/introspection_endpoint");
+        filter = new JWTFilter();
+        filter.setUserIdClaim("sub");
+        filter.picSureWarInit = picSureWarInit;
+        filter.resourceWebClient = new ResourceWebClient();
+        filter.queryRepo = mock(QueryRepository.class);
+        filter.resourceRepo = mock(ResourceRepository.class);
+        filter.uriInfo = mock(UriInfo.class);
+        when(filter.uriInfo.getPath()).thenReturn("/test");
+    }
 
-	private ContainerRequestContext createRequestContext() {
-		ContainerRequestContext ctx = mock(ContainerRequestContext.class);
-		UriInfo uriInfo = mock(UriInfo.class);
-		Request request = mock(Request.class);
-		when(ctx.getUriInfo()).thenReturn(uriInfo);
-		when(ctx.getRequest()).thenReturn(request);
-		return ctx;
-	}
+    private ContainerRequestContext createRequestContext() {
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        UriInfo uriInfo = mock(UriInfo.class);
+        Request request = mock(Request.class);
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        when(ctx.getRequest()).thenReturn(request);
+        return ctx;
+    }
 
 
-	private Query persistedQuery() {
-		Resource resource = basicResource();
-		Query query = new Query();
-		query.setQuery("{\"resourceUUID\":\""+RESOURCE_UUID+"\"}");
-		query.setResource(resource);
-		when(filter.queryRepo.getById(
-				QUERY_UUID))
-		.thenReturn(query);
-		return query;
-	}
+    private Query persistedQuery() {
+        Resource resource = basicResource();
+        Query query = new Query();
+        query.setQuery("{\"resourceUUID\":\"" + RESOURCE_UUID + "\"}");
+        query.setResource(resource);
+        when(filter.queryRepo.getById(QUERY_UUID)).thenReturn(query);
+        return query;
+    }
 
-	private Resource basicResource() {
-		Resource resource = mock(Resource.class);
-		when(resource.getResourceRSPath()).thenReturn("http://localhost:" + wireMockRule.port() + "/resource");
-		when(resource.getToken()).thenReturn("RESOURCE_TOKEN");
-		when(resource.getUuid()).thenReturn(RESOURCE_UUID);
+    private Resource basicResource() {
+        Resource resource = mock(Resource.class);
+        when(resource.getResourceRSPath()).thenReturn("http://localhost:" + wireMockRule.port() + "/resource");
+        when(resource.getToken()).thenReturn("RESOURCE_TOKEN");
+        when(resource.getUuid()).thenReturn(RESOURCE_UUID);
 
-		when(filter.resourceRepo.getById(
-				RESOURCE_UUID))
-		.thenReturn(resource);
-		return resource;
-	}
+        when(filter.resourceRepo.getById(RESOURCE_UUID)).thenReturn(resource);
+        return resource;
+    }
 
-	private void tokenIntrospectionStub() {
-		tokenIntrospectionStub(true);
-	}
+    private void tokenIntrospectionStub() {
+        tokenIntrospectionStub(true);
+    }
 
-	private void tokenIntrospectionStub(Boolean active) {
-		stubFor(post(urlEqualTo("/introspection_endpoint"))
-			.willReturn(aResponse()
-				.withStatus(200)
-				.withHeader("Content-Type", "application/json")
-				.withBody("{"
-					+ "\"active\":" + Boolean.toString(active) + ","
-					+ "\"sub\":\"TEST_USER\","
-					+ "\"email\":\"some@email.com\","
-					+ "\"roles\":\"PIC_SURE_ANY_QUERY\""
-				+ "}")));
-	}
+    private void tokenIntrospectionStub(Boolean active) {
+        stubFor(
+            post(urlEqualTo("/introspection_endpoint")).willReturn(
+                aResponse().withStatus(200).withHeader("Content-Type", "application/json").withBody(
+                    "{" + "\"active\":" + Boolean.toString(active) + "," + "\"sub\":\"TEST_USER\"," + "\"email\":\"some@email.com\","
+                        + "\"roles\":\"PIC_SURE_ANY_QUERY\"," + "\"tokenRefreshed\":" + Boolean.FALSE + "}"
+                )
+            )
+        );
+    }
 
-	@Test
-	public void testSystemPathDoesNotRequireAuthenticationHeader() throws IOException {
-		ContainerRequestContext ctx = createRequestContext();
-		when(ctx.getUriInfo().getPath()).thenReturn("/system/status");
-		when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.GET);
-		filter.filter(ctx);
-		verify(ctx).setProperty("username", "SYSTEM_MONITOR");
-	}
+    @Test
+    public void testSystemPathDoesNotRequireAuthenticationHeader() throws IOException {
+        ContainerRequestContext ctx = createRequestContext();
+        when(ctx.getUriInfo().getPath()).thenReturn("/system/status");
+        when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.GET);
+        filter.filter(ctx);
+        verify(ctx).setProperty("username", "SYSTEM_MONITOR");
+    }
 
-	@Test
-	public void testFilterCallsTokenIntrospectionAppropriatelyForQuerySync() throws IOException {
+    @Test
+    public void testFilterCallsTokenIntrospectionAppropriatelyForQuerySync() throws IOException {
 
-		tokenIntrospectionStub();
+        tokenIntrospectionStub();
 
-		ContainerRequestContext ctx = createRequestContext();
-		when(ctx.getUriInfo().getPath()).thenReturn("/query/sync");
-		when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.POST);
-		InputStream entityStream = new ByteArrayInputStream("{\"query\":\"test\"}".getBytes());
-		when(ctx.getEntityStream()).thenReturn(entityStream);
-		when(ctx.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer USER_TOKEN");
-		filter.filter(ctx);
+        ContainerRequestContext ctx = createRequestContext();
+        when(ctx.getUriInfo().getPath()).thenReturn("/query/sync");
+        when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.POST);
+        InputStream entityStream = new ByteArrayInputStream("{\"query\":\"test\"}".getBytes());
+        when(ctx.getEntityStream()).thenReturn(entityStream);
+        when(ctx.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer USER_TOKEN");
+        filter.filter(ctx);
 
-		verify(postRequestedFor(
-				urlEqualTo("/introspection_endpoint")).
-				withRequestBody(matchingJsonPath(
-						"$.request.['Target Service']", matching("/query/sync")))
-				.withRequestBody(matchingJsonPath(
-						"$.request.['query']", matchingJsonPath("query",matching("test"))))
-				.withRequestBody(matchingJsonPath(
-						"$.token", matching("USER_TOKEN"))));
-	}
+        verify(
+            postRequestedFor(urlEqualTo("/introspection_endpoint"))
+                .withRequestBody(matchingJsonPath("$.request.['Target Service']", matching("/query/sync")))
+                .withRequestBody(matchingJsonPath("$.request.['query']", matchingJsonPath("query", matching("test"))))
+                .withRequestBody(matchingJsonPath("$.token", matching("USER_TOKEN")))
+        );
+    }
 
-	@Test
-	public void testFilterCallsTokenIntrospectionAppropriatelyForQuery() throws IOException {
+    @Test
+    public void testFilterCallsTokenIntrospectionAppropriatelyForQuery() throws IOException {
 
-		tokenIntrospectionStub();
+        tokenIntrospectionStub();
 
-		ContainerRequestContext ctx = createRequestContext();
-		when(ctx.getUriInfo().getPath()).thenReturn("/query");
-		when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.POST);
-		InputStream entityStream = new ByteArrayInputStream("{\"query\":\"test\"}".getBytes());
-		when(ctx.getEntityStream()).thenReturn(entityStream);
-		when(ctx.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer USER_TOKEN");
-		filter.filter(ctx);
+        ContainerRequestContext ctx = createRequestContext();
+        when(ctx.getUriInfo().getPath()).thenReturn("/query");
+        when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.POST);
+        InputStream entityStream = new ByteArrayInputStream("{\"query\":\"test\"}".getBytes());
+        when(ctx.getEntityStream()).thenReturn(entityStream);
+        when(ctx.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer USER_TOKEN");
+        filter.filter(ctx);
 
-		verify(postRequestedFor(
-				urlEqualTo("/introspection_endpoint")).
-				withRequestBody(matchingJsonPath(
-						"$.request.['Target Service']", matching("/query")))
-				.withRequestBody(matchingJsonPath(
-						"$.request.['query']", matchingJsonPath("query",matching("test"))))
-				.withRequestBody(matchingJsonPath(
-						"$.token", matching("USER_TOKEN"))));
-	}
+        verify(
+            postRequestedFor(urlEqualTo("/introspection_endpoint"))
+                .withRequestBody(matchingJsonPath("$.request.['Target Service']", matching("/query")))
+                .withRequestBody(matchingJsonPath("$.request.['query']", matchingJsonPath("query", matching("test"))))
+                .withRequestBody(matchingJsonPath("$.token", matching("USER_TOKEN")))
+        );
+    }
 
-	@Test
-	public void testFilterCallsTokenIntrospectionAppropriatelyForResultWithoutTrailingSlash() throws IOException {
+    @Test
+    public void testFilterCallsTokenIntrospectionAppropriatelyForResultWithoutTrailingSlash() throws IOException {
 
-		tokenIntrospectionStub();
+        tokenIntrospectionStub();
 
-		queryFormatStub();
+        queryFormatStub();
 
-		Query query = persistedQuery();
+        Query query = persistedQuery();
 
-		ContainerRequestContext ctx = createRequestContext();
-		when(ctx.getUriInfo().getPath()).thenReturn("/query/e830138f-2943-4661-90ae-da053bd94a18/result");
-		when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.POST);
-		when(ctx.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer USER_TOKEN");
-		filter.filter(ctx);
+        ContainerRequestContext ctx = createRequestContext();
+        when(ctx.getUriInfo().getPath()).thenReturn("/query/e830138f-2943-4661-90ae-da053bd94a18/result");
+        when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.POST);
+        when(ctx.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer USER_TOKEN");
+        filter.filter(ctx);
 
-		verify(postRequestedFor(
-				urlEqualTo("/resource/query/format")));
-		verify(postRequestedFor(
-				urlEqualTo("/introspection_endpoint")).
-				withRequestBody(matchingJsonPath(
-						"$.request.['Target Service']", matching("/query/e830138f-2943-4661-90ae-da053bd94a18/result")))
-				.withRequestBody(matchingJsonPath(
-						"$.request.query", equalToJson(query.getQuery())))
-				.withRequestBody(matchingJsonPath(
-						"$.request.formattedQuery", equalToJson("{\"formatted\":\"query\"}")))
-				.withRequestBody(matchingJsonPath(
-						"$.token", matching("USER_TOKEN"))));
-	}
+        verify(postRequestedFor(urlEqualTo("/resource/query/format")));
+        verify(
+            postRequestedFor(urlEqualTo("/introspection_endpoint"))
+                .withRequestBody(
+                    matchingJsonPath("$.request.['Target Service']", matching("/query/e830138f-2943-4661-90ae-da053bd94a18/result"))
+                ).withRequestBody(matchingJsonPath("$.request.query", equalToJson(query.getQuery())))
+                .withRequestBody(matchingJsonPath("$.request.formattedQuery", equalToJson("{\"formatted\":\"query\"}")))
+                .withRequestBody(matchingJsonPath("$.token", matching("USER_TOKEN")))
+        );
+    }
 
-	@Test
-	public void testFilterCallsTokenIntrospectionAppropriatelyForResultWithTrailingSlash() throws IOException {
+    @Test
+    public void testFilterCallsTokenIntrospectionAppropriatelyForResultWithTrailingSlash() throws IOException {
 
-		tokenIntrospectionStub();
+        tokenIntrospectionStub();
 
-		queryFormatStub();
+        queryFormatStub();
 
-		filter.queryRepo = mock(QueryRepository.class);
+        filter.queryRepo = mock(QueryRepository.class);
 
-		Query query = persistedQuery();
+        Query query = persistedQuery();
 
-		ContainerRequestContext ctx = createRequestContext();
-		when(ctx.getUriInfo().getPath()).thenReturn("/query/e830138f-2943-4661-90ae-da053bd94a18/result/");
-		when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.POST);
-		when(ctx.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer USER_TOKEN");
-		filter.filter(ctx);
-		ArgumentCaptor<Map> requestBody = ArgumentCaptor.forClass(Map.class);
-		verify(postRequestedFor(
-				urlEqualTo("/introspection_endpoint")).
-				withRequestBody(matchingJsonPath(
-						"$.request.['Target Service']", matching("/query/e830138f-2943-4661-90ae-da053bd94a18/result/")))
-				.withRequestBody(matchingJsonPath(
-						"$.request.query", equalToJson(query.getQuery())))
-				.withRequestBody(matchingJsonPath(
-						"$.request.formattedQuery", equalToJson("{\"formatted\":\"query\"}")))
-				.withRequestBody(matchingJsonPath(
-						"$.token", matching("USER_TOKEN"))));
-	}
+        ContainerRequestContext ctx = createRequestContext();
+        when(ctx.getUriInfo().getPath()).thenReturn("/query/e830138f-2943-4661-90ae-da053bd94a18/result/");
+        when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.POST);
+        when(ctx.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer USER_TOKEN");
+        filter.filter(ctx);
+        ArgumentCaptor<Map> requestBody = ArgumentCaptor.forClass(Map.class);
+        verify(
+            postRequestedFor(urlEqualTo("/introspection_endpoint"))
+                .withRequestBody(
+                    matchingJsonPath("$.request.['Target Service']", matching("/query/e830138f-2943-4661-90ae-da053bd94a18/result/"))
+                ).withRequestBody(matchingJsonPath("$.request.query", equalToJson(query.getQuery())))
+                .withRequestBody(matchingJsonPath("$.request.formattedQuery", equalToJson("{\"formatted\":\"query\"}")))
+                .withRequestBody(matchingJsonPath("$.token", matching("USER_TOKEN")))
+        );
+    }
 
-	private void queryFormatStub() {
-		stubFor(post(urlEqualTo("/resource/query/format"))
-				.willReturn(aResponse()
-						.withStatus(200)
-						.withHeader("Content-Type", "application/json")
-						.withBody("{\"formatted\":\"query\"}")));
-	}
+    private void queryFormatStub() {
+        stubFor(
+            post(urlEqualTo("/resource/query/format")).willReturn(
+                aResponse().withStatus(200).withHeader("Content-Type", "application/json").withBody("{\"formatted\":\"query\"}")
+            )
+        );
+    }
 
-	@Test
-	public void testFilterAbortsRequestIfTokenIntrospectionReturnsFalse() throws IOException {
-		tokenIntrospectionStub(false);
+    @Test
+    public void testFilterAbortsRequestIfTokenIntrospectionReturnsFalse() throws IOException {
+        tokenIntrospectionStub(false);
 
-		ContainerRequestContext ctx = createRequestContext();
-		when(ctx.getUriInfo().getPath()).thenReturn("/query/sync");
-		when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.POST);
-		InputStream entityStream = new ByteArrayInputStream("{}".getBytes());
-		when(ctx.getEntityStream()).thenReturn(entityStream);
-		when(ctx.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer USER_TOKEN");
-		filter.filter(ctx);
-		verify(postRequestedFor(urlEqualTo("/introspection_endpoint")));
-		ArgumentCaptor<Response> abortedRequestContext = ArgumentCaptor.forClass(Response.class);
-		verify(ctx).abortWith(abortedRequestContext.capture());
-		assertEquals(abortedRequestContext.getValue().getStatus(), 401);
-		assertEquals(((PICSUREResponseError)abortedRequestContext.getValue().getEntity()).getMessage(), "User is not authorized. [Token invalid or expired]");
-	}
+        ContainerRequestContext ctx = createRequestContext();
+        when(ctx.getUriInfo().getPath()).thenReturn("/query/sync");
+        when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.POST);
+        InputStream entityStream = new ByteArrayInputStream("{}".getBytes());
+        when(ctx.getEntityStream()).thenReturn(entityStream);
+        when(ctx.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer USER_TOKEN");
+        filter.filter(ctx);
+        verify(postRequestedFor(urlEqualTo("/introspection_endpoint")));
+        ArgumentCaptor<Response> abortedRequestContext = ArgumentCaptor.forClass(Response.class);
+        verify(ctx).abortWith(abortedRequestContext.capture());
+        assertEquals(abortedRequestContext.getValue().getStatus(), 401);
+        assertEquals(
+            ((PICSUREResponseError) abortedRequestContext.getValue().getEntity()).getMessage(),
+            "User is not authorized. [Token invalid or expired]"
+        );
+    }
 
-	@Test
-	public void testFilterSetsUsernameIfTokenIntrospectionReturnsTrue() throws IOException {
-		tokenIntrospectionStub();
+    @Test
+    public void testFilterSetsUsernameIfTokenIntrospectionReturnsTrue() throws IOException {
+        tokenIntrospectionStub();
 
-		ContainerRequestContext ctx = createRequestContext();
-		when(ctx.getUriInfo().getPath()).thenReturn("/query/sync");
-		when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.POST);
-		InputStream entityStream = new ByteArrayInputStream("{}".getBytes());
-		when(ctx.getEntityStream()).thenReturn(entityStream);
-		when(ctx.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer USER_TOKEN");
-		filter.filter(ctx);
-		verify(postRequestedFor(urlEqualTo("/introspection_endpoint")));
-		verify(ctx).setProperty("username", "TEST_USER");
-	}
+        ContainerRequestContext ctx = createRequestContext();
+        when(ctx.getUriInfo().getPath()).thenReturn("/query/sync");
+        when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.POST);
+        InputStream entityStream = new ByteArrayInputStream("{}".getBytes());
+        when(ctx.getEntityStream()).thenReturn(entityStream);
+        when(ctx.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer USER_TOKEN");
+        filter.filter(ctx);
+        verify(postRequestedFor(urlEqualTo("/introspection_endpoint")));
+        verify(ctx).setProperty("username", "TEST_USER");
+    }
 
-	@Test
-	public void testFilterRemovesResourceCredentialsBeforeSendingToTokenIntrospectionOrFormatter() throws IOException {
+    @Test
+    public void testFilterRemovesResourceCredentialsBeforeSendingToTokenIntrospectionOrFormatter() throws IOException {
 
-		tokenIntrospectionStub();
+        tokenIntrospectionStub();
 
-		ContainerRequestContext ctx = createRequestContext();
-		when(ctx.getUriInfo().getPath()).thenReturn("/query");
-		when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.POST);
-		InputStream entityStream = new ByteArrayInputStream(("{\"query\":\"test\", \"resourceUUID\":\""+RESOURCE_UUID+"\", \"resourceCredentials\":\"foobar\"}").getBytes());
-		when(ctx.getEntityStream()).thenReturn(entityStream);
-		when(ctx.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer USER_TOKEN");
-		filter.filter(ctx);
+        ContainerRequestContext ctx = createRequestContext();
+        when(ctx.getUriInfo().getPath()).thenReturn("/query");
+        when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.POST);
+        InputStream entityStream = new ByteArrayInputStream(
+            ("{\"query\":\"test\", \"resourceUUID\":\"" + RESOURCE_UUID + "\", \"resourceCredentials\":\"foobar\"}").getBytes()
+        );
+        when(ctx.getEntityStream()).thenReturn(entityStream);
+        when(ctx.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer USER_TOKEN");
+        filter.filter(ctx);
 
-		verify(postRequestedFor(
-				urlEqualTo("/introspection_endpoint")).
-				withRequestBody(matchingJsonPath(
-						"$.request.['Target Service']", matching("/query")))
-				.withRequestBody(matchingJsonPath(
-						"$.request.['query']", matchingJsonPath("query",matching("test"))))
-				.withRequestBody(matchingJsonPath(
-						"$.request.['query']", notMatching("resourceCredentials")))
-				.withRequestBody(matchingJsonPath(
-						"$.token", matching("USER_TOKEN"))));
-	}
+        verify(
+            postRequestedFor(urlEqualTo("/introspection_endpoint"))
+                .withRequestBody(matchingJsonPath("$.request.['Target Service']", matching("/query")))
+                .withRequestBody(matchingJsonPath("$.request.['query']", matchingJsonPath("query", matching("test"))))
+                .withRequestBody(matchingJsonPath("$.request.['query']", notMatching("resourceCredentials")))
+                .withRequestBody(matchingJsonPath("$.token", matching("USER_TOKEN")))
+        );
+    }
 
 }


### PR DESCRIPTION
[ALS-6665] When validating the authorization header with pic-sure-auth-micro-app, a refreshed Bearer token may be returned. If a new token is provided, we now ensure it is included in the Authorization header sent back to the client, allowing the user to replace their existing token.