### PR TITLE
[ALS-7554] User should not be able to search without a valid token

### DIFF
--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/JWTFilter.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/JWTFilter.java
@@ -96,7 +96,7 @@ public class JWTFilter implements ContainerRequestFilter {
                 if (isExplorer) {
                     // If the request is coming from the explorer, we should not allow open access
                     logger.error("User is not authorized.");
-                    requestContext.abortWith(PICSUREResponse.unauthorizedError("User is not authorized."));
+                    requestContext.abortWith(PICSUREResponse.unauthorizedError("Your session has expired. Please log in again."));
                 }
 
                 boolean isAuthorized = callOpenAccessValidationEndpoint(requestContext);


### PR DESCRIPTION
[ALS-7554] User should not be able to search, on the explorer page, without a valid token.