### PR TITLE
ALS-8239: Fix PFB encoding issues

### DIFF
--- a/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/AggregateDataSharingResourceRS.java
+++ b/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/AggregateDataSharingResourceRS.java
@@ -30,6 +30,7 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -207,7 +208,7 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
         checkQuery(resultRequest);
         HttpResponse response = postRequest(resultRequest, "/query/" + queryId + "/result");
         try {
-            String responseBody = httpClientUtil.readObjectFromResponse(response);
+            String responseBody = httpClientUtil.readObjectFromResponse(response, StandardCharsets.UTF_8);
             return Response.ok(responseBody).build();
         } finally {
             HttpClientUtil.closeHttpResponse(response);

--- a/pic-sure-resources/pic-sure-passthrough-resource/src/main/java/edu/harvard/hms/dbmi/avillach/resource/passthru/PassThroughResourceRS.java
+++ b/pic-sure-resources/pic-sure-passthrough-resource/src/main/java/edu/harvard/hms/dbmi/avillach/resource/passthru/PassThroughResourceRS.java
@@ -1,6 +1,7 @@
 package edu.harvard.hms.dbmi.avillach.resource.passthru;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 import javax.inject.Inject;
@@ -13,7 +14,6 @@ import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.message.BasicHeader;
-import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,7 +69,7 @@ public class PassThroughResourceRS implements IResourceRS {
     public ResourceInfo info(QueryRequest infoRequest) {
         String pathName = "/info";
 
-		HttpResponse response = null;
+        HttpResponse response = null;
         try {
             QueryRequest chainRequest = new GeneralQueryRequest();
             if (infoRequest != null) {
@@ -101,8 +101,8 @@ public class PassThroughResourceRS implements IResourceRS {
             logger.error(e.getMessage());
             throw new ProtocolException(ProtocolException.INCORRECTLY_FORMATTED_REQUEST);
         } finally {
-			closeHttpResponse(response);
-		}
+            closeHttpResponse(response);
+        }
     }
 
     @POST
@@ -154,7 +154,7 @@ public class PassThroughResourceRS implements IResourceRS {
 
         String pathName = "/query/" + queryId + "/result";
 
-		HttpResponse response = null;
+        HttpResponse response = null;
         try {
             QueryRequest chainRequest = new GeneralQueryRequest();
             chainRequest.setQuery(resultRequest.getQuery());
@@ -164,8 +164,8 @@ public class PassThroughResourceRS implements IResourceRS {
             String payload = objectMapper.writeValueAsString(chainRequest);
             response = httpClient
                 .retrievePostResponse(httpClient.composeURL(properties.getTargetPicsureUrl(), pathName), createAuthHeader(), payload);
-			String content = httpClient.readObjectFromResponse(response);
-			if (response.getStatusLine().getStatusCode() != 200) {
+            String content = httpClient.readObjectFromResponse(response, StandardCharsets.UTF_8);
+            if (response.getStatusLine().getStatusCode() != 200) {
                 logger.error(
                     "{}{} calling resource with id {} did not return a 200: {} {} ", properties.getTargetPicsureUrl(), pathName,
                     chainRequest.getResourceUUID(), response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase()
@@ -180,8 +180,8 @@ public class PassThroughResourceRS implements IResourceRS {
             logger.error(e.getMessage());
             throw new ProtocolException(ProtocolException.INCORRECTLY_FORMATTED_REQUEST);
         } finally {
-			closeHttpResponse(response);
-		}
+            closeHttpResponse(response);
+        }
     }
 
     @POST

--- a/pic-sure-resources/pic-sure-passthrough-resource/src/main/java/edu/harvard/hms/dbmi/avillach/resource/passthru/PassThroughResourceRS.java
+++ b/pic-sure-resources/pic-sure-passthrough-resource/src/main/java/edu/harvard/hms/dbmi/avillach/resource/passthru/PassThroughResourceRS.java
@@ -164,7 +164,7 @@ public class PassThroughResourceRS implements IResourceRS {
             String payload = objectMapper.writeValueAsString(chainRequest);
             response = httpClient
                 .retrievePostResponse(httpClient.composeURL(properties.getTargetPicsureUrl(), pathName), createAuthHeader(), payload);
-            String content = httpClient.readObjectFromResponse(response, StandardCharsets.UTF_8);
+            byte[] content = httpClient.readBytesFromResponse(response);
             if (response.getStatusLine().getStatusCode() != 200) {
                 logger.error(
                     "{}{} calling resource with id {} did not return a 200: {} {} ", properties.getTargetPicsureUrl(), pathName,

--- a/pic-sure-resources/pic-sure-passthrough-resource/src/test/java/edu/harvard/hms/dbmi/avillach/resource/passthru/PassThroughResourceRSTest.java
+++ b/pic-sure-resources/pic-sure-passthrough-resource/src/test/java/edu/harvard/hms/dbmi/avillach/resource/passthru/PassThroughResourceRSTest.java
@@ -2,8 +2,7 @@ package edu.harvard.hms.dbmi.avillach.resource.passthru;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -139,7 +138,7 @@ class PassThroughResourceRSTest {
         when(httpResponse.getStatusLine()).thenReturn(statusLine);
         when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
         when(httpClient.retrievePostResponse(anyString(), any(Header[].class), anyString())).thenReturn(httpResponse);
-        when(httpClient.readObjectFromResponse(any(HttpResponse.class), StandardCharsets.ISO_8859_1)).thenReturn("4");
+        when(httpClient.readObjectFromResponse(any(HttpResponse.class), eq(StandardCharsets.UTF_8))).thenReturn("4");
 
         assertThrows(ProtocolException.class, () -> {
             resource.queryResult("", null);

--- a/pic-sure-resources/pic-sure-passthrough-resource/src/test/java/edu/harvard/hms/dbmi/avillach/resource/passthru/PassThroughResourceRSTest.java
+++ b/pic-sure-resources/pic-sure-passthrough-resource/src/test/java/edu/harvard/hms/dbmi/avillach/resource/passthru/PassThroughResourceRSTest.java
@@ -139,7 +139,7 @@ class PassThroughResourceRSTest {
         when(httpResponse.getStatusLine()).thenReturn(statusLine);
         when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
         when(httpClient.retrievePostResponse(anyString(), any(Header[].class), anyString())).thenReturn(httpResponse);
-        when(httpClient.readObjectFromResponse(any(HttpResponse.class))).thenReturn("4");
+        when(httpClient.readObjectFromResponse(any(HttpResponse.class), StandardCharsets.UTF_8)).thenReturn("4");
 
         assertThrows(ProtocolException.class, () -> {
             resource.queryResult("", null);

--- a/pic-sure-resources/pic-sure-passthrough-resource/src/test/java/edu/harvard/hms/dbmi/avillach/resource/passthru/PassThroughResourceRSTest.java
+++ b/pic-sure-resources/pic-sure-passthrough-resource/src/test/java/edu/harvard/hms/dbmi/avillach/resource/passthru/PassThroughResourceRSTest.java
@@ -1,7 +1,6 @@
 package edu.harvard.hms.dbmi.avillach.resource.passthru;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -138,7 +137,8 @@ class PassThroughResourceRSTest {
         when(httpResponse.getStatusLine()).thenReturn(statusLine);
         when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
         when(httpClient.retrievePostResponse(anyString(), any(Header[].class), anyString())).thenReturn(httpResponse);
-        when(httpClient.readObjectFromResponse(any(HttpResponse.class), eq(StandardCharsets.UTF_8))).thenReturn("4");
+        byte[] byteResponse = {101};
+        when(httpClient.readBytesFromResponse(any(HttpResponse.class))).thenReturn(byteResponse);
 
         assertThrows(ProtocolException.class, () -> {
             resource.queryResult("", null);
@@ -166,7 +166,7 @@ class PassThroughResourceRSTest {
         when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
         GeneralQueryRequest queryRequest = newQueryRequest(null);
         javax.ws.rs.core.Response returnVal = resource.queryResult(queryId.toString(), queryRequest);
-        assertEquals("4", returnVal.getEntity());
+        assertArrayEquals(byteResponse, (byte[]) returnVal.getEntity());
         // assertEquals(resultId, returnVal.getHeaderString("resultId"));
     }
 

--- a/pic-sure-resources/pic-sure-passthrough-resource/src/test/java/edu/harvard/hms/dbmi/avillach/resource/passthru/PassThroughResourceRSTest.java
+++ b/pic-sure-resources/pic-sure-passthrough-resource/src/test/java/edu/harvard/hms/dbmi/avillach/resource/passthru/PassThroughResourceRSTest.java
@@ -139,7 +139,7 @@ class PassThroughResourceRSTest {
         when(httpResponse.getStatusLine()).thenReturn(statusLine);
         when(httpResponse.getEntity()).thenReturn(httpResponseEntity);
         when(httpClient.retrievePostResponse(anyString(), any(Header[].class), anyString())).thenReturn(httpResponse);
-        when(httpClient.readObjectFromResponse(any(HttpResponse.class), StandardCharsets.UTF_8)).thenReturn("4");
+        when(httpClient.readObjectFromResponse(any(HttpResponse.class), StandardCharsets.ISO_8859_1)).thenReturn("4");
 
         assertThrows(ProtocolException.class, () -> {
             resource.queryResult("", null);

--- a/pic-sure-resources/pic-sure-resource-api/src/main/java/edu/harvard/dbmi/avillach/service/ResourceWebClient.java
+++ b/pic-sure-resources/pic-sure-resource-api/src/main/java/edu/harvard/dbmi/avillach/service/ResourceWebClient.java
@@ -21,6 +21,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -240,15 +241,16 @@ public class ResourceWebClient {
                 HttpClientUtil.composeURL(rsURL, pathName), createHeaders(queryRequest.getResourceCredentials()), body
             );
 
-            String content = httpClientUtil.readObjectFromResponse(resourcesResponse, StandardCharsets.ISO_8859_1);
             if (resourcesResponse.getStatusLine().getStatusCode() != 200) {
                 logger.error("ResourceRS did not return a 200");
                 HttpClientUtil.throwResponseError(resourcesResponse, rsURL);
             }
-            return Response.ok(content).build();
+            return Response.ok(resourcesResponse.getEntity().getContent()).build();
         } catch (JsonProcessingException e) {
             logger.error("Unable to encode resource credentials");
             throw new NotAuthorizedException("Unable to encode resource credentials", e);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         } finally {
             closeHttpResponse(resourcesResponse);
         }

--- a/pic-sure-resources/pic-sure-resource-api/src/main/java/edu/harvard/dbmi/avillach/service/ResourceWebClient.java
+++ b/pic-sure-resources/pic-sure-resource-api/src/main/java/edu/harvard/dbmi/avillach/service/ResourceWebClient.java
@@ -14,7 +14,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.message.BasicHeader;
-import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,6 +22,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import static edu.harvard.dbmi.avillach.util.HttpClientUtil.closeHttpResponse;
@@ -240,7 +240,7 @@ public class ResourceWebClient {
                 HttpClientUtil.composeURL(rsURL, pathName), createHeaders(queryRequest.getResourceCredentials()), body
             );
 
-            String content = httpClientUtil.readObjectFromResponse(resourcesResponse);
+            String content = httpClientUtil.readObjectFromResponse(resourcesResponse, StandardCharsets.ISO_8859_1);
             if (resourcesResponse.getStatusLine().getStatusCode() != 200) {
                 logger.error("ResourceRS did not return a 200");
                 HttpClientUtil.throwResponseError(resourcesResponse, rsURL);
@@ -281,7 +281,7 @@ public class ResourceWebClient {
                 httpClientUtil.throwResponseError(resourcesResponse, rsURL);
             }
 
-            String content = httpClientUtil.readObjectFromResponse(resourcesResponse);
+            String content = httpClientUtil.readObjectFromResponse(resourcesResponse, StandardCharsets.UTF_8);
             return Response.ok(content).build();
         } catch (JsonProcessingException e) {
             logger.error("Unable to encode resource credentials");
@@ -311,7 +311,7 @@ public class ResourceWebClient {
                 httpClientUtil.composeURL(rsURL, pathName), createHeaders(queryRequest.getResourceCredentials()), body
             );
 
-            String content = httpClientUtil.readObjectFromResponse(resourcesResponse);
+            String content = httpClientUtil.readObjectFromResponse(resourcesResponse, StandardCharsets.UTF_8);
             int status = resourcesResponse.getStatusLine().getStatusCode();
             if (status != 200) {
                 logger.error("Query format request did not return a 200:  {}", resourcesResponse.getStatusLine().getStatusCode());
@@ -360,7 +360,7 @@ public class ResourceWebClient {
                 throwError(resourcesResponse, rsURL);
             }
 
-            String content = httpClientUtil.readObjectFromResponse(resourcesResponse);
+            String content = httpClientUtil.readObjectFromResponse(resourcesResponse, StandardCharsets.UTF_8);
             if (resourcesResponse.containsHeader(QUERY_METADATA_FIELD)) {
                 Header metadataHeader = ((Header[]) resourcesResponse.getHeaders(QUERY_METADATA_FIELD))[0];
                 return Response.ok(content).header(QUERY_METADATA_FIELD, metadataHeader.getValue()).build();
@@ -417,7 +417,7 @@ public class ResourceWebClient {
                 throwError(resourcesResponse, rsURL);
             }
 
-            String content = httpClientUtil.readObjectFromResponse(resourcesResponse);
+            String content = httpClientUtil.readObjectFromResponse(resourcesResponse, StandardCharsets.UTF_8);
             return Response.ok(content).build();
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);

--- a/pic-sure-resources/pic-sure-resource-api/src/main/java/edu/harvard/dbmi/avillach/service/ResourceWebClient.java
+++ b/pic-sure-resources/pic-sure-resource-api/src/main/java/edu/harvard/dbmi/avillach/service/ResourceWebClient.java
@@ -20,8 +20,7 @@ import org.slf4j.LoggerFactory;
 import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
-import java.io.IOException;
-import java.io.UncheckedIOException;
+import java.io.*;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -242,6 +241,12 @@ public class ResourceWebClient {
             );
 
             byte[] content = httpClientUtil.readBytesFromResponse(resourcesResponse);
+            FileOutputStream fos = new FileOutputStream("/tmp/test.avro");
+            fos.write(content);
+
+            String contentString = new String(content, StandardCharsets.ISO_8859_1);
+            logger.info("Query result:");
+            logger.info(contentString);
             if (resourcesResponse.getStatusLine().getStatusCode() != 200) {
                 logger.error("ResourceRS did not return a 200");
                 HttpClientUtil.throwResponseError(resourcesResponse, rsURL);
@@ -250,6 +255,10 @@ public class ResourceWebClient {
         } catch (JsonProcessingException e) {
             logger.error("Unable to encode resource credentials");
             throw new NotAuthorizedException("Unable to encode resource credentials", e);
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         } finally {
             closeHttpResponse(resourcesResponse);
         }

--- a/pic-sure-resources/pic-sure-resource-api/src/main/java/edu/harvard/dbmi/avillach/service/ResourceWebClient.java
+++ b/pic-sure-resources/pic-sure-resource-api/src/main/java/edu/harvard/dbmi/avillach/service/ResourceWebClient.java
@@ -241,16 +241,15 @@ public class ResourceWebClient {
                 HttpClientUtil.composeURL(rsURL, pathName), createHeaders(queryRequest.getResourceCredentials()), body
             );
 
+            byte[] content = httpClientUtil.readBytesFromResponse(resourcesResponse);
             if (resourcesResponse.getStatusLine().getStatusCode() != 200) {
                 logger.error("ResourceRS did not return a 200");
                 HttpClientUtil.throwResponseError(resourcesResponse, rsURL);
             }
-            return Response.ok(resourcesResponse.getEntity().getContent()).build();
+            return Response.ok(content).build();
         } catch (JsonProcessingException e) {
             logger.error("Unable to encode resource credentials");
             throw new NotAuthorizedException("Unable to encode resource credentials", e);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
         } finally {
             closeHttpResponse(resourcesResponse);
         }

--- a/pic-sure-resources/pic-sure-resource-api/src/main/java/edu/harvard/dbmi/avillach/service/ResourceWebClient.java
+++ b/pic-sure-resources/pic-sure-resource-api/src/main/java/edu/harvard/dbmi/avillach/service/ResourceWebClient.java
@@ -241,12 +241,6 @@ public class ResourceWebClient {
             );
 
             byte[] content = httpClientUtil.readBytesFromResponse(resourcesResponse);
-            FileOutputStream fos = new FileOutputStream("/tmp/test.avro");
-            fos.write(content);
-
-            String contentString = new String(content, StandardCharsets.ISO_8859_1);
-            logger.info("Query result:");
-            logger.info(contentString);
             if (resourcesResponse.getStatusLine().getStatusCode() != 200) {
                 logger.error("ResourceRS did not return a 200");
                 HttpClientUtil.throwResponseError(resourcesResponse, rsURL);
@@ -255,10 +249,6 @@ public class ResourceWebClient {
         } catch (JsonProcessingException e) {
             logger.error("Unable to encode resource credentials");
             throw new NotAuthorizedException("Unable to encode resource credentials", e);
-        } catch (FileNotFoundException e) {
-            throw new RuntimeException(e);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
         } finally {
             closeHttpResponse(resourcesResponse);
         }

--- a/pic-sure-resources/pic-sure-resource-api/src/test/java/edu/harvard/dbmi/avillach/service/ResourceWebClientTest.java
+++ b/pic-sure-resources/pic-sure-resource-api/src/test/java/edu/harvard/dbmi/avillach/service/ResourceWebClientTest.java
@@ -292,7 +292,7 @@ public class ResourceWebClientTest {
     @Test
     public void testQueryResult() throws JsonProcessingException {
         String testId = "230048";
-        String mockResult = "{}";
+        byte[] mockResult = new byte[] {};
 
 
 
@@ -341,8 +341,8 @@ public class ResourceWebClientTest {
         Response result = cut.queryResult(testURL, testId, queryRequest);
         assertNotNull("Result should not be null", result);
         // String resultContent = IOUtils.toString((InputStream) result.getEntity(), "UTF-8");
-        String resultContent = (String) result.getEntity();
-        assertEquals("Result should match " + mockResult, mockResult, resultContent);
+        byte[] resultContent = (byte[]) result.getEntity();
+        assertArrayEquals("Result should match " + mockResult, mockResult, resultContent);
 
         // What if the resource has a problem?
         wireMockRule.stubFor(any(urlMatching("/query/.*/result")).willReturn(aResponse().withStatus(500)));

--- a/pic-sure-util/src/main/java/edu/harvard/dbmi/avillach/util/HttpClientUtil.java
+++ b/pic-sure-util/src/main/java/edu/harvard/dbmi/avillach/util/HttpClientUtil.java
@@ -150,6 +150,17 @@ public class HttpClientUtil {
         }
     }
 
+    public byte[] readBytesFromResponse(HttpResponse response) {
+        logger.debug("HttpClientUtil readObjectFromResponse(HttpResponse response)");
+        try {
+            byte[] responseBody = EntityUtils.toByteArray(response.getEntity());
+            logger.debug("readObjectFromResponse() responseBody {}", responseBody);
+            return responseBody;
+        } catch (IOException e) {
+            throw new ApplicationException("Incorrect object type returned", e);
+        }
+    }
+
     public static <T> T readObjectFromResponse(HttpResponse response, Class<T> expectedElementType) {
         logger.debug("HttpClientUtil readObjectFromResponse()");
         try {

--- a/pic-sure-util/src/main/java/edu/harvard/dbmi/avillach/util/HttpClientUtil.java
+++ b/pic-sure-util/src/main/java/edu/harvard/dbmi/avillach/util/HttpClientUtil.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
@@ -19,7 +20,6 @@ import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -139,10 +139,10 @@ public class HttpClientUtil {
         }
     }
 
-    public String readObjectFromResponse(HttpResponse response) {
+    public String readObjectFromResponse(HttpResponse response, Charset charset) {
         logger.debug("HttpClientUtil readObjectFromResponse(HttpResponse response)");
         try {
-            String responseBody = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+            String responseBody = EntityUtils.toString(response.getEntity(), charset);
             logger.debug("readObjectFromResponse() responseBody {}", responseBody);
             return responseBody;
         } catch (IOException e) {


### PR DESCRIPTION
* Update the query result methods to not convert responses to strings, which was breaking the encoding of binary files