### PR TITLE
[Bug] Session timeout not logged

### DIFF
--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/JWTFilter.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/JWTFilter.java
@@ -106,6 +106,10 @@ public class JWTFilter implements ContainerRequestFilter {
             return;
         }
 
+        if (uriInfo.getPath().startsWith("proxy/pic-sure-logging/")) {
+            return;
+        }
+
         if (
             requestContext.getUriInfo().getPath().contentEquals("/system/status")
                 && requestContext.getRequest().getMethod().contentEquals(HttpMethod.GET)

--- a/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/security/JWTFilterTest.java
+++ b/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/security/JWTFilterTest.java
@@ -120,6 +120,15 @@ public class JWTFilterTest {
     }
 
     @Test
+    public void testLoggingProxyPathSkipsAuthentication() throws IOException {
+        ContainerRequestContext ctx = createRequestContext();
+        when(filter.uriInfo.getPath()).thenReturn("proxy/pic-sure-logging/audit");
+        filter.filter(ctx);
+        verify(ctx, never()).getHeaderString(HttpHeaders.AUTHORIZATION);
+        verify(ctx, never()).abortWith(any(Response.class));
+    }
+
+    @Test
     public void testFilterCallsTokenIntrospectionAppropriatelyForQuerySync() throws IOException {
 
         tokenIntrospectionStub();


### PR DESCRIPTION
When a user expires, their token was still being inspected and thus would return a 401.  Thus the log would be dropped. User tokens being inspected was not really intentional.