### PR TITLE
Remove Guava dependency and update plugin configurations

### DIFF
--- a/pic-sure-resources/pic-sure-passthrough-resource/pom.xml
+++ b/pic-sure-resources/pic-sure-passthrough-resource/pom.xml
@@ -48,10 +48,6 @@
 			<artifactId>commons-lang3</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>

--- a/pic-sure-resources/pic-sure-passthrough-resource/src/test/java/edu/harvard/hms/dbmi/avillach/resource/passthru/PassThroughResourceRSTest.java
+++ b/pic-sure-resources/pic-sure-passthrough-resource/src/test/java/edu/harvard/hms/dbmi/avillach/resource/passthru/PassThroughResourceRSTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -28,7 +29,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
 
 import edu.harvard.dbmi.avillach.domain.QueryFormat;
 import edu.harvard.dbmi.avillach.domain.GeneralQueryRequest;
@@ -42,304 +42,307 @@ import edu.harvard.dbmi.avillach.util.exception.ResourceInterfaceException;
 @ExtendWith(MockitoExtension.class)
 class PassThroughResourceRSTest {
 
-	HttpClientUtil httpClient;
-	PassThroughResourceRS resource;
-	ObjectMapper objectMapper = new ObjectMapper();
+    HttpClientUtil httpClient;
+    PassThroughResourceRS resource;
+    ObjectMapper objectMapper = new ObjectMapper();
 
-	@BeforeEach
-	void init() {
-		ApplicationProperties appProperties = mock(ApplicationProperties.class);
-		lenient().when(appProperties.getTargetPicsureToken()).thenReturn("/tmp/unit_test");
-		lenient().when(appProperties.getTargetPicsureUrl()).thenReturn("http://test");
-		lenient().when(appProperties.getTargetResourceId()).thenReturn(UUID.randomUUID().toString());
+    @BeforeEach
+    void init() {
+        ApplicationProperties appProperties = mock(ApplicationProperties.class);
+        lenient().when(appProperties.getTargetPicsureToken()).thenReturn("/tmp/unit_test");
+        lenient().when(appProperties.getTargetPicsureUrl()).thenReturn("http://test");
+        lenient().when(appProperties.getTargetResourceId()).thenReturn(UUID.randomUUID().toString());
 
-		httpClient = mock(HttpClientUtil.class);
+        httpClient = mock(HttpClientUtil.class);
 
-		resource = new PassThroughResourceRS(appProperties, httpClient);
-	}
+        resource = new PassThroughResourceRS(appProperties, httpClient);
+    }
 
-	@Test
-	void testInfo() throws Exception {
-		// setup http response mocks
-		HttpResponse httpResponse = mock(HttpResponse.class);
-		StringEntity httpResponseEntity = new StringEntity("");
-		StatusLine statusLine = mock(StatusLine.class);
-		when(httpResponse.getStatusLine()).thenReturn(statusLine);
-		when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
-		when(httpClient.retrievePostResponse(anyString(), any(Header[].class), anyString())).thenReturn(httpResponse);
+    @Test
+    void testInfo() throws Exception {
+        // setup http response mocks
+        HttpResponse httpResponse = mock(HttpResponse.class);
+        StringEntity httpResponseEntity = new StringEntity("");
+        StatusLine statusLine = mock(StatusLine.class);
+        when(httpResponse.getStatusLine()).thenReturn(statusLine);
+        when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
+        when(httpClient.retrievePostResponse(anyString(), any(Header[].class), anyString())).thenReturn(httpResponse);
 
-		when(statusLine.getStatusCode()).thenReturn(500);
-		assertThrows(ResourceInterfaceException.class, () -> {
-			resource.info(new GeneralQueryRequest());
-		}, "Downstream Resource returned 500 and should cause 'ResourceInterfaceException'");
+        when(statusLine.getStatusCode()).thenReturn(500);
+        assertThrows(ResourceInterfaceException.class, () -> {
+            resource.info(new GeneralQueryRequest());
+        }, "Downstream Resource returned 500 and should cause 'ResourceInterfaceException'");
 
-		when(statusLine.getStatusCode()).thenReturn(401);
-		assertThrows(ResourceInterfaceException.class, () -> {
-			resource.info(new GeneralQueryRequest());
-		}, "Downstream Resource returned 401 and should cause 'ResourceInterfaceException'");
+        when(statusLine.getStatusCode()).thenReturn(401);
+        assertThrows(ResourceInterfaceException.class, () -> {
+            resource.info(new GeneralQueryRequest());
+        }, "Downstream Resource returned 401 and should cause 'ResourceInterfaceException'");
 
-		when(statusLine.getStatusCode()).thenReturn(200);
-		ResourceInfo resourceInfo = newResourceInfo();
-		httpResponseEntity = new StringEntity(new String(objectMapper.writeValueAsBytes(resourceInfo)));
-		when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
-		ResourceInfo returnVal = resource.info(new GeneralQueryRequest());
-		assertEquals(resourceInfo.getId(), returnVal.getId(), "Downstream ResourceInfo Id should match output");
-		assertEquals(resourceInfo.getName(), returnVal.getName(), "Downstream ResourceInfo Name should match output");
-		assertEquals(resourceInfo.getQueryFormats().size(), returnVal.getQueryFormats().size(),
-				"Downstream ResourceInfo QueryFormats should match output");
-	}
+        when(statusLine.getStatusCode()).thenReturn(200);
+        ResourceInfo resourceInfo = newResourceInfo();
+        httpResponseEntity = new StringEntity(new String(objectMapper.writeValueAsBytes(resourceInfo)));
+        when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
+        ResourceInfo returnVal = resource.info(new GeneralQueryRequest());
+        assertEquals(resourceInfo.getId(), returnVal.getId(), "Downstream ResourceInfo Id should match output");
+        assertEquals(resourceInfo.getName(), returnVal.getName(), "Downstream ResourceInfo Name should match output");
+        assertEquals(
+            resourceInfo.getQueryFormats().size(), returnVal.getQueryFormats().size(),
+            "Downstream ResourceInfo QueryFormats should match output"
+        );
+    }
 
-	@Test
-	void testQuery() throws Exception {
-		// setup http response mocks
-		HttpResponse httpResponse = mock(HttpResponse.class);
-		StringEntity httpResponseEntity = new StringEntity("");
-		StatusLine statusLine = mock(StatusLine.class);
-		when(statusLine.getStatusCode()).thenReturn(200);
-		when(httpResponse.getStatusLine()).thenReturn(statusLine);
-		when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
-		when(httpClient.retrievePostResponse(anyString(), any(Header[].class), anyString())).thenReturn(httpResponse);
+    @Test
+    void testQuery() throws Exception {
+        // setup http response mocks
+        HttpResponse httpResponse = mock(HttpResponse.class);
+        StringEntity httpResponseEntity = new StringEntity("");
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(200);
+        when(httpResponse.getStatusLine()).thenReturn(statusLine);
+        when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
+        when(httpClient.retrievePostResponse(anyString(), any(Header[].class), anyString())).thenReturn(httpResponse);
 
-		assertThrows(ProtocolException.class, () -> {
-			resource.query(null);
-		}, "QueryRequest is required");
+        assertThrows(ProtocolException.class, () -> {
+            resource.query(null);
+        }, "QueryRequest is required");
 
-		assertThrows(ProtocolException.class, () -> {
-			resource.query(new GeneralQueryRequest());
-		}, "Query is required");
+        assertThrows(ProtocolException.class, () -> {
+            resource.query(new GeneralQueryRequest());
+        }, "Query is required");
 
-		when(statusLine.getStatusCode()).thenReturn(500);
-		assertThrows(ResourceInterfaceException.class, () -> {
-			resource.query(newQueryRequest("test"));
-		}, "Downstream Resource returned 500 and should cause 'ResourceInterfaceException'");
+        when(statusLine.getStatusCode()).thenReturn(500);
+        assertThrows(ResourceInterfaceException.class, () -> {
+            resource.query(newQueryRequest("test"));
+        }, "Downstream Resource returned 500 and should cause 'ResourceInterfaceException'");
 
-		when(statusLine.getStatusCode()).thenReturn(401);
-		assertThrows(ResourceInterfaceException.class, () -> {
-			resource.query(newQueryRequest("test"));
-		}, "Downstream Resource returned 401 and should cause 'ResourceInterfaceException'");
+        when(statusLine.getStatusCode()).thenReturn(401);
+        assertThrows(ResourceInterfaceException.class, () -> {
+            resource.query(newQueryRequest("test"));
+        }, "Downstream Resource returned 401 and should cause 'ResourceInterfaceException'");
 
-		when(statusLine.getStatusCode()).thenReturn(200);
-		QueryStatus queryStatus = newQueryStatus(null);
-		httpResponseEntity = new StringEntity(new String(objectMapper.writeValueAsBytes(queryStatus)));
-		when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
-		GeneralQueryRequest queryRequest = newQueryRequest("test");
-		QueryStatus returnVal = resource.query(queryRequest);
-		assertEquals(queryRequest.getResourceUUID(), returnVal.getResourceID());
-	}
+        when(statusLine.getStatusCode()).thenReturn(200);
+        QueryStatus queryStatus = newQueryStatus(null);
+        httpResponseEntity = new StringEntity(new String(objectMapper.writeValueAsBytes(queryStatus)));
+        when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
+        GeneralQueryRequest queryRequest = newQueryRequest("test");
+        QueryStatus returnVal = resource.query(queryRequest);
+        assertEquals(queryRequest.getResourceUUID(), returnVal.getResourceID());
+    }
 
-	@Test
-	void testQueryResult() throws Exception {
-		// setup http response mocks
-		HttpResponse httpResponse = mock(HttpResponse.class);
-		StringEntity httpResponseEntity = new StringEntity("");
-		StatusLine statusLine = mock(StatusLine.class);
-		when(statusLine.getStatusCode()).thenReturn(200);
-		when(httpResponse.getStatusLine()).thenReturn(statusLine);
-		when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
-		when(httpClient.retrievePostResponse(anyString(), any(Header[].class), anyString())).thenReturn(httpResponse);
-		when(httpClient.readObjectFromResponse(any(HttpResponse.class))).thenReturn("4");
+    @Test
+    void testQueryResult() throws Exception {
+        // setup http response mocks
+        HttpResponse httpResponse = mock(HttpResponse.class);
+        StringEntity httpResponseEntity = new StringEntity("");
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(200);
+        when(httpResponse.getStatusLine()).thenReturn(statusLine);
+        when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
+        when(httpClient.retrievePostResponse(anyString(), any(Header[].class), anyString())).thenReturn(httpResponse);
+        when(httpClient.readObjectFromResponse(any(HttpResponse.class))).thenReturn("4");
 
-		assertThrows(ProtocolException.class, () -> {
-			resource.queryResult("", null);
-		}, "QueryID is required");
+        assertThrows(ProtocolException.class, () -> {
+            resource.queryResult("", null);
+        }, "QueryID is required");
 
-		assertThrows(ProtocolException.class, () -> {
-			resource.queryResult(UUID.randomUUID().toString(), null);
-		}, "QueryRequest is required");
+        assertThrows(ProtocolException.class, () -> {
+            resource.queryResult(UUID.randomUUID().toString(), null);
+        }, "QueryRequest is required");
 
-		when(statusLine.getStatusCode()).thenReturn(500);
-		assertThrows(ResourceInterfaceException.class, () -> {
-			resource.queryResult(UUID.randomUUID().toString(), newQueryRequest(null));
-		}, "Downstream Resource returned 500 and should cause 'ResourceInterfaceException'");
+        when(statusLine.getStatusCode()).thenReturn(500);
+        assertThrows(ResourceInterfaceException.class, () -> {
+            resource.queryResult(UUID.randomUUID().toString(), newQueryRequest(null));
+        }, "Downstream Resource returned 500 and should cause 'ResourceInterfaceException'");
 
-		when(statusLine.getStatusCode()).thenReturn(401);
-		assertThrows(ResourceInterfaceException.class, () -> {
-			resource.queryResult(UUID.randomUUID().toString(), newQueryRequest(null));
-		}, "Downstream Resource returned 401 and should cause 'ResourceInterfaceException'");
+        when(statusLine.getStatusCode()).thenReturn(401);
+        assertThrows(ResourceInterfaceException.class, () -> {
+            resource.queryResult(UUID.randomUUID().toString(), newQueryRequest(null));
+        }, "Downstream Resource returned 401 and should cause 'ResourceInterfaceException'");
 
-		when(statusLine.getStatusCode()).thenReturn(200);
-		String resultId = UUID.randomUUID().toString();
-		UUID queryId = UUID.randomUUID();
-		lenient().when(httpResponse.getFirstHeader("resultId")).thenReturn(newHeader("resultId", resultId));
-		httpResponseEntity = new StringEntity("4");
-		when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
-		GeneralQueryRequest queryRequest = newQueryRequest(null);
-		javax.ws.rs.core.Response returnVal = resource.queryResult(queryId.toString(), queryRequest);
-		assertEquals("4", returnVal.getEntity());
-		//assertEquals(resultId, returnVal.getHeaderString("resultId"));
-	}
+        when(statusLine.getStatusCode()).thenReturn(200);
+        String resultId = UUID.randomUUID().toString();
+        UUID queryId = UUID.randomUUID();
+        lenient().when(httpResponse.getFirstHeader("resultId")).thenReturn(newHeader("resultId", resultId));
+        httpResponseEntity = new StringEntity("4");
+        when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
+        GeneralQueryRequest queryRequest = newQueryRequest(null);
+        javax.ws.rs.core.Response returnVal = resource.queryResult(queryId.toString(), queryRequest);
+        assertEquals("4", returnVal.getEntity());
+        // assertEquals(resultId, returnVal.getHeaderString("resultId"));
+    }
 
-	@Test
-	void testQueryStatus() throws Exception {
-		// setup http response mocks
-		HttpResponse httpResponse = mock(HttpResponse.class);
-		StringEntity httpResponseEntity = new StringEntity("");
-		StatusLine statusLine = mock(StatusLine.class);
-		when(statusLine.getStatusCode()).thenReturn(200);
-		when(httpResponse.getStatusLine()).thenReturn(statusLine);
-		when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
-		when(httpClient.retrievePostResponse(anyString(), any(Header[].class), anyString())).thenReturn(httpResponse);
+    @Test
+    void testQueryStatus() throws Exception {
+        // setup http response mocks
+        HttpResponse httpResponse = mock(HttpResponse.class);
+        StringEntity httpResponseEntity = new StringEntity("");
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(200);
+        when(httpResponse.getStatusLine()).thenReturn(statusLine);
+        when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
+        when(httpClient.retrievePostResponse(anyString(), any(Header[].class), anyString())).thenReturn(httpResponse);
 
-		assertThrows(ProtocolException.class, () -> {
-			resource.queryStatus("", null);
-		}, "QueryID is required");
+        assertThrows(ProtocolException.class, () -> {
+            resource.queryStatus("", null);
+        }, "QueryID is required");
 
-		assertThrows(ProtocolException.class, () -> {
-			resource.queryStatus(UUID.randomUUID().toString(), null);
-		}, "QueryRequest is required");
+        assertThrows(ProtocolException.class, () -> {
+            resource.queryStatus(UUID.randomUUID().toString(), null);
+        }, "QueryRequest is required");
 
-		when(statusLine.getStatusCode()).thenReturn(500);
-		assertThrows(ResourceInterfaceException.class, () -> {
-			resource.queryStatus(UUID.randomUUID().toString(), newQueryRequest(null));
-		}, "Downstream Resource returned 500 and should cause 'ResourceInterfaceException'");
+        when(statusLine.getStatusCode()).thenReturn(500);
+        assertThrows(ResourceInterfaceException.class, () -> {
+            resource.queryStatus(UUID.randomUUID().toString(), newQueryRequest(null));
+        }, "Downstream Resource returned 500 and should cause 'ResourceInterfaceException'");
 
-		when(statusLine.getStatusCode()).thenReturn(401);
-		assertThrows(ResourceInterfaceException.class, () -> {
-			resource.queryStatus(UUID.randomUUID().toString(), newQueryRequest(null));
-		}, "Downstream Resource returned 401 and should cause 'ResourceInterfaceException'");
+        when(statusLine.getStatusCode()).thenReturn(401);
+        assertThrows(ResourceInterfaceException.class, () -> {
+            resource.queryStatus(UUID.randomUUID().toString(), newQueryRequest(null));
+        }, "Downstream Resource returned 401 and should cause 'ResourceInterfaceException'");
 
-		when(statusLine.getStatusCode()).thenReturn(200);
-		UUID queryId = UUID.randomUUID();
-		QueryStatus queryStatus = newQueryStatus(queryId);
-		httpResponseEntity = new StringEntity(new String(objectMapper.writeValueAsBytes(queryStatus)));
-		when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
-		GeneralQueryRequest queryRequest = newQueryRequest(null);
-		QueryStatus returnVal = resource.queryStatus(queryId.toString(), queryRequest);
-		assertEquals(queryId, returnVal.getPicsureResultId());
-		assertEquals(queryStatus.getStatus(), returnVal.getStatus());
-		assertEquals(queryStatus.getResourceStatus(), returnVal.getResourceStatus());
-	}
+        when(statusLine.getStatusCode()).thenReturn(200);
+        UUID queryId = UUID.randomUUID();
+        QueryStatus queryStatus = newQueryStatus(queryId);
+        httpResponseEntity = new StringEntity(new String(objectMapper.writeValueAsBytes(queryStatus)));
+        when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
+        GeneralQueryRequest queryRequest = newQueryRequest(null);
+        QueryStatus returnVal = resource.queryStatus(queryId.toString(), queryRequest);
+        assertEquals(queryId, returnVal.getPicsureResultId());
+        assertEquals(queryStatus.getStatus(), returnVal.getStatus());
+        assertEquals(queryStatus.getResourceStatus(), returnVal.getResourceStatus());
+    }
 
-	@Test
-	void testQuerySync() throws Exception {
-		// setup http response mocks
-		HttpResponse httpResponse = mock(HttpResponse.class);
-		StringEntity httpResponseEntity = new StringEntity("");
-		StatusLine statusLine = mock(StatusLine.class);
-		when(statusLine.getStatusCode()).thenReturn(200);
-		when(httpResponse.getStatusLine()).thenReturn(statusLine);
-		when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
-		when(httpClient.retrievePostResponse(anyString(), any(Header[].class), anyString())).thenReturn(httpResponse);
+    @Test
+    void testQuerySync() throws Exception {
+        // setup http response mocks
+        HttpResponse httpResponse = mock(HttpResponse.class);
+        StringEntity httpResponseEntity = new StringEntity("");
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(200);
+        when(httpResponse.getStatusLine()).thenReturn(statusLine);
+        when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
+        when(httpClient.retrievePostResponse(anyString(), any(Header[].class), anyString())).thenReturn(httpResponse);
 
-		assertThrows(ProtocolException.class, () -> {
-			resource.querySync(null);
-		}, "QueryRequest is required");
+        assertThrows(ProtocolException.class, () -> {
+            resource.querySync(null);
+        }, "QueryRequest is required");
 
-		assertThrows(ProtocolException.class, () -> {
-			resource.querySync(new GeneralQueryRequest());
-		}, "Query is required");
+        assertThrows(ProtocolException.class, () -> {
+            resource.querySync(new GeneralQueryRequest());
+        }, "Query is required");
 
-		when(statusLine.getStatusCode()).thenReturn(500);
-		assertThrows(ResourceInterfaceException.class, () -> {
-			resource.querySync(newQueryRequest("test"));
-		}, "Downstream Resource returned 500 and should cause 'ResourceInterfaceException'");
+        when(statusLine.getStatusCode()).thenReturn(500);
+        assertThrows(ResourceInterfaceException.class, () -> {
+            resource.querySync(newQueryRequest("test"));
+        }, "Downstream Resource returned 500 and should cause 'ResourceInterfaceException'");
 
-		when(statusLine.getStatusCode()).thenReturn(401);
-		assertThrows(ResourceInterfaceException.class, () -> {
-			resource.querySync(newQueryRequest("test"));
-		}, "Downstream Resource returned 401 and should cause 'ResourceInterfaceException'");
+        when(statusLine.getStatusCode()).thenReturn(401);
+        assertThrows(ResourceInterfaceException.class, () -> {
+            resource.querySync(newQueryRequest("test"));
+        }, "Downstream Resource returned 401 and should cause 'ResourceInterfaceException'");
 
-		when(statusLine.getStatusCode()).thenReturn(200);
-		String resultId = UUID.randomUUID().toString();
-		lenient().when(httpResponse.getFirstHeader("resultId")).thenReturn(newHeader("resultId", resultId));
-		httpResponseEntity = new StringEntity("4");
-		when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
-		GeneralQueryRequest queryRequest = newQueryRequest(newQuery());
-		javax.ws.rs.core.Response returnVal = resource.querySync(queryRequest);
-		assertEquals("4", IOUtils.toString((InputStream) returnVal.getEntity(), StandardCharsets.UTF_8));
-		//assertEquals(resultId, returnVal.getHeaderString("resultId"));
-	}
+        when(statusLine.getStatusCode()).thenReturn(200);
+        String resultId = UUID.randomUUID().toString();
+        lenient().when(httpResponse.getFirstHeader("resultId")).thenReturn(newHeader("resultId", resultId));
+        httpResponseEntity = new StringEntity("4");
+        when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
+        GeneralQueryRequest queryRequest = newQueryRequest(newQuery());
+        javax.ws.rs.core.Response returnVal = resource.querySync(queryRequest);
+        assertEquals("4", IOUtils.toString((InputStream) returnVal.getEntity(), StandardCharsets.UTF_8));
+        // assertEquals(resultId, returnVal.getHeaderString("resultId"));
+    }
 
-	@Test
-	void testSearch() throws Exception {
-		// setup http response mocks
-		HttpResponse httpResponse = mock(HttpResponse.class);
-		StringEntity httpResponseEntity = new StringEntity("");
-		StatusLine statusLine = mock(StatusLine.class);
-		when(statusLine.getStatusCode()).thenReturn(200);
-		when(httpResponse.getStatusLine()).thenReturn(statusLine);
-		when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
-		when(httpClient.retrievePostResponse(anyString(), any(Header[].class), anyString())).thenReturn(httpResponse);
+    @Test
+    void testSearch() throws Exception {
+        // setup http response mocks
+        HttpResponse httpResponse = mock(HttpResponse.class);
+        StringEntity httpResponseEntity = new StringEntity("");
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(200);
+        when(httpResponse.getStatusLine()).thenReturn(statusLine);
+        when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
+        when(httpClient.retrievePostResponse(anyString(), any(Header[].class), anyString())).thenReturn(httpResponse);
 
-		assertThrows(ProtocolException.class, () -> {
-			resource.search(null);
-		}, "QueryRequest is required");
+        assertThrows(ProtocolException.class, () -> {
+            resource.search(null);
+        }, "QueryRequest is required");
 
-		assertThrows(ProtocolException.class, () -> {
-			resource.search(new GeneralQueryRequest());
-		}, "Query is required");
+        assertThrows(ProtocolException.class, () -> {
+            resource.search(new GeneralQueryRequest());
+        }, "Query is required");
 
-		when(statusLine.getStatusCode()).thenReturn(500);
-		assertThrows(ResourceInterfaceException.class, () -> {
-			resource.search(newQueryRequest("test"));
-		}, "Downstream Resource returned 500 and should cause 'ResourceInterfaceException'");
+        when(statusLine.getStatusCode()).thenReturn(500);
+        assertThrows(ResourceInterfaceException.class, () -> {
+            resource.search(newQueryRequest("test"));
+        }, "Downstream Resource returned 500 and should cause 'ResourceInterfaceException'");
 
-		when(statusLine.getStatusCode()).thenReturn(401);
-		assertThrows(ResourceInterfaceException.class, () -> {
-			resource.search(newQueryRequest("test"));
-		}, "Downstream Resource returned 401 and should cause 'ResourceInterfaceException'");
+        when(statusLine.getStatusCode()).thenReturn(401);
+        assertThrows(ResourceInterfaceException.class, () -> {
+            resource.search(newQueryRequest("test"));
+        }, "Downstream Resource returned 401 and should cause 'ResourceInterfaceException'");
 
-		String queryText = "test";
-		when(statusLine.getStatusCode()).thenReturn(200);
-		SearchResults searchResults = new SearchResults();
-		searchResults.setSearchQuery(queryText);
-		httpResponseEntity = new StringEntity(new String(objectMapper.writeValueAsBytes(searchResults)));
-		when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
-		GeneralQueryRequest queryRequest = newQueryRequest(queryText);
-		SearchResults returnVal = resource.search(queryRequest);
-		assertEquals(queryText, returnVal.getSearchQuery());
-	}
+        String queryText = "test";
+        when(statusLine.getStatusCode()).thenReturn(200);
+        SearchResults searchResults = new SearchResults();
+        searchResults.setSearchQuery(queryText);
+        httpResponseEntity = new StringEntity(new String(objectMapper.writeValueAsBytes(searchResults)));
+        when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
+        GeneralQueryRequest queryRequest = newQueryRequest(queryText);
+        SearchResults returnVal = resource.search(queryRequest);
+        assertEquals(queryText, returnVal.getSearchQuery());
+    }
 
-	private ResourceInfo newResourceInfo() {
-		ResourceInfo info = new ResourceInfo();
-		info.setName("PhenoCube v1.0-SNAPSHOT");
-		info.setId(UUID.randomUUID());
-		info.setQueryFormats(ImmutableList
-				.of(new QueryFormat().setDescription("PhenoCube Query Format").setName("PhenoCube Query Format")));
-		return info;
-	}
+    private ResourceInfo newResourceInfo() {
+        ResourceInfo info = new ResourceInfo();
+        info.setName("PhenoCube v1.0-SNAPSHOT");
+        info.setId(UUID.randomUUID());
+        info.setQueryFormats(
+            Collections.singletonList(new QueryFormat().setDescription("PhenoCube Query Format").setName("PhenoCube Query Format"))
+        );
+        return info;
+    }
 
-	private QueryStatus newQueryStatus(UUID picsureResultId) {
-		QueryStatus status = new QueryStatus();
-		status.setStatus(PicSureStatus.QUEUED);
-		status.setResourceID(UUID.randomUUID());
-		status.setResourceStatus("PENDING");
-		status.setPicsureResultId(picsureResultId);
-		status.setResourceResultId(UUID.randomUUID().toString());
-		return status;
-	}
+    private QueryStatus newQueryStatus(UUID picsureResultId) {
+        QueryStatus status = new QueryStatus();
+        status.setStatus(PicSureStatus.QUEUED);
+        status.setResourceID(UUID.randomUUID());
+        status.setResourceStatus("PENDING");
+        status.setPicsureResultId(picsureResultId);
+        status.setResourceResultId(UUID.randomUUID().toString());
+        return status;
+    }
 
-	private GeneralQueryRequest newQueryRequest(Object query) {
-		GeneralQueryRequest request = new GeneralQueryRequest();
-		request.setResourceUUID(UUID.randomUUID());
-		request.setQuery(query);
-		return request;
-	}
-	
-	// replace with Map 
-	private Map<String,String> newQuery() {
-		Map<String,String> queryMap = new HashMap<>();
-		queryMap.put("requiredFields", "\\TEST");
-		queryMap.put("expectedResultType", "COUNT");
-		return queryMap;
-	}
+    private GeneralQueryRequest newQueryRequest(Object query) {
+        GeneralQueryRequest request = new GeneralQueryRequest();
+        request.setResourceUUID(UUID.randomUUID());
+        request.setQuery(query);
+        return request;
+    }
 
-	private Header newHeader(final String name, final String value) {
-		return new Header() {
-			@Override
-			public String getValue() {
-				return value;
-			}
+    // replace with Map
+    private Map<String, String> newQuery() {
+        Map<String, String> queryMap = new HashMap<>();
+        queryMap.put("requiredFields", "\\TEST");
+        queryMap.put("expectedResultType", "COUNT");
+        return queryMap;
+    }
 
-			@Override
-			public String getName() {
-				return name;
-			}
+    private Header newHeader(final String name, final String value) {
+        return new Header() {
+            @Override
+            public String getValue() {
+                return value;
+            }
 
-			@Override
-			public HeaderElement[] getElements() throws ParseException {
-				return null;
-			}
-		};
-	}
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public HeaderElement[] getElements() throws ParseException {
+                return null;
+            }
+        };
+    }
 }

--- a/pic-sure-resources/pic-sure-visualization-resource/pom.xml
+++ b/pic-sure-resources/pic-sure-visualization-resource/pom.xml
@@ -100,6 +100,22 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.10.1</version>
+				<configuration>
+					<source>11</source>
+					<target>11</target>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>1.18.30</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
 				<configuration>
 					<failOnMissingWebXml>false</failOnMissingWebXml>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
   </repositories>
   <properties>
     <jackson.version>2.16.0</jackson.version>
-    <guava.version>32.1.3-jre</guava.version>
     <junit-jupiter.version>5.6.2</junit-jupiter.version>
     <mockito-core.version>3.5.10</mockito-core.version>
     <mockito-junit-jupiter.version>3.5.10</mockito-junit-jupiter.version>
@@ -254,11 +253,6 @@
         <artifactId>wiremock-jre8</artifactId>
         <version>2.27.2</version>
         <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>${guava.version}</version>
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Guava dependency was removed from multiple modules to simplify and reduce project dependencies. Necessary updates were made to tests to replace Guava utilities with standard Java library methods. Additionally, Maven plugin configurations were updated, including the Maven compiler plugin, to ensure compatibility with Java 11 and support for Lombok's annotation processing.