### PR TITLE
[ALS-10196] [ALS-10195] Add configuration endpoint and table

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This is the git repository for version 2+ of the PIC-SURE API.
 
-## Pre-requisits
+## Pre-requisites
 
 * Java 11
 * Before contributing code, please set up our git hook:
@@ -22,9 +22,8 @@ The build consists of the following top level maven modules:
 
 To build the entire project, change directory to the projects top level, and execute:
 
-```
-mvn clean install
-
+```shell
+  mvn clean install
 ```
 
 This command will run all tests, with the included WildFly server.
@@ -38,17 +37,19 @@ PIC_SURE_USER_ID_CLAIM - This should be "email"
 
 To run the app for development, go into the pic-sure-api-wildfly folder and use this:
 
-mvn wildfly:run && mvn wildfly:shutdown
+```shell
+  mvn wildfly:run && mvn wildfly:shutdown
+```
 
 This will start the app with the console output in your terminal session and CTRL-C will kill it correctly.
 
 If you wish to debug your tests from Eclipse, use `mvnDebug clean install` and connect your debugger.
 
-If you wish to debug your services while the tests run, set the suspend=n to suspend=y in 
+If you wish to debug your services while the tests run, set the `suspend=n` to `suspend=y` in 
 the wildfly-maven-plugin configuration in the pom file for pic-sure-api-wildfly on the line that looks like:
 
+```pom
 <java-opt>-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005</java-opt>
-						
+```
+
 Both of these will pause the build allowing you to connect your debuggers.
-
-

--- a/pic-sure-api-data/src/main/java/edu/harvard/dbmi/avillach/data/entity/Configuration.java
+++ b/pic-sure-api-data/src/main/java/edu/harvard/dbmi/avillach/data/entity/Configuration.java
@@ -1,0 +1,104 @@
+package edu.harvard.dbmi.avillach.data.entity;
+
+import javax.json.Json;
+import javax.persistence.*;
+
+import edu.harvard.dbmi.avillach.data.request.ConfigurationRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "A Configuration object containing name, kind, enabled status, and description.")
+@Entity(name = "configuration")
+@Table(
+    name = "configuration",
+    uniqueConstraints = {@UniqueConstraint(name = "unique_uuid", columnNames = {"uuid"}),
+        @UniqueConstraint(name = "unique_name_kind", columnNames = {"name", "kind"})}
+)
+public class Configuration extends BaseEntity {
+    @Schema(description = "The configuration name")
+    @Column(length = 255)
+    private String name;
+
+    @Schema(description = "The configuration kind/type")
+    @Column(length = 255)
+    private String kind;
+
+    @Schema(description = "The configuration description")
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String value;
+
+    @Schema(description = "The configuration value")
+    @Column(length = 255)
+    private String description;
+
+    @Schema(description = "This configuration is flagged for deletion")
+    private Boolean markForDelete = false;
+
+    public Configuration setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Configuration setKind(String kind) {
+        this.kind = kind;
+        return this;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public Configuration setValue(String value) {
+        this.value = value;
+        return this;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public Configuration setDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Configuration setMarkForDelete(Boolean markForDelete) {
+        this.markForDelete = markForDelete;
+        return this;
+    }
+
+    public Boolean getMarkForDelete() {
+        return markForDelete;
+    }
+
+    @Override
+    public String toString() {
+        return Json.createObjectBuilder().add("uuid", uuid.toString()).add("name", name != null ? name : "")
+            .add("kind", kind != null ? kind : "").add("value", value != null ? value : "")
+            .add("description", description != null ? description : "").add("markForDelete", markForDelete != null ? value : "").build()
+            .toString();
+    }
+
+    public Configuration patch(ConfigurationRequest request) {
+        if (request.getName() != null) this.setName(request.getName());
+        if (request.getKind() != null) this.setKind(request.getKind());
+        if (request.getValue() != null) this.setValue(request.getValue());
+        if (request.getDescription() != null) this.setDescription(request.getDescription());
+        if (request.getMarkForDelete() != null) this.setMarkForDelete(request.getMarkForDelete());
+
+        return this;
+    }
+
+    public static Configuration fromRequest(ConfigurationRequest request) {
+        Configuration config = new Configuration();
+        return config.patch(request);
+    }
+}

--- a/pic-sure-api-data/src/main/java/edu/harvard/dbmi/avillach/data/entity/Configuration.java
+++ b/pic-sure-api-data/src/main/java/edu/harvard/dbmi/avillach/data/entity/Configuration.java
@@ -22,12 +22,12 @@ public class Configuration extends BaseEntity {
     @Column(length = 255)
     private String kind;
 
-    @Schema(description = "The configuration description")
+    @Schema(description = "The configuration value")
     @Lob
     @Column(columnDefinition = "TEXT")
     private String value;
 
-    @Schema(description = "The configuration value")
+    @Schema(description = "The configuration description")
     @Column(length = 255)
     private String description;
 
@@ -81,10 +81,10 @@ public class Configuration extends BaseEntity {
 
     @Override
     public String toString() {
-        return Json.createObjectBuilder().add("uuid", uuid.toString()).add("name", name != null ? name : "")
+        return Json.createObjectBuilder().add("uuid", uuid != null ? uuid.toString() : "").add("name", name != null ? name : "")
             .add("kind", kind != null ? kind : "").add("value", value != null ? value : "")
-            .add("description", description != null ? description : "").add("markForDelete", markForDelete != null ? value : "").build()
-            .toString();
+            .add("description", description != null ? description : "").add("markForDelete", markForDelete != null ? markForDelete : false)
+            .build().toString();
     }
 
     public Configuration patch(ConfigurationRequest request) {

--- a/pic-sure-api-data/src/main/java/edu/harvard/dbmi/avillach/data/repository/BaseRepository.java
+++ b/pic-sure-api-data/src/main/java/edu/harvard/dbmi/avillach/data/repository/BaseRepository.java
@@ -16,235 +16,234 @@ import java.util.*;
  */
 public abstract class BaseRepository<T extends BaseEntity, K> {
 
-	Logger logger = LoggerFactory.getLogger(BaseRepository.class);
+    Logger logger = LoggerFactory.getLogger(BaseRepository.class);
 
-	protected final Class<T> type;
-	
-	protected BaseRepository(Class<T> type){
-		this.type = type;
-	}
+    protected final Class<T> type;
 
-	@PersistenceContext
-	protected EntityManager em;
-	
-	protected EntityManager em(){
-		return em;
-	}
-	
-	protected CriteriaBuilder cb() {
-		return em().getCriteriaBuilder();
-	}
-
-	/**
-	 *
-	 * @return a criteriaQuery instance created by criteriaBuilder in entityManager
-	 */
-	public CriteriaQuery<T> query(){
-		return cb().createQuery(type);
-	}
-
-	public Predicate eq(Root root, String columnName, Object value){
-		return eq(cb(),root,columnName,value);
-	}
-
-	public Predicate eq(CriteriaBuilder cb, Root root, String columnName, Object value){
-		return cb.equal(root.get(columnName), value);
-	}
-
-	public <V extends Number> Predicate lt(CriteriaBuilder cb, Root root, String columnName, V value){
-		return cb.lt(root.get(columnName),value);
-	}
-
-	public <V extends Number> Predicate gt(CriteriaBuilder cb, Root root, String columnName, V value){
-		return cb.gt(root.get(columnName),value);
-	}
-
-	public <V extends Comparable> Predicate between(CriteriaBuilder cb, Root root, String columnName, V value1, V value2){
-		Expression<V> exp = root.get(columnName);
-		return cb.between(exp,value1,value2);
-	}
-
-	public Predicate like(CriteriaBuilder cb, Root root, String columnName, String value){
-		Expression<String> exp = root.get(columnName);
-		return cb.like(exp, value);
-	}
-
-	public Predicate or(CriteriaBuilder cb, Predicate... restrictions){
-		return cb.or(restrictions);
-	}
-
-	public T getById(K id){
-		return em().find(type, id);
-	}
-
-	/**
-	 * assume the operator is eq
-	 * @param columnName
-	 * @param value
-	 * @return
-	 */
-	public List<T> getByColumn(String columnName, Object value){
-	    CriteriaQuery query = query();
-		Root root = root(query);
-		return getByColumns(query, root, eq(cb(),root,columnName,value));
-	}
-
-	/**
-	 * assume the operator is eq
-	 * @param columnName
-	 * @param value
-	 * @return
-	 */
-	public T getUniqueResultByColumn(String columnName, Object value){
-		CriteriaQuery query = query();
-		Root root = root(query);
-		return getUniqueResultByColumns(query, root, eq(cb(),root,columnName,value));
-	}
-
-	/**
-	 * assume the operator is eq
-	 * @param columnNameValueMap
-	 * @return
-	 */
-	public List<T> getByColumns(CriteriaQuery query, Map<String, Object> columnNameValueMap){
-		CriteriaBuilder cb = cb();
-	    List<Predicate> predicates = new ArrayList<>();
-		Root root = root(query);
-		for (Map.Entry<String, Object> entry : columnNameValueMap.entrySet()){
-			predicates.add(eq(cb,root,entry.getKey(), entry.getValue()));
-		}
-		return getByColumns(query, root, (Predicate[]) predicates.toArray());
-	}
-
-	/**
-	 * assume the operator is eq
-	 * @param columnNameValueMap
-	 * @return
-	 */
-	public T getUniqueResultByColumns(CriteriaQuery query, Map<String, Object> columnNameValueMap){
-		CriteriaBuilder cb = cb();
-		List<Predicate> predicates = new ArrayList<>();
-		Root root = root(query);
-		for (Map.Entry<String, Object> entry : columnNameValueMap.entrySet()){
-			predicates.add(eq(cb,root,entry.getKey(), entry.getValue()));
-		}
-		return getUniqueResultByColumns(query, root, (Predicate[]) predicates.toArray());
-	}
-
-	/**
-	 * given the ability to assign your own predicates like lt, eq, like
-	 * @param root
-	 * @param predicates provide your own predicates
-	 * @return
-	 */
-	public List<T> getByColumns(CriteriaQuery query, Root root, Predicate... predicates){
-
-		query.select(root);
-		if (predicates != null && predicates.length > 0)
-			query.where(predicates);
-		return em().createQuery(query)
-				.getResultList();
-
-	}
-
-	/**
-	 * given the ability to assign your own predicates like lt, eq, like
-	 * @param root
-	 * @param predicates provide your own predicates
-	 * @return
-	 */
-	public T getUniqueResultByColumns(CriteriaQuery query, Root root, Predicate... predicates){
-
-		query.select(root);
-		if (predicates != null && predicates.length > 0)
-			query.where(predicates);
-		try {
-			return (T) em().createQuery(query)
-				.getSingleResult();
-		} catch (NoResultException e){
-			return null;
-		}
-	}
-
-	public List<T> list(){
-        CriteriaQuery query = query();
-		return getByColumns(query, root(query));
-	}
-
-	protected Root<T> root(CriteriaQuery query){
-		return query.from(type);
-	}
-	
-	public class InParam<S>{
-		private String parameterName;
-		private Class<S> parameterValueClass;
-		private S parameterValue;
-		
-		public InParam(Class<S> type) {
-			this.parameterValueClass = type;
-		}
-		public String getParameterName() {
-			return parameterName;
-		}
-		public InParam<S> name(String parameterName) {
-			this.parameterName = parameterName;
-			return this;
-		}
-		public Class<S> getParameterValueClass() {
-			return parameterValueClass;
-		}
-		public InParam<S> type(Class<S> parameterValueClass) {
-			this.parameterValueClass = parameterValueClass;
-			return this;
-		}
-		public S getParameterValue() {
-			return parameterValue;
-		}
-		public InParam<S> value(S parameterValue) {
-			this.parameterValue = parameterValue;
-			return this;
-		}
-	}
-	
-	public InParam inParam(Class type){
-		return new InParam(type);
-	}
-	
-	public StoredProcedureQuery createQueryFor(String procedureName, Class entityType, InParam ... inParams){
-		StoredProcedureQuery validationsQuery = 
-				em().createStoredProcedureQuery(procedureName, entityType);
-		for(InParam param : inParams){
-			validationsQuery.registerStoredProcedureParameter(param.parameterName, param.parameterValueClass, ParameterMode.IN)
-			.setParameter(param.parameterName, param.parameterValue);			
-		}
-		return validationsQuery;
-	}
-
-	public void persist(T t){
-		em().persist(t);
-	}
-
-	public void remove(T t){
-		em().remove(t);
-	}
-
-	public T merge(T t){
-	    return em().merge(t);
+    protected BaseRepository(Class<T> type) {
+        this.type = type;
     }
 
-	public void addObjectToSet(Set<T> set, BaseRepository<T, UUID> baseRepository, T t)
-			throws ProtocolException {
+    @PersistenceContext
+    protected EntityManager em;
 
-		if (t.getUuid() == null)
-			return;
+    protected EntityManager em() {
+        return em;
+    }
 
-		T temp = baseRepository.getById(t.getUuid());
-		if (temp == null) {
-			String className = type.getSimpleName();
-			logger.error("Cannot find " + className + " instance by uuid: " + t.getUuid().toString());
-			throw new ProtocolException("Cannot find " + className + " instance by uuid: " + t.getUuid().toString());
-		} else {
-			set.add(temp);
-		}
-	}
+    protected CriteriaBuilder cb() {
+        return em().getCriteriaBuilder();
+    }
+
+    /**
+     *
+     * @return a criteriaQuery instance created by criteriaBuilder in entityManager
+     */
+    public CriteriaQuery<T> query() {
+        return cb().createQuery(type);
+    }
+
+    public Predicate eq(Root root, String columnName, Object value) {
+        return eq(cb(), root, columnName, value);
+    }
+
+    public Predicate eq(CriteriaBuilder cb, Root root, String columnName, Object value) {
+        return cb.equal(root.get(columnName), value);
+    }
+
+    public <V extends Number> Predicate lt(CriteriaBuilder cb, Root root, String columnName, V value) {
+        return cb.lt(root.get(columnName), value);
+    }
+
+    public <V extends Number> Predicate gt(CriteriaBuilder cb, Root root, String columnName, V value) {
+        return cb.gt(root.get(columnName), value);
+    }
+
+    public <V extends Comparable> Predicate between(CriteriaBuilder cb, Root root, String columnName, V value1, V value2) {
+        Expression<V> exp = root.get(columnName);
+        return cb.between(exp, value1, value2);
+    }
+
+    public Predicate like(CriteriaBuilder cb, Root root, String columnName, String value) {
+        Expression<String> exp = root.get(columnName);
+        return cb.like(exp, value);
+    }
+
+    public Predicate or(CriteriaBuilder cb, Predicate... restrictions) {
+        return cb.or(restrictions);
+    }
+
+    public T getById(K id) {
+        return em().find(type, id);
+    }
+
+    /**
+     * assume the operator is eq
+     * @param columnName
+     * @param value
+     * @return
+     */
+    public List<T> getByColumn(String columnName, Object value) {
+        CriteriaQuery query = query();
+        Root root = root(query);
+        return getByColumns(query, root, eq(cb(), root, columnName, value));
+    }
+
+    /**
+     * assume the operator is eq
+     * @param columnName
+     * @param value
+     * @return
+     */
+    public T getUniqueResultByColumn(String columnName, Object value) {
+        CriteriaQuery query = query();
+        Root root = root(query);
+        return getUniqueResultByColumns(query, root, eq(cb(), root, columnName, value));
+    }
+
+    /**
+     * assume the operator is eq
+     * @param columnNameValueMap
+     * @return
+     */
+    public List<T> getByColumns(CriteriaQuery query, Map<String, Object> columnNameValueMap) {
+        CriteriaBuilder cb = cb();
+        List<Predicate> predicates = new ArrayList<>();
+        Root root = root(query);
+        for (Map.Entry<String, Object> entry : columnNameValueMap.entrySet()) {
+            predicates.add(eq(cb, root, entry.getKey(), entry.getValue()));
+        }
+        return getByColumns(query, root, predicates.toArray(new Predicate[0]));
+    }
+
+    /**
+     * assume the operator is eq
+     * @param columnNameValueMap
+     * @return
+     */
+    public T getUniqueResultByColumns(CriteriaQuery query, Map<String, Object> columnNameValueMap) {
+        CriteriaBuilder cb = cb();
+        List<Predicate> predicates = new ArrayList<>();
+        Root root = root(query);
+        for (Map.Entry<String, Object> entry : columnNameValueMap.entrySet()) {
+            predicates.add(eq(cb, root, entry.getKey(), entry.getValue()));
+        }
+        return getUniqueResultByColumns(query, root, (Predicate[]) predicates.toArray());
+    }
+
+    /**
+     * given the ability to assign your own predicates like lt, eq, like
+     * @param root
+     * @param predicates provide your own predicates
+     * @return
+     */
+    public List<T> getByColumns(CriteriaQuery query, Root root, Predicate... predicates) {
+
+        query.select(root);
+        if (predicates != null && predicates.length > 0) query.where(predicates);
+        return em().createQuery(query).getResultList();
+
+    }
+
+    /**
+     * given the ability to assign your own predicates like lt, eq, like
+     * @param root
+     * @param predicates provide your own predicates
+     * @return
+     */
+    public T getUniqueResultByColumns(CriteriaQuery query, Root root, Predicate... predicates) {
+
+        query.select(root);
+        if (predicates != null && predicates.length > 0) query.where(predicates);
+        try {
+            return (T) em().createQuery(query).getSingleResult();
+        } catch (NoResultException e) {
+            return null;
+        }
+    }
+
+    public List<T> list() {
+        CriteriaQuery query = query();
+        return getByColumns(query, root(query));
+    }
+
+    protected Root<T> root(CriteriaQuery query) {
+        return query.from(type);
+    }
+
+    public class InParam<S> {
+        private String parameterName;
+        private Class<S> parameterValueClass;
+        private S parameterValue;
+
+        public InParam(Class<S> type) {
+            this.parameterValueClass = type;
+        }
+
+        public String getParameterName() {
+            return parameterName;
+        }
+
+        public InParam<S> name(String parameterName) {
+            this.parameterName = parameterName;
+            return this;
+        }
+
+        public Class<S> getParameterValueClass() {
+            return parameterValueClass;
+        }
+
+        public InParam<S> type(Class<S> parameterValueClass) {
+            this.parameterValueClass = parameterValueClass;
+            return this;
+        }
+
+        public S getParameterValue() {
+            return parameterValue;
+        }
+
+        public InParam<S> value(S parameterValue) {
+            this.parameterValue = parameterValue;
+            return this;
+        }
+    }
+
+    public InParam inParam(Class type) {
+        return new InParam(type);
+    }
+
+    public StoredProcedureQuery createQueryFor(String procedureName, Class entityType, InParam... inParams) {
+        StoredProcedureQuery validationsQuery = em().createStoredProcedureQuery(procedureName, entityType);
+        for (InParam param : inParams) {
+            validationsQuery.registerStoredProcedureParameter(param.parameterName, param.parameterValueClass, ParameterMode.IN)
+                .setParameter(param.parameterName, param.parameterValue);
+        }
+        return validationsQuery;
+    }
+
+    public void persist(T t) {
+        em().persist(t);
+    }
+
+    public void remove(T t) {
+        em().remove(t);
+    }
+
+    public T merge(T t) {
+        return em().merge(t);
+    }
+
+    public void addObjectToSet(Set<T> set, BaseRepository<T, UUID> baseRepository, T t) throws ProtocolException {
+
+        if (t.getUuid() == null) return;
+
+        T temp = baseRepository.getById(t.getUuid());
+        if (temp == null) {
+            String className = type.getSimpleName();
+            logger.error("Cannot find " + className + " instance by uuid: " + t.getUuid().toString());
+            throw new ProtocolException("Cannot find " + className + " instance by uuid: " + t.getUuid().toString());
+        } else {
+            set.add(temp);
+        }
+    }
 }

--- a/pic-sure-api-data/src/main/java/edu/harvard/dbmi/avillach/data/repository/BaseRepository.java
+++ b/pic-sure-api-data/src/main/java/edu/harvard/dbmi/avillach/data/repository/BaseRepository.java
@@ -128,7 +128,7 @@ public abstract class BaseRepository<T extends BaseEntity, K> {
         for (Map.Entry<String, Object> entry : columnNameValueMap.entrySet()) {
             predicates.add(eq(cb, root, entry.getKey(), entry.getValue()));
         }
-        return getUniqueResultByColumns(query, root, (Predicate[]) predicates.toArray());
+        return getUniqueResultByColumns(query, root, predicates.toArray(new Predicate[0]));
     }
 
     /**

--- a/pic-sure-api-data/src/main/java/edu/harvard/dbmi/avillach/data/repository/ConfigurationRepository.java
+++ b/pic-sure-api-data/src/main/java/edu/harvard/dbmi/avillach/data/repository/ConfigurationRepository.java
@@ -1,0 +1,15 @@
+package edu.harvard.dbmi.avillach.data.repository;
+
+import edu.harvard.dbmi.avillach.data.entity.Configuration;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.transaction.Transactional;
+import java.util.UUID;
+
+@Transactional
+@ApplicationScoped
+public class ConfigurationRepository extends BaseRepository<Configuration, UUID> {
+    protected ConfigurationRepository() {
+        super(Configuration.class);
+    }
+}

--- a/pic-sure-api-data/src/main/java/edu/harvard/dbmi/avillach/data/request/ConfigurationRequest.java
+++ b/pic-sure-api-data/src/main/java/edu/harvard/dbmi/avillach/data/request/ConfigurationRequest.java
@@ -1,0 +1,78 @@
+package edu.harvard.dbmi.avillach.data.request;
+
+import javax.validation.constraints.Pattern;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+@Schema(
+    description = "Request to add or update a configuration.",
+    example = "{\n" + "    \"uuid\": \"076d4f2a-cfe8-486e-a7f9-b938086f3e1e\",\n" + "    \"name\": \"FEATURE_FLAG_X\",\n"
+        + "    \"kind\": \"ui\",\n" + "    \"value\": \"true\",\n" + "    \"markForDelete\": falseq,\n"
+        + "    \"description\": \"This configuration controls feature X\"\n" + "}"
+)
+public class ConfigurationRequest {
+    private UUID uuid;
+
+    // Matches strings containing only alphanumeric characters, underscores, hyphens,
+    // question marks, brackets, parentheses, colons, and periods from start to end
+    @Pattern(regexp = "^[\\w\\d\\-?\\[\\].():]+$")
+    private String name;
+    @Pattern(regexp = "^[\\w\\d\\-?\\[\\].():]+$")
+    private String kind;
+
+    private String value;
+
+    private String description;
+
+    private Boolean markForDelete;
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getKind() {
+        return this.kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Boolean getMarkForDelete() {
+        return this.markForDelete;
+    }
+
+    public void setMarkForDelete(Boolean markForDelete) {
+        this.markForDelete = markForDelete;
+    }
+}

--- a/pic-sure-api-data/src/main/java/edu/harvard/dbmi/avillach/data/request/ConfigurationRequest.java
+++ b/pic-sure-api-data/src/main/java/edu/harvard/dbmi/avillach/data/request/ConfigurationRequest.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 @Schema(
     description = "Request to add or update a configuration.",
     example = "{\n" + "    \"uuid\": \"076d4f2a-cfe8-486e-a7f9-b938086f3e1e\",\n" + "    \"name\": \"FEATURE_FLAG_X\",\n"
-        + "    \"kind\": \"ui\",\n" + "    \"value\": \"true\",\n" + "    \"markForDelete\": falseq,\n"
+        + "    \"kind\": \"ui\",\n" + "    \"value\": \"true\",\n" + "    \"markForDelete\": false,\n"
         + "    \"description\": \"This configuration controls feature X\"\n" + "}"
 )
 public class ConfigurationRequest {

--- a/pic-sure-api-data/src/main/resources/db/sql/V8__ADD_CONFIG_TABLE.sql
+++ b/pic-sure-api-data/src/main/resources/db/sql/V8__ADD_CONFIG_TABLE.sql
@@ -1,0 +1,12 @@
+USE `picsure`;
+
+CREATE TABLE `configuration` (
+    `uuid` binary(16) NOT NULL UNIQUE DEFAULT (UNHEX(REPLACE(UUID(),'-',''))),
+    `name` varchar(255) COLLATE utf8_bin NOT NULL,
+    `kind` varchar(255) COLLATE utf8_bin NOT NULL,
+    `value` TEXT NOT NULL,
+    `description` varchar(255) COLLATE utf8_bin DEFAULT '',
+    `markForDelete` bit(1) NOT NULL DEFAULT FALSE,
+    PRIMARY KEY (`uuid`),
+    CONSTRAINT `unique_name_kind` UNIQUE (`name`, `kind`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;

--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/ConfigurationRS.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/ConfigurationRS.java
@@ -1,0 +1,152 @@
+package edu.harvard.dbmi.avillach;
+
+import java.util.UUID;
+
+import javax.inject.Inject;
+
+import javax.validation.Valid;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+
+import edu.harvard.dbmi.avillach.data.entity.Configuration;
+import edu.harvard.dbmi.avillach.data.request.ConfigurationRequest;
+import edu.harvard.dbmi.avillach.service.ConfigurationService;
+import edu.harvard.dbmi.avillach.util.response.PICSUREResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Path("/configuration")
+@Produces("application/json")
+@Consumes("application/json")
+public class ConfigurationRS {
+    @Inject
+    ConfigurationService configurationService;
+
+    @GET
+    @Path("/")
+    @Operation(
+        summary = "Returns a list of all configurations.", tags = {"configuration"}, operationId = "getConfigurations",
+        responses = {
+            @ApiResponse(
+                responseCode = "200", description = "A list of all configurations.",
+                content = @Content(array = @ArraySchema(schema = @Schema(implementation = Configuration.class)))
+            ),
+            @ApiResponse(
+                responseCode = "500", description = "Error finding configurations.",
+                content = @Content(
+                    examples = {@ExampleObject(
+                        name = "error", value = "{\"errorType\":\"error\",\"message\":\"Could not retrieve configurations\"}"
+                    )}
+                )
+            )}
+    )
+    public Response getConfigurations(@Context SecurityContext context, @QueryParam("kind") String kind) {
+        return configurationService.getConfigurations(kind).map(PICSUREResponse::success)
+            .orElse(PICSUREResponse.error("Could not retrieve configurations"));
+    }
+
+    @GET
+    @Path("/{configuration}/")
+    @Operation(
+        summary = "Returns a configuration by ID.", tags = {"configuration"}, operationId = "getConfigurationById",
+        responses = {
+            @ApiResponse(
+                responseCode = "200", description = "The requested configuration.",
+                content = @Content(schema = @Schema(implementation = Configuration.class))
+            ),
+            @ApiResponse(
+                responseCode = "500", description = "Error finding the configuration.",
+                content = @Content(
+                    examples = {@ExampleObject(
+                        name = "error", value = "{\"errorType\":\"error\",\"message\":\"Could not retrieve configuration\"}"
+                    )}
+                )
+            )}
+    )
+    public Response getConfigurationById(@Context SecurityContext context, @PathParam("configuration") String identifier) {
+        return configurationService.getConfigurationByIdentifier(identifier).map(PICSUREResponse::success)
+            .orElse(PICSUREResponse.error("Could not retrieve configuration"));
+    }
+
+    @POST
+    @Path("/admin/")
+    @Operation(
+        summary = "Creates a new configuration.", tags = {"configuration"}, operationId = "addConfiguration",
+        responses = {
+            @ApiResponse(
+                responseCode = "200", description = "The configuration created.",
+                content = @Content(schema = @Schema(implementation = Configuration.class))
+            ),
+            @ApiResponse(
+                responseCode = "500", description = "Error adding configuration.",
+                content = @Content(
+                    examples = {
+                        @ExampleObject(name = "error", value = "{\"errorType\":\"error\",\"message\":\"Could not save configuration\"}")}
+                )
+            )}
+    )
+    public Response addConfiguration(@Context SecurityContext context, @Parameter @Valid ConfigurationRequest request) {
+        if (request.getName() == null || request.getKind() == null || request.getValue() == null) {
+            return PICSUREResponse.error("Name, Kind, and Value properties must not be null");
+        }
+
+        return configurationService.addConfiguration(request).map(PICSUREResponse::success)
+            .orElse(PICSUREResponse.error("Could not add configuration"));
+    }
+
+    @PATCH
+    @Path("/admin/{configurationId}/")
+    @Operation(
+        summary = "Updates an existing configuration.", tags = {"configuration"}, operationId = "updateConfiguration",
+        responses = {
+            @ApiResponse(
+                responseCode = "200", description = "The updated configuration.",
+                content = @Content(schema = @Schema(implementation = Configuration.class))
+            ),
+            @ApiResponse(
+                responseCode = "500", description = "Error updating the configuration.",
+                content = @Content(
+                    examples = {
+                        @ExampleObject(name = "error", value = "{\"errorType\":\"error\",\"message\":\"Could not update configuration\"}")}
+                )
+            )}
+    )
+    public Response updateConfiguration(
+        @Context SecurityContext context, @PathParam("configurationId") UUID configurationId, @Parameter @Valid ConfigurationRequest request
+    ) {
+        if (request.getUuid() != null && !configurationId.equals(request.getUuid())) {
+            return PICSUREResponse.error("UUID cannot be changed");
+        }
+
+        request.setUuid(configurationId);
+        return configurationService.updateConfiguration(request).map(PICSUREResponse::success)
+            .orElse(PICSUREResponse.error("Could not update configuration"));
+    }
+
+    @DELETE
+    @Path("/admin/{configurationId}/")
+    @Operation(
+        summary = "Deletes a configuration.", tags = {"configuration"}, operationId = "deleteConfiguration",
+        responses = {@ApiResponse(responseCode = "200", description = "Configuration successfully deleted."),
+            @ApiResponse(
+                responseCode = "500", description = "Error deleting the configuration.",
+                content = @Content(
+                    examples = {
+                        @ExampleObject(name = "error", value = "{\"errorType\":\"error\",\"message\":\"Could not delete configuration\"}")}
+                )
+            )}
+    )
+    public Response deleteConfiguration(@Context SecurityContext context, @PathParam("configurationId") UUID configurationId) {
+        return configurationService.deleteConfiguration(configurationId).map(PICSUREResponse::success)
+            .orElse(PICSUREResponse.error("Could not delete configuration"));
+    }
+}

--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/ConfigurationRS.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/ConfigurationRS.java
@@ -80,7 +80,7 @@ public class ConfigurationRS {
 
     @POST
     @Path("/admin/")
-    @RolesAllowed("SuperUser")
+    @RolesAllowed("SUPER_ADMIN")
     @Operation(
         summary = "Creates a new configuration.", tags = {"configuration"}, operationId = "addConfiguration",
         responses = {
@@ -97,6 +97,9 @@ public class ConfigurationRS {
             )}
     )
     public Response addConfiguration(@Context SecurityContext context, @Parameter @Valid ConfigurationRequest request) {
+        if (request == null) {
+            return PICSUREResponse.error("Request body is required");
+        }
         if (request.getName() == null || request.getKind() == null || request.getValue() == null) {
             return PICSUREResponse.error("Name, Kind, and Value properties must not be null");
         }
@@ -107,7 +110,7 @@ public class ConfigurationRS {
 
     @PATCH
     @Path("/admin/{configurationId}/")
-    @RolesAllowed("SuperUser")
+    @RolesAllowed("SUPER_ADMIN")
     @Operation(
         summary = "Updates an existing configuration.", tags = {"configuration"}, operationId = "updateConfiguration",
         responses = {
@@ -126,6 +129,9 @@ public class ConfigurationRS {
     public Response updateConfiguration(
         @Context SecurityContext context, @PathParam("configurationId") UUID configurationId, @Parameter @Valid ConfigurationRequest request
     ) {
+        if (request == null) {
+            return PICSUREResponse.error("Request body is required");
+        }
         if (request.getUuid() != null && !configurationId.equals(request.getUuid())) {
             return PICSUREResponse.error("UUID cannot be changed");
         }
@@ -137,7 +143,7 @@ public class ConfigurationRS {
 
     @DELETE
     @Path("/admin/{configurationId}/")
-    @RolesAllowed("SuperUser")
+    @RolesAllowed("SUPER_ADMIN")
     @Operation(
         summary = "Deletes a configuration.", tags = {"configuration"}, operationId = "deleteConfiguration",
         responses = {@ApiResponse(responseCode = "200", description = "Configuration successfully deleted."),

--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/ConfigurationRS.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/ConfigurationRS.java
@@ -10,6 +10,7 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
+import javax.annotation.security.RolesAllowed;
 
 import edu.harvard.dbmi.avillach.data.entity.Configuration;
 import edu.harvard.dbmi.avillach.data.request.ConfigurationRequest;
@@ -79,6 +80,7 @@ public class ConfigurationRS {
 
     @POST
     @Path("/admin/")
+    @RolesAllowed("SuperUser")
     @Operation(
         summary = "Creates a new configuration.", tags = {"configuration"}, operationId = "addConfiguration",
         responses = {
@@ -105,6 +107,7 @@ public class ConfigurationRS {
 
     @PATCH
     @Path("/admin/{configurationId}/")
+    @RolesAllowed("SuperUser")
     @Operation(
         summary = "Updates an existing configuration.", tags = {"configuration"}, operationId = "updateConfiguration",
         responses = {
@@ -134,6 +137,7 @@ public class ConfigurationRS {
 
     @DELETE
     @Path("/admin/{configurationId}/")
+    @RolesAllowed("SuperUser")
     @Operation(
         summary = "Deletes a configuration.", tags = {"configuration"}, operationId = "deleteConfiguration",
         responses = {@ApiResponse(responseCode = "200", description = "Configuration successfully deleted."),

--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/JWTFilter.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/JWTFilter.java
@@ -40,13 +40,38 @@ import javax.servlet.http.HttpServletRequest;
 
 import java.io.*;
 import java.util.*;
+import java.util.regex.Pattern;
 
 import static edu.harvard.dbmi.avillach.util.Utilities.buildHttpClientContext;
 
+class PathRule {
+    final Pattern pattern;
+    final Set<String> allowedMethods; // null means all methods
+
+    PathRule(String regex, String... methods) {
+        this.pattern = Pattern.compile(regex);
+        this.allowedMethods = methods.length == 0 ? null : Set.of(methods);
+    }
+
+    boolean matches(String path, String method) {
+        if (!pattern.matcher(path).find()) {
+            return false;
+        }
+        return allowedMethods == null || allowedMethods.contains(method);
+    }
+}
+
+
 @Provider
 public class JWTFilter implements ContainerRequestFilter {
-
     private final Logger logger = LoggerFactory.getLogger(JWTFilter.class);
+    private static final List<PathRule> EXCLUDED_PATHS = Arrays.asList(
+        new PathRule("\\/openapi\\.json$"),
+        // Matches /configuration or /configuration/<uuid or config-name> with optional trailing slash
+        // Explicitly excludes /configuration/admin (but allows /configuration/admin/something)
+        new PathRule("^\\/configuration(\\/(?!admin\\/?$)[\\w\\d\\-?\\[\\].():]*)?\\/?$", HttpMethod.GET),
+        new PathRule("^\\/proxy/pic-sure-logging")
+    );
 
     @Context
     UriInfo uriInfo;
@@ -101,19 +126,15 @@ public class JWTFilter implements ContainerRequestFilter {
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
         logger.debug("Entered jwtfilter.filter()...");
+        String path = requestContext.getUriInfo().getPath();
+        String method = requestContext.getRequest().getMethod();
 
-        if (uriInfo.getPath().endsWith("/openapi.json")) {
+        if (EXCLUDED_PATHS.stream().anyMatch(rule -> rule.matches(path, method))) {
+            logger.info("Accessing excluded path " + path + " method " + method);
             return;
         }
 
-        if (uriInfo.getPath().startsWith("proxy/pic-sure-logging/")) {
-            return;
-        }
-
-        if (
-            requestContext.getUriInfo().getPath().contentEquals("/system/status")
-                && requestContext.getRequest().getMethod().contentEquals(HttpMethod.GET)
-        ) {
+        if (path.contentEquals("/system/status") && method.contentEquals(HttpMethod.GET)) {
             // GET calls to /system/status do not require authentication or authorization
             requestContext.setProperty("username", "SYSTEM_MONITOR");
         } else {

--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/JWTFilter.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/JWTFilter.java
@@ -67,8 +67,8 @@ public class JWTFilter implements ContainerRequestFilter {
     private final Logger logger = LoggerFactory.getLogger(JWTFilter.class);
     private static final List<PathRule> EXCLUDED_PATHS = Arrays.asList(
         new PathRule("\\/openapi\\.json$"),
-        // Matches /configuration or /configuration/<uuid or config-name> with optional trailing slash
-        // Explicitly excludes /configuration/admin (but allows /configuration/admin/something)
+        // Matches GET /configuration or /configuration/<uuid or config-name> with optional trailing slash
+        // Excludes /configuration/admin(/*) routes
         new PathRule("^\\/configuration(\\/(?!admin\\/?$)[\\w\\d\\-?\\[\\].():]*)?\\/?$", HttpMethod.GET),
         new PathRule("^\\/proxy/pic-sure-logging")
     );

--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/service/ConfigurationService.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/service/ConfigurationService.java
@@ -1,0 +1,118 @@
+package edu.harvard.dbmi.avillach.service;
+
+import edu.harvard.dbmi.avillach.data.entity.Configuration;
+import edu.harvard.dbmi.avillach.data.repository.ConfigurationRepository;
+import edu.harvard.dbmi.avillach.data.request.ConfigurationRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+public class ConfigurationService {
+    private final Logger logger = LoggerFactory.getLogger(ConfigurationRepository.class);
+
+    @Inject
+    ConfigurationRepository configurationRepository;
+
+    // If the request has no uuid it's new so match any uuid with this name &/or kind
+    // else, match any uuid with this name &/or kind that isn't the one we're updating
+    private boolean nameKindPairExists(Configuration config) {
+        Map<String, Object> columns = new HashMap<>();
+        columns.put("name", config.getName());
+        columns.put("kind", config.getKind());
+        return configurationRepository.getByColumns(configurationRepository.query(), columns).stream().map(Configuration::getUuid)
+            .anyMatch(uuid -> config.getUuid() == null || !uuid.equals(config.getUuid()));
+    }
+
+    public Optional<List<Configuration>> getConfigurations(String kind) {
+        try {
+            List<Configuration> configs = kind != null ? configurationRepository.getByColumn("kind", kind) : configurationRepository.list();
+            return Optional.ofNullable(configs);
+        } catch (Exception exception) {
+            logger.error("Error retrieving configurations " + (kind != null ? "with kind " + kind : ""), exception);
+            return Optional.empty();
+        }
+    }
+
+    public Optional<Configuration> getConfigurationByIdentifier(String identifier) {
+        try {
+            // Try to parse as UUID first
+            UUID uuid = UUID.fromString(identifier);
+            Configuration config = configurationRepository.getById(uuid);
+            return Optional.ofNullable(config);
+        } catch (IllegalArgumentException e) {
+            // Not a valid UUID, treat as name
+            List<Configuration> configs = configurationRepository.getByColumn("name", identifier);
+            return configs != null && !configs.isEmpty() ? Optional.of(configs.get(0)) : Optional.empty();
+        } catch (Exception exception) {
+            logger.error("Error retrieving configurations with uuid " + identifier, exception);
+            return Optional.empty();
+        }
+    }
+
+    @Transactional
+    public Optional<Configuration> addConfiguration(ConfigurationRequest request) {
+        try {
+            Configuration config = Configuration.fromRequest(request);
+
+            if (nameKindPairExists(config)) {
+                logger.error("Error persisting configuration: name already exists " + request.getName());
+                return Optional.empty();
+            }
+
+            configurationRepository.persist(config);
+            logger.debug("Added configuration: " + config.getUuid());
+            return Optional.of(config);
+        } catch (Exception exception) {
+            logger.error("Error persisting configuration " + request.getName(), exception);
+            return Optional.empty();
+        }
+    }
+
+    @Transactional
+    public Optional<Configuration> updateConfiguration(ConfigurationRequest request) {
+        try {
+            Configuration config = configurationRepository.getById(request.getUuid());
+            if (config == null) {
+                logger.error("Configuration not found with id " + request.getUuid().toString());
+                return Optional.empty();
+            }
+            config.patch(request);
+
+            if (nameKindPairExists(config)) {
+                logger.error("Error updating configuration: new name already exists " + request.getName());
+                return Optional.empty();
+            }
+
+            configurationRepository.merge(config);
+            logger.debug("Updated configuration " + config.getUuid().toString() + "(" + config.getName() + ")");
+            return Optional.of(config);
+        } catch (Exception exception) {
+            logger.error("Error updating configuration " + request.getName() + " with value " + request.getValue(), exception);
+            return Optional.empty();
+        }
+    }
+
+    @Transactional
+    public Optional<Configuration> deleteConfiguration(UUID configurationId) {
+        try {
+            Configuration config = configurationRepository.getById(configurationId);
+            if (config == null) {
+                logger.error("Configuration not found with id " + configurationId.toString());
+                return Optional.empty();
+            }
+            configurationRepository.remove(config);
+            logger.debug("Deleted configuration " + config.getUuid().toString() + "(" + config.getName() + ")");
+            return Optional.of(config);
+        } catch (Exception exception) {
+            logger.error("Error deleting configuration " + configurationId.toString(), exception);
+            return Optional.empty();
+        }
+    }
+}

--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/service/ConfigurationService.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/service/ConfigurationService.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 public class ConfigurationService {
-    private final Logger logger = LoggerFactory.getLogger(ConfigurationRepository.class);
+    private final Logger logger = LoggerFactory.getLogger(ConfigurationService.class);
 
     @Inject
     ConfigurationRepository configurationRepository;
@@ -94,7 +94,8 @@ public class ConfigurationService {
             logger.debug("Updated configuration " + config.getUuid().toString() + "(" + config.getName() + ")");
             return Optional.of(config);
         } catch (Exception exception) {
-            logger.error("Error updating configuration " + request.getName() + " with value " + request.getValue(), exception);
+            String requestName = request != null ? request.getName() : "<null>";
+            logger.error("Error updating configuration {}", requestName, exception);
             return Optional.empty();
         }
     }

--- a/pic-sure-api-war/src/main/resources/META-INF/persistence.xml
+++ b/pic-sure-api-war/src/main/resources/META-INF/persistence.xml
@@ -6,6 +6,7 @@
 		<jta-data-source>java:jboss/datasources/PicsureDS</jta-data-source>
 		<class>edu.harvard.dbmi.avillach.data.entity.Query</class>
 		<class>edu.harvard.dbmi.avillach.data.entity.Resource</class>
+		<class>edu.harvard.dbmi.avillach.data.entity.Configuration</class>
 		<class>edu.harvard.dbmi.avillach.data.entity.NamedDataset</class>
 		<class>edu.harvard.dbmi.avillach.data.entity.Site</class>
 

--- a/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/ConfigurationRSTest.java
+++ b/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/ConfigurationRSTest.java
@@ -3,6 +3,7 @@ package edu.harvard.dbmi.avillach;
 import edu.harvard.dbmi.avillach.data.request.ConfigurationRequest;
 import org.junit.Test;
 
+import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.core.SecurityContext;
 import java.lang.reflect.Method;
@@ -13,6 +14,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class ConfigurationRSTest {
+    private final String SUPER_ADMIN = "SUPER_ADMIN";
 
     private void assertRolesAllowed(Method method, String role) {
         RolesAllowed annotation = method.getAnnotation(RolesAllowed.class);
@@ -20,25 +22,31 @@ public class ConfigurationRSTest {
         assertTrue(role + " role missing on " + method.getName(), Arrays.asList(annotation.value()).contains(role));
     }
 
+    // These unit tests only guard against accidental removal during refactor & they are not an E2E test of the functionality
     @Test
-    public void adminEndpoints_requireSuperUserRole() throws NoSuchMethodException {
+    public void adminEndpoints_requireSuperAdminRole() throws NoSuchMethodException {
         assertRolesAllowed(
-            ConfigurationRS.class.getMethod("addConfiguration", SecurityContext.class, ConfigurationRequest.class),
-            "SuperUser"
+            ConfigurationRS.class.getMethod("addConfiguration", SecurityContext.class, ConfigurationRequest.class), SUPER_ADMIN
         );
         assertRolesAllowed(
             ConfigurationRS.class.getMethod("updateConfiguration", SecurityContext.class, UUID.class, ConfigurationRequest.class),
-            "SuperUser"
+            SUPER_ADMIN
         );
-        assertRolesAllowed(
-            ConfigurationRS.class.getMethod("deleteConfiguration", SecurityContext.class, UUID.class),
-            "SuperUser"
+        assertRolesAllowed(ConfigurationRS.class.getMethod("deleteConfiguration", SecurityContext.class, UUID.class), SUPER_ADMIN);
+    }
+
+    private void assertNotRestrictedToSuperAdmin(Method method) {
+        PermitAll permitAll = method.getAnnotation(PermitAll.class);
+        RolesAllowed rolesAllowed = method.getAnnotation(RolesAllowed.class);
+        assertTrue(
+            method.getName() + " must not restrict access to " + SUPER_ADMIN,
+            permitAll != null || rolesAllowed == null || !Arrays.asList(rolesAllowed.value()).contains(SUPER_ADMIN)
         );
     }
 
     @Test
-    public void readEndpoints_doNotRequireSuperUserRole() throws NoSuchMethodException {
-        assertNotNull(ConfigurationRS.class.getMethod("getConfigurations", SecurityContext.class, String.class));
-        assertNotNull(ConfigurationRS.class.getMethod("getConfigurationById", SecurityContext.class, String.class));
+    public void readEndpoints_doNotRequireSuperAdminRole() throws NoSuchMethodException {
+        assertNotRestrictedToSuperAdmin(ConfigurationRS.class.getMethod("getConfigurations", SecurityContext.class, String.class));
+        assertNotRestrictedToSuperAdmin(ConfigurationRS.class.getMethod("getConfigurationById", SecurityContext.class, String.class));
     }
 }

--- a/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/ConfigurationRSTest.java
+++ b/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/ConfigurationRSTest.java
@@ -1,0 +1,44 @@
+package edu.harvard.dbmi.avillach;
+
+import edu.harvard.dbmi.avillach.data.request.ConfigurationRequest;
+import org.junit.Test;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.core.SecurityContext;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.UUID;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class ConfigurationRSTest {
+
+    private void assertRolesAllowed(Method method, String role) {
+        RolesAllowed annotation = method.getAnnotation(RolesAllowed.class);
+        assertNotNull("@RolesAllowed missing on " + method.getName(), annotation);
+        assertTrue(role + " role missing on " + method.getName(), Arrays.asList(annotation.value()).contains(role));
+    }
+
+    @Test
+    public void adminEndpoints_requireSuperUserRole() throws NoSuchMethodException {
+        assertRolesAllowed(
+            ConfigurationRS.class.getMethod("addConfiguration", SecurityContext.class, ConfigurationRequest.class),
+            "SuperUser"
+        );
+        assertRolesAllowed(
+            ConfigurationRS.class.getMethod("updateConfiguration", SecurityContext.class, UUID.class, ConfigurationRequest.class),
+            "SuperUser"
+        );
+        assertRolesAllowed(
+            ConfigurationRS.class.getMethod("deleteConfiguration", SecurityContext.class, UUID.class),
+            "SuperUser"
+        );
+    }
+
+    @Test
+    public void readEndpoints_doNotRequireSuperUserRole() throws NoSuchMethodException {
+        assertNotNull(ConfigurationRS.class.getMethod("getConfigurations", SecurityContext.class, String.class));
+        assertNotNull(ConfigurationRS.class.getMethod("getConfigurationById", SecurityContext.class, String.class));
+    }
+}

--- a/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/security/JWTFilterTest.java
+++ b/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/security/JWTFilterTest.java
@@ -1,16 +1,19 @@
 package edu.harvard.dbmi.avillach.security;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import javax.ws.rs.HttpMethod;
+import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Request;
@@ -34,7 +37,6 @@ import edu.harvard.dbmi.avillach.service.ResourceWebClient;
 import edu.harvard.dbmi.avillach.util.response.PICSUREResponseError;
 
 public class JWTFilterTest {
-
     private static final UUID QUERY_UUID = UUID.fromString("e830138f-2943-4661-90ae-da053bd94a18");
 
     private static final UUID RESOURCE_UUID = UUID.fromString("30ef4941-9656-4b47-af80-528f2b98cf17");
@@ -122,10 +124,63 @@ public class JWTFilterTest {
     @Test
     public void testLoggingProxyPathSkipsAuthentication() throws IOException {
         ContainerRequestContext ctx = createRequestContext();
-        when(filter.uriInfo.getPath()).thenReturn("proxy/pic-sure-logging/audit");
+        when(ctx.getUriInfo().getPath()).thenReturn("/proxy/pic-sure-logging/audit");
         filter.filter(ctx);
         verify(ctx, never()).getHeaderString(HttpHeaders.AUTHORIZATION);
         verify(ctx, never()).abortWith(any(Response.class));
+    }
+
+    @Test
+    public void testExcludedFilterPaths_openapi() throws IOException {
+        ContainerRequestContext ctx = createRequestContext();
+        when(ctx.getUriInfo().getPath()).thenReturn("/openapi.json");
+        when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.GET);
+        filter.filter(ctx);
+        verify(ctx, never()).setProperty(eq("username"), anyString());
+    }
+
+    @Test
+    public void testExcludedFilterPaths_config_validPathsWithNoAuthRequired() throws RuntimeException {
+        List<String> letters = List.of(
+            "", "/ui:(feature.flag3)?-wear[e12]", "/address", "/postadmin", "/data", "/meta", "/init", "/names", "/administrators",
+            "/00000000-0000-0000-0000-000000000000"
+        );
+
+        List<String> exceptions = new ArrayList<>();
+        for (String letter : letters) {
+            ContainerRequestContext ctx = createRequestContext();
+            when(ctx.getUriInfo().getPath()).thenReturn("/configuration" + letter);
+            when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.GET);
+
+            try {
+                filter.filter(ctx);
+                verify(ctx, never()).setProperty(eq("username"), anyString());
+                verify(ctx, never()).abortWith(any(Response.class));
+            } catch (Exception e) {
+                exceptions.add(letter);
+            }
+        }
+        assertEquals(0, exceptions.size());
+    }
+
+    @Test(expected = NotAuthorizedException.class)
+    public void testExcludedFilterPaths_config_invalidPathsHitNoAuthException() throws IOException {
+        ContainerRequestContext ctx = createRequestContext();
+        when(ctx.getUriInfo().getPath()).thenReturn("/configuration/SOME_FLA%G");
+        when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.GET);
+
+        filter.filter(ctx);
+        // Test passes if NotAuthorizedException is thrown
+    }
+
+    @Test(expected = NotAuthorizedException.class)
+    public void testExcludedFilterPaths_config_blockedAdminPathHitsNoAuthException() throws IOException {
+        ContainerRequestContext ctx = createRequestContext();
+        when(ctx.getUriInfo().getPath()).thenReturn("/configuration/admin");
+        when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.GET);
+
+        filter.filter(ctx);
+        // Test passes if NotAuthorizedException is thrown
     }
 
     @Test

--- a/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/service/ConfigurationServiceTest.java
+++ b/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/service/ConfigurationServiceTest.java
@@ -1,0 +1,415 @@
+package edu.harvard.dbmi.avillach.service;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doThrow;
+
+import java.util.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import edu.harvard.dbmi.avillach.data.entity.Configuration;
+import edu.harvard.dbmi.avillach.data.repository.ConfigurationRepository;
+import edu.harvard.dbmi.avillach.data.request.ConfigurationRequest;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConfigurationServiceTest {
+    private final String testName = "FEATURE_FLAG_X";
+    private final String testKind = "ui";
+    private final String testValue = "true";
+    private final String testDescription = "This configuration controls feature X";
+
+    @InjectMocks
+    private ConfigurationService configurationService = new ConfigurationService();
+
+    @Mock
+    private ConfigurationRepository configurationRepository = mock(ConfigurationRepository.class);
+
+    private Configuration makeConfiguration(UUID id) {
+        Configuration config = new Configuration();
+        config.setUuid(id);
+        config.setName(testName);
+        config.setKind(testKind);
+        config.setValue(testValue);
+        config.setDescription(testDescription);
+        return config;
+    }
+
+    private ConfigurationRequest makeConfigurationRequest() {
+        ConfigurationRequest request = new ConfigurationRequest();
+        request.setName(testName);
+        request.setKind(testKind);
+        request.setValue(testValue);
+        request.setDescription(testDescription);
+        return request;
+    }
+
+    @Test
+    public void getConfigurations_withKind_success() {
+        // Given there are saved configurations in the database with a specific kind
+        Configuration config1 = makeConfiguration(UUID.randomUUID());
+        Configuration config2 = makeConfiguration(UUID.randomUUID());
+        ArrayList<Configuration> configs = new ArrayList<Configuration>();
+        configs.add(config1);
+        configs.add(config2);
+        when(configurationRepository.getByColumn("kind", testKind)).thenReturn(configs);
+
+        // When the request is received
+        Optional<List<Configuration>> response = configurationService.getConfigurations(testKind);
+
+        // Then return a non-empty optional with the configurations
+        assertTrue(response.isPresent());
+        assertEquals("correct number of configurations returned", 2, response.get().size());
+    }
+
+    @Test
+    public void getConfigurations_withoutKind_success() {
+        // Given there are saved configurations in the database
+        Configuration config1 = makeConfiguration(UUID.randomUUID());
+        Configuration config2 = makeConfiguration(UUID.randomUUID());
+        ArrayList<Configuration> configs = new ArrayList<Configuration>();
+        configs.add(config1);
+        configs.add(config2);
+        when(configurationRepository.list()).thenReturn(configs);
+
+        // When the request is received without specifying a kind
+        Optional<List<Configuration>> response = configurationService.getConfigurations(null);
+
+        // Then return a non-empty optional with all configurations
+        assertTrue(response.isPresent());
+        assertEquals("correct number of configurations returned", 2, response.get().size());
+    }
+
+    @Test
+    public void getConfigurations_noValues() {
+        // Given there are no saved configurations in the database
+        ArrayList<Configuration> configs = new ArrayList<Configuration>();
+        when(configurationRepository.list()).thenReturn(configs);
+
+        // When the request is received
+        Optional<List<Configuration>> response = configurationService.getConfigurations(null);
+
+        // Then return a non-empty optional with an empty list
+        assertTrue(response.isPresent());
+        assertEquals(0, response.get().size());
+    }
+
+    @Test
+    public void getConfigurationByIdentifier_withUUID_success() {
+        // Given there is a saved configuration in the database with this UUID
+        UUID configId = UUID.randomUUID();
+        Configuration config = makeConfiguration(configId);
+        when(configurationRepository.getById(configId)).thenReturn(config);
+
+        // When the request is received with a UUID
+        Optional<Configuration> response = configurationService.getConfigurationByIdentifier(configId.toString());
+
+        // Then return a non-empty optional
+        assertTrue(response.isPresent());
+        assertEquals("correct configuration returned", configId, response.get().getUuid());
+    }
+
+    @Test
+    public void getConfigurationByIdentifier_withName_success() {
+        // Given there is a saved configuration in the database with this name
+        Configuration config = makeConfiguration(UUID.randomUUID());
+        ArrayList<Configuration> configs = new ArrayList<Configuration>();
+        configs.add(config);
+        when(configurationRepository.getByColumn("name", testName)).thenReturn(configs);
+
+        // When the request is received with a name
+        Optional<Configuration> response = configurationService.getConfigurationByIdentifier(testName);
+
+        // Then return a non-empty optional
+        assertTrue(response.isPresent());
+        assertEquals("correct configuration returned", testName, response.get().getName());
+    }
+
+    @Test
+    public void getConfigurationByIdentifier_withUUID_notFound() {
+        // Given there is no configuration with this UUID
+        UUID configId = UUID.randomUUID();
+        when(configurationRepository.getById(configId)).thenReturn(null);
+
+        // When the request is received
+        Optional<Configuration> response = configurationService.getConfigurationByIdentifier(configId.toString());
+
+        // Then return an empty optional
+        assertTrue(response.isEmpty());
+    }
+
+    @Test
+    public void getConfigurationByIdentifier_withName_notFound() {
+        // Given there is no configuration with this name
+        ArrayList<Configuration> configs = new ArrayList<Configuration>();
+        when(configurationRepository.getByColumn("name", testName)).thenReturn(configs);
+
+        // When the request is received with a name
+        Optional<Configuration> response = configurationService.getConfigurationByIdentifier(testName);
+
+        // Then return an empty optional
+        assertTrue(response.isEmpty());
+    }
+
+    @Test
+    public void getConfigurationByIdentifier_withName_nullResult() {
+        // Given the repository returns null for this name
+        when(configurationRepository.getByColumn("name", testName)).thenReturn(null);
+
+        // When the request is received with a name
+        Optional<Configuration> response = configurationService.getConfigurationByIdentifier(testName);
+
+        // Then return an empty optional
+        assertTrue(response.isEmpty());
+    }
+
+    @Test
+    public void addConfiguration_success() {
+        // Given a valid configuration request
+        ConfigurationRequest request = makeConfigurationRequest();
+
+        // When the request is received
+        Optional<Configuration> response = configurationService.addConfiguration(request);
+
+        // Then return a non-empty optional
+        assertTrue(response.isPresent());
+        assertEquals("name is saved", testName, response.get().getName());
+        assertEquals("kind is saved", testKind, response.get().getKind());
+        assertEquals("value is saved", testValue, response.get().getValue());
+        assertEquals("description is saved", testDescription, response.get().getDescription());
+    }
+
+    @Test
+    public void addConfiguration_nameKindCollision() {
+        // Given a valid configuration request
+        ConfigurationRequest request = makeConfigurationRequest();
+
+        // And there is a second configuration in the database with desired name
+        List<Configuration> duplicateNames = new ArrayList<>(List.of(makeConfiguration(UUID.randomUUID())));
+        when(configurationRepository.getByColumns(any(), any())).thenReturn(duplicateNames);
+
+        // When the request is received
+        Optional<Configuration> response = configurationService.addConfiguration(request);
+
+        // Then return an empty optional
+        assertTrue(response.isEmpty());
+    }
+
+    @Test
+    public void addConfiguration_cannotPersist() {
+        // Given there is an error saving to the configuration table
+        doThrow(new RuntimeException("Persistence error")).when(configurationRepository).persist(any(Configuration.class));
+
+        // When the request is received
+        ConfigurationRequest request = makeConfigurationRequest();
+        Optional<Configuration> response = configurationService.addConfiguration(request);
+
+        // Then return an empty optional
+        assertTrue(response.isEmpty());
+    }
+
+    @Test
+    public void updateConfiguration_changeValue_success() {
+        // Given there is a saved configuration in the database with this id
+        UUID configId = UUID.randomUUID();
+        Configuration config = makeConfiguration(configId);
+        when(configurationRepository.getById(configId)).thenReturn(config);
+
+        // When the request is received with updated values
+        String newValue = "false";
+        ConfigurationRequest request = makeConfigurationRequest();
+        request.setUuid(configId);
+        request.setValue(newValue);
+        Optional<Configuration> response = configurationService.updateConfiguration(request);
+
+        // Then return a non-empty optional
+        assertTrue(response.isPresent());
+        assertEquals("new value is saved", newValue, response.get().getValue());
+    }
+
+    @Test
+    public void updateConfiguration_changeName_success() {
+        // Given there is a saved configuration in the database with this id
+        UUID configId = UUID.randomUUID();
+        Configuration config = makeConfiguration(configId);
+        when(configurationRepository.getById(configId)).thenReturn(config);
+
+        // When the request is received with a new name
+        String newName = "FEATURE_FLAG_Y";
+        ConfigurationRequest request = makeConfigurationRequest();
+        request.setUuid(configId);
+        request.setName(newName);
+        Optional<Configuration> response = configurationService.updateConfiguration(request);
+
+        // Then return a non-empty optional
+        assertTrue(response.isPresent());
+        assertEquals("new name is saved", newName, response.get().getName());
+    }
+
+
+    @Test
+    public void updateConfiguration_changeDeleteRequestedDate() {
+        // Given there is a saved configuration in the database with this id
+        UUID configId = UUID.randomUUID();
+        Configuration config = makeConfiguration(configId);
+        when(configurationRepository.getById(configId)).thenReturn(config);
+
+        // When the request is received with updated delete request date
+        ConfigurationRequest request = makeConfigurationRequest();
+        request.setUuid(configId);
+        request.setMarkForDelete(true);
+        Optional<Configuration> response = configurationService.updateConfiguration(request);
+
+        // Then return a non-empty optional
+        assertTrue(response.isPresent());
+        assertEquals("new delete requested date is saved", true, response.get().getMarkForDelete());
+    }
+
+    @Test
+    public void updateConfiguration_changeName_nameKindCollision() {
+        // Given there is a saved configuration in the database with this id
+        String newName = "FEATURE_FLAG_Y";
+        String newKind = "some kind";
+        UUID configId = UUID.randomUUID();
+        Configuration config = makeConfiguration(UUID.randomUUID());
+        when(configurationRepository.getById(configId)).thenReturn(config);
+
+        // And there is a second configuration in the database with desired name and kind
+        Configuration config2 = makeConfiguration(UUID.randomUUID());
+        config2.setName(newName);
+        config2.setKind("some kind");
+        List<Configuration> duplicateNames = new ArrayList<>(List.of(config, config2));
+        when(configurationRepository.getByColumns(any(), any())).thenReturn(duplicateNames);
+
+        // When the request is received with a new name
+        ConfigurationRequest request = makeConfigurationRequest();
+        request.setUuid(configId);
+        request.setName(newName);
+        request.setKind("some other kind");
+        Optional<Configuration> response = configurationService.updateConfiguration(request);
+
+        // Then return an empty optional
+        assertTrue(response.isEmpty());
+    }
+
+    @Test
+    public void updateConfiguration_changeKind_success() {
+        // Given there is a saved configuration in the database with this id
+        UUID configId = UUID.randomUUID();
+        Configuration config = makeConfiguration(configId);
+        when(configurationRepository.getById(configId)).thenReturn(config);
+
+        // When the request is received with a new kind
+        String newKind = "backend";
+        ConfigurationRequest request = makeConfigurationRequest();
+        request.setUuid(configId);
+        request.setKind(newKind);
+        Optional<Configuration> response = configurationService.updateConfiguration(request);
+
+        // Then return a non-empty optional
+        assertTrue(response.isPresent());
+        assertEquals("new kind is saved", newKind, response.get().getKind());
+    }
+
+    @Test
+    public void updateConfiguration_changeDescription_success() {
+        // Given there is a saved configuration in the database with this id
+        UUID configId = UUID.randomUUID();
+        Configuration config = makeConfiguration(configId);
+        when(configurationRepository.getById(configId)).thenReturn(config);
+
+        // When the request is received with a new description
+        String newDescription = "Updated description";
+        ConfigurationRequest request = makeConfigurationRequest();
+        request.setUuid(configId);
+        request.setDescription(newDescription);
+        Optional<Configuration> response = configurationService.updateConfiguration(request);
+
+        // Then return a non-empty optional
+        assertTrue(response.isPresent());
+        assertEquals("new description is saved", newDescription, response.get().getDescription());
+    }
+
+    @Test
+    public void updateConfiguration_noConfigurationWithId() {
+        // Given there is no configuration in the database with this id
+        UUID configId = UUID.randomUUID();
+        when(configurationRepository.getById(configId)).thenReturn(null);
+
+        // When the request is received
+        ConfigurationRequest request = makeConfigurationRequest();
+        request.setUuid(configId);
+        Optional<Configuration> response = configurationService.updateConfiguration(request);
+
+        // Then return an empty optional
+        assertTrue(response.isEmpty());
+    }
+
+    @Test
+    public void updateConfiguration_cannotPersistChanges() {
+        // Given there is an error saving to the configuration table
+        UUID configId = UUID.randomUUID();
+        Configuration config = makeConfiguration(configId);
+        when(configurationRepository.getById(configId)).thenReturn(config);
+        doThrow(new RuntimeException()).when(configurationRepository).merge(any(Configuration.class));
+
+        // When the request is received
+        ConfigurationRequest request = makeConfigurationRequest();
+        request.setUuid(configId);
+        Optional<Configuration> response = configurationService.updateConfiguration(request);
+
+        // Then return an empty optional
+        assertTrue(response.isEmpty());
+    }
+
+    @Test
+    public void deleteConfiguration_success() {
+        // Given there is a saved configuration in the database with this id
+        UUID configId = UUID.randomUUID();
+        Configuration config = makeConfiguration(configId);
+        when(configurationRepository.getById(configId)).thenReturn(config);
+
+        // When the request is received
+        Optional<Configuration> response = configurationService.deleteConfiguration(configId);
+
+        // Then return a non-empty optional with the deleted configuration
+        assertTrue(response.isPresent());
+        assertEquals("correct configuration returned", configId, response.get().getUuid());
+    }
+
+    @Test
+    public void deleteConfiguration_noConfigurationWithId() {
+        // Given there is no configuration in the database with this id
+        UUID configId = UUID.randomUUID();
+        when(configurationRepository.getById(configId)).thenReturn(null);
+
+        // When the request is received
+        Optional<Configuration> response = configurationService.deleteConfiguration(configId);
+
+        // Then return an empty optional
+        assertTrue(response.isEmpty());
+    }
+
+    @Test
+    public void deleteConfiguration_cannotDelete() {
+        // Given there is an error deleting from the configuration table
+        UUID configId = UUID.randomUUID();
+        Configuration config = makeConfiguration(configId);
+        when(configurationRepository.getById(configId)).thenReturn(config);
+        doThrow(new RuntimeException()).when(configurationRepository).remove(any(Configuration.class));
+
+        // When the request is received
+        Optional<Configuration> response = configurationService.deleteConfiguration(configId);
+
+        // Then return an empty optional
+        assertTrue(response.isEmpty());
+    }
+}


### PR DESCRIPTION
- Protect `/configuration/admin` write access behind SuperAdmin role check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin API to create, read, update, and delete application configurations; supports lookup by identifier or name and filtering by type
  * Database migration adding a persistent configurations table

* **Security**
  * Read endpoints remain public; mutating configuration endpoints require an elevated admin role
  * Authentication filter now uses centralized, data-driven excluded-path rules

* **Tests**
  * Added unit tests covering config endpoints, service logic, and auth exclusion behavior

* **Documentation**
  * README spelling fix and improved fenced code examples for build/run and debugging instructions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hms-dbmi/pic-sure/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->