### PR TITLE
[ALS-10714] Return ObfuscatedCount objects for cross-count types

### DIFF
--- a/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/AggregateDataSharingResourceRS.java
+++ b/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/AggregateDataSharingResourceRS.java
@@ -567,16 +567,20 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
     }
 
     /**
-     * This method will return an obfuscated binned count of continuous crosses. Due to the format of a continuous cross count, we are
-     * unable to directly obfuscate it in its original form. First, we send the continuous cross count data to the visualization resource to
-     * group it into bins. Once the data is binned, we assess whether obfuscation is necessary for this particular continuous cross count.
-     * If obfuscation is not required, we return the data in string format. However, if obfuscation is needed, we first obfuscate the data
-     * and then return it.
+     * Returns the obfuscated continuous cross-count JSON. Continuous values can't be obfuscated directly in their
+     * raw form (one entry per distinct numeric value gives too many cells with small counts), so we first bin them
+     * via the visualization resource — when a visualization service is configured — and obfuscate the binned counts.
+     * Without a configured visualization service we obfuscate the raw per-value counts as a fallback.
+     *
+     * Either way, every value in the returned map is obfuscated through {@link #obfuscateCrossCount}: counts below
+     * the threshold collapse to {@code "< threshold"}, larger counts get variance-randomized. Returns null only when
+     * the upstream produced no data or when {@link #canShowContinuousCrossCounts} signals the cohort is too small
+     * to safely render.
      *
      * @param continuousCrossCountResponse The continuous cross count response
      * @param crossCountResponse The cross count response
      * @param queryRequest The original query request
-     * @return String The obfuscated binned continuous cross count
+     * @return String The obfuscated continuous cross count JSON, or null if not safe / nothing to return
      * @throws IOException If there is an error processing the JSON
      */
     protected String processContinuousCrossCounts(String continuousCrossCountResponse, String crossCountResponse, QueryRequest queryRequest)
@@ -708,10 +712,16 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
         return result;
     }
 
-    private static int toInt(Object value) {
-        if (value instanceof Integer) return (Integer) value;
+    /**
+     * Jackson hands us {@code Object}-typed values from JSON; the runtime type depends on the number's magnitude
+     * (Integer, Long, Double, BigInteger, ...) and on whether the upstream stringified it. Accept anything that
+     * represents an integral count and narrow to int. The previous shape ({@code innerValue.toString()} into
+     * {@link Integer#parseInt}) silently accepted Long/Double for free; preserve that breadth via {@link Number}.
+     */
+    static int toInt(Object value) {
+        if (value instanceof Number) return ((Number) value).intValue();
         if (value instanceof String) return Integer.parseInt((String) value);
-        throw new IllegalArgumentException("Cross-count value was neither Integer nor numeric String: " + value);
+        throw new IllegalArgumentException("Cross-count value was neither Number nor numeric String: " + value);
     }
 
 

--- a/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/AggregateDataSharingResourceRS.java
+++ b/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/AggregateDataSharingResourceRS.java
@@ -37,9 +37,7 @@ import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static edu.harvard.dbmi.avillach.service.ResourceWebClient.QUERY_METADATA_FIELD;
 import static edu.harvard.dbmi.avillach.util.HttpClientUtil.*;
@@ -363,10 +361,16 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
         String crossCountResponse;
         switch (expectedResultType) {
             case "COUNT":
-                int requestVariance = generateRequestVariance(entityString);
-                responseString = applyThresholdFloor(entityString)
-                    .map(ObfuscatedCount::display)
-                    .orElseGet(() -> randomize(Integer.parseInt(entityString), requestVariance).display());
+                try {
+                    int count = Integer.parseInt(entityString);
+                    int requestVariance = generateRequestVariance(entityString);
+                    responseString = applyThresholdFloor(count)
+                        .map(ObfuscatedCount::display)
+                        .orElseGet(() -> randomize(count, requestVariance).display());
+                } catch (NumberFormatException nfe) {
+                    logger.warn("COUNT response was not a number! " + entityString);
+                    responseString = entityString;
+                }
 
                 break;
             case "CROSS_COUNT":
@@ -529,8 +533,6 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
                 floored.ifPresent((x) -> obfuscatedKeys.add(key));
                 crossCounts.put(key, floored.map(ObfuscatedCount::display).orElse(crossCount));
             });
-
-            Set<String> obfuscatedParents = obfuscatedKeys.stream().flatMap(this::generateParents).collect(Collectors.toSet());
 
             crossCounts.keySet().forEach(key -> {
                 String crossCount = crossCounts.get(key);
@@ -768,17 +770,6 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
     ObfuscatedCount randomize(int crossCount, int requestVariance) {
         int randomized = Math.max(crossCount + requestVariance, threshold);
         return new ObfuscatedCount(randomized, randomized + " \u00B1" + variance, variance);
-    }
-
-    private Stream<String> generateParents(String key) {
-        StringJoiner stringJoiner = new StringJoiner("\\", "\\", "\\");
-
-        String[] split = key.split("\\\\");
-        if (split.length > 1) {
-            return Arrays.stream(Arrays.copyOfRange(split, 0, split.length - 1)).filter(Predicate.not(String::isEmpty))
-                .map(segment -> stringJoiner.add(segment).toString());
-        }
-        return Stream.empty();
     }
 
     /**

--- a/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/AggregateDataSharingResourceRS.java
+++ b/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/AggregateDataSharingResourceRS.java
@@ -767,7 +767,7 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
 
     ObfuscatedCount randomize(int crossCount, int requestVariance) {
         int randomized = Math.max(crossCount + requestVariance, threshold);
-        return new ObfuscatedCount(randomized, randomized + " \u00B1" + variance);
+        return new ObfuscatedCount(randomized, randomized + " \u00B1" + variance, variance);
     }
 
     private Stream<String> generateParents(String key) {
@@ -783,14 +783,15 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
 
     /**
      * Core privacy floor: small (potentially identifiable) cohorts get hidden behind a "< threshold" display.
-     * The numeric component is set to threshold-1 so the chart bar still renders at a visible height just under
-     * the threshold; the true count lies in [0, threshold-1] but we don't disclose which.
+     * The value is encoded as count 0 with variance threshold-1, so consumers rendering the uncertainty band
+     * [max(0, count - variance), count + variance] draw 0..threshold-1 — the true count lies somewhere in that
+     * band but we don't disclose where.
      *
      * Returns empty when the value is at or above the threshold (caller should then call {@link #randomize}).
      */
     Optional<ObfuscatedCount> applyThresholdFloor(int actualCount) {
         if (actualCount < threshold) {
-            return Optional.of(new ObfuscatedCount(threshold - 1, "< " + threshold));
+            return Optional.of(new ObfuscatedCount(0, "< " + threshold, threshold - 1));
         }
         return Optional.empty();
     }

--- a/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/AggregateDataSharingResourceRS.java
+++ b/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/AggregateDataSharingResourceRS.java
@@ -364,7 +364,9 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
         switch (expectedResultType) {
             case "COUNT":
                 int requestVariance = generateRequestVariance(entityString);
-                responseString = aggregateCount(entityString).orElse(randomize(entityString, requestVariance));
+                responseString = aggregateCount(entityString)
+                    .map(ObfuscatedCount::display)
+                    .orElseGet(() -> randomize(entityString, requestVariance).display());
 
                 break;
             case "CROSS_COUNT":
@@ -523,9 +525,9 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
         if (crossCounts != null) {
             crossCounts.keySet().forEach(key -> {
                 String crossCount = crossCounts.get(key);
-                Optional<String> aggregatedCount = aggregateCount(crossCount);
+                Optional<ObfuscatedCount> aggregatedCount = aggregateCount(crossCount);
                 aggregatedCount.ifPresent((x) -> obfuscatedKeys.add(key));
-                crossCounts.put(key, aggregatedCount.orElse(crossCount));
+                crossCounts.put(key, aggregatedCount.map(ObfuscatedCount::display).orElse(crossCount));
             });
 
             Set<String> obfuscatedParents = obfuscatedKeys.stream().flatMap(this::generateParents).collect(Collectors.toSet());
@@ -533,7 +535,7 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
             crossCounts.keySet().forEach(key -> {
                 String crossCount = crossCounts.get(key);
                 if (!obfuscatedKeys.contains(key)) {
-                    crossCounts.put(key, randomize(crossCount, requestVariance));
+                    crossCounts.put(key, randomize(crossCount, requestVariance).display());
                 }
             });
         }
@@ -695,7 +697,7 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
     private void obfuscatedCrossCount(int generatedVariance, Map<String, Map<String, Object>> crossCount) {
         crossCount.forEach((key, value) -> {
             value.forEach((innerKey, innerValue) -> {
-                Optional<String> aggregateCount = aggregateCountHelper(innerValue);
+                Optional<ObfuscatedCount> aggregateCount = aggregateCountHelper(innerValue);
                 if (aggregateCount.isPresent()) {
                     value.put(innerKey, aggregateCount.get());
                 } else {
@@ -746,8 +748,9 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
         return Math.abs((entityString + randomSalt).hashCode()) % (variance * 2 + 1) - variance;
     }
 
-    private String randomize(String crossCount, int requestVariance) {
-        return Math.max((Integer.parseInt(crossCount) + requestVariance), threshold) + " \u00B1" + variance;
+    ObfuscatedCount randomize(String crossCount, int requestVariance) {
+        int randomized = Math.max((Integer.parseInt(crossCount) + requestVariance), threshold);
+        return new ObfuscatedCount(randomized, randomized + " \u00B1" + variance);
     }
 
     private Stream<String> generateParents(String key) {
@@ -767,11 +770,11 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
      * @param actualCount
      * @return
      */
-    private Optional<String> aggregateCount(String actualCount) {
+    Optional<ObfuscatedCount> aggregateCount(String actualCount) {
         try {
             int queryResult = Integer.parseInt(actualCount);
             if (queryResult < threshold) {
-                return Optional.of("< " + threshold);
+                return Optional.of(new ObfuscatedCount(threshold - 1, "< " + threshold));
             }
         } catch (NumberFormatException nfe) {
             logger.warn("Count was not a number! " + actualCount);
@@ -785,7 +788,7 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
      * @param actualCount
      * @return
      */
-    private Optional<String> aggregateCountHelper(Object actualCount) {
+    private Optional<ObfuscatedCount> aggregateCountHelper(Object actualCount) {
         if (actualCount instanceof Integer) {
             return aggregateCount(actualCount.toString());
         } else if (actualCount instanceof String) {

--- a/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/AggregateDataSharingResourceRS.java
+++ b/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/AggregateDataSharingResourceRS.java
@@ -364,9 +364,9 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
         switch (expectedResultType) {
             case "COUNT":
                 int requestVariance = generateRequestVariance(entityString);
-                responseString = aggregateCount(entityString)
+                responseString = applyThresholdFloor(entityString)
                     .map(ObfuscatedCount::display)
-                    .orElseGet(() -> randomize(entityString, requestVariance).display());
+                    .orElseGet(() -> randomize(Integer.parseInt(entityString), requestVariance).display());
 
                 break;
             case "CROSS_COUNT":
@@ -525,9 +525,9 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
         if (crossCounts != null) {
             crossCounts.keySet().forEach(key -> {
                 String crossCount = crossCounts.get(key);
-                Optional<ObfuscatedCount> aggregatedCount = aggregateCount(crossCount);
-                aggregatedCount.ifPresent((x) -> obfuscatedKeys.add(key));
-                crossCounts.put(key, aggregatedCount.map(ObfuscatedCount::display).orElse(crossCount));
+                Optional<ObfuscatedCount> floored = applyThresholdFloor(crossCount);
+                floored.ifPresent((x) -> obfuscatedKeys.add(key));
+                crossCounts.put(key, floored.map(ObfuscatedCount::display).orElse(crossCount));
             });
 
             Set<String> obfuscatedParents = obfuscatedKeys.stream().flatMap(this::generateParents).collect(Collectors.toSet());
@@ -535,7 +535,7 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
             crossCounts.keySet().forEach(key -> {
                 String crossCount = crossCounts.get(key);
                 if (!obfuscatedKeys.contains(key)) {
-                    crossCounts.put(key, randomize(crossCount, requestVariance).display());
+                    crossCounts.put(key, randomize(Integer.parseInt(crossCount), requestVariance).display());
                 }
             });
         }
@@ -604,15 +604,12 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
             // Log the binned continuous cross counts
             logger.info("Binned continuous cross counts: {}", binnedContinuousCrossCounts);
 
-            obfuscatedCrossCount(generatedVariance, binnedContinuousCrossCounts);
-
-            return objectMapper.writeValueAsString(binnedContinuousCrossCounts);
+            return objectMapper.writeValueAsString(obfuscateCrossCount(generatedVariance, binnedContinuousCrossCounts));
         } else {
             Map<String, Map<String, Object>> continuousCrossCounts =
                 objectMapper.readValue(continuousCrossCountResponse, new TypeReference<>() {});
 
-            obfuscatedCrossCount(generatedVariance, continuousCrossCounts);
-            return objectMapper.writeValueAsString(continuousCrossCounts);
+            return objectMapper.writeValueAsString(obfuscateCrossCount(generatedVariance, continuousCrossCounts));
         }
     }
 
@@ -673,9 +670,7 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
         processResults(categoricalCrossCount);
 
         // Now we need to obfuscate our return data. The only consideration is do we apply < threshold or variance
-        obfuscatedCrossCount(generatedVariance, categoricalCrossCount);
-
-        return objectMapper.writeValueAsString(categoricalCrossCount);
+        return objectMapper.writeValueAsString(obfuscateCrossCount(generatedVariance, categoricalCrossCount));
     }
 
     private static void processResults(Map<String, Map<String, Object>> categoricalCrossCount) {
@@ -688,23 +683,35 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
     }
 
     /**
-     * This method will obfuscate the cross counts based on the generated variance. We do not have a return because we are modifying the
-     * passed crossCount object. Java passes objects by reference value, so we do not need to return.
+     * Obfuscates every value in a cross-count map. Returns a freshly constructed map keyed identically to the
+     * input but with values replaced by either a threshold-floor obfuscation (for counts below the threshold)
+     * or a variance-randomized one.
      *
      * @param generatedVariance The variance for the request
-     * @param crossCount The cross count that will be obfuscated
+     * @param crossCount The cross count to obfuscate; values are JSON-deserialized so may be Integer or String
      */
-    private void obfuscatedCrossCount(int generatedVariance, Map<String, Map<String, Object>> crossCount) {
+    private Map<String, Map<String, ObfuscatedCount>> obfuscateCrossCount(
+        int generatedVariance, Map<String, Map<String, Object>> crossCount
+    ) {
+        Map<String, Map<String, ObfuscatedCount>> result = new LinkedHashMap<>();
         crossCount.forEach((key, value) -> {
+            Map<String, ObfuscatedCount> obfuscated = new LinkedHashMap<>();
             value.forEach((innerKey, innerValue) -> {
-                Optional<ObfuscatedCount> aggregateCount = aggregateCountHelper(innerValue);
-                if (aggregateCount.isPresent()) {
-                    value.put(innerKey, aggregateCount.get());
-                } else {
-                    value.put(innerKey, randomize(innerValue.toString(), generatedVariance));
-                }
+                int count = toInt(innerValue);
+                obfuscated.put(
+                    innerKey,
+                    applyThresholdFloor(count).orElseGet(() -> randomize(count, generatedVariance))
+                );
             });
+            result.put(key, obfuscated);
         });
+        return result;
+    }
+
+    private static int toInt(Object value) {
+        if (value instanceof Integer) return (Integer) value;
+        if (value instanceof String) return Integer.parseInt((String) value);
+        throw new IllegalArgumentException("Cross-count value was neither Integer nor numeric String: " + value);
     }
 
 
@@ -748,8 +755,8 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
         return Math.abs((entityString + randomSalt).hashCode()) % (variance * 2 + 1) - variance;
     }
 
-    ObfuscatedCount randomize(String crossCount, int requestVariance) {
-        int randomized = Math.max((Integer.parseInt(crossCount) + requestVariance), threshold);
+    ObfuscatedCount randomize(int crossCount, int requestVariance) {
+        int randomized = Math.max(crossCount + requestVariance, threshold);
         return new ObfuscatedCount(randomized, randomized + " \u00B1" + variance);
     }
 
@@ -765,35 +772,29 @@ public class AggregateDataSharingResourceRS implements IResourceRS {
     }
 
     /**
-     * Here's the core of this resource - make sure we do not return results with small (potentially identifiable) cohorts.
+     * Core privacy floor: small (potentially identifiable) cohorts get hidden behind a "< threshold" display.
+     * The numeric component is set to threshold-1 so the chart bar still renders at a visible height just under
+     * the threshold; the true count lies in [0, threshold-1] but we don't disclose which.
      *
-     * @param actualCount
-     * @return
+     * Returns empty when the value is at or above the threshold (caller should then call {@link #randomize}).
      */
-    Optional<ObfuscatedCount> aggregateCount(String actualCount) {
-        try {
-            int queryResult = Integer.parseInt(actualCount);
-            if (queryResult < threshold) {
-                return Optional.of(new ObfuscatedCount(threshold - 1, "< " + threshold));
-            }
-        } catch (NumberFormatException nfe) {
-            logger.warn("Count was not a number! " + actualCount);
+    Optional<ObfuscatedCount> applyThresholdFloor(int actualCount) {
+        if (actualCount < threshold) {
+            return Optional.of(new ObfuscatedCount(threshold - 1, "< " + threshold));
         }
         return Optional.empty();
     }
 
     /**
-     * Helper method to handle the fact that the actualCount could be an Integer or a String.
-     *
-     * @param actualCount
-     * @return
+     * String overload for callers (COUNT / CROSS_COUNT) that hold the value as a JSON string. Logs and returns
+     * empty on parse failure so the caller can fall through to its untouched-value path.
      */
-    private Optional<ObfuscatedCount> aggregateCountHelper(Object actualCount) {
-        if (actualCount instanceof Integer) {
-            return aggregateCount(actualCount.toString());
-        } else if (actualCount instanceof String) {
-            return aggregateCount((String) actualCount);
+    Optional<ObfuscatedCount> applyThresholdFloor(String actualCount) {
+        try {
+            return applyThresholdFloor(Integer.parseInt(actualCount));
+        } catch (NumberFormatException nfe) {
+            logger.warn("Count was not a number! " + actualCount);
+            return Optional.empty();
         }
-        return Optional.empty();
     }
 }

--- a/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/AggregateDataSharingResourceRSV3.java
+++ b/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/AggregateDataSharingResourceRSV3.java
@@ -340,9 +340,9 @@ public class AggregateDataSharingResourceRSV3 implements IResourceRS {
         switch (expectedResultType) {
             case "COUNT":
                 int requestVariance = generateRequestVariance(entityString);
-                responseString = aggregateCount(entityString)
+                responseString = applyThresholdFloor(entityString)
                     .map(ObfuscatedCount::display)
-                    .orElseGet(() -> randomize(entityString, requestVariance).display());
+                    .orElseGet(() -> randomize(Integer.parseInt(entityString), requestVariance).display());
 
                 break;
             case "CROSS_COUNT":
@@ -501,9 +501,9 @@ public class AggregateDataSharingResourceRSV3 implements IResourceRS {
         if (crossCounts != null) {
             crossCounts.keySet().forEach(key -> {
                 String crossCount = crossCounts.get(key);
-                Optional<ObfuscatedCount> aggregatedCount = aggregateCount(crossCount);
-                aggregatedCount.ifPresent((x) -> obfuscatedKeys.add(key));
-                crossCounts.put(key, aggregatedCount.map(ObfuscatedCount::display).orElse(crossCount));
+                Optional<ObfuscatedCount> floored = applyThresholdFloor(crossCount);
+                floored.ifPresent((x) -> obfuscatedKeys.add(key));
+                crossCounts.put(key, floored.map(ObfuscatedCount::display).orElse(crossCount));
             });
 
             Set<String> obfuscatedParents = obfuscatedKeys.stream().flatMap(this::generateParents).collect(Collectors.toSet());
@@ -511,7 +511,7 @@ public class AggregateDataSharingResourceRSV3 implements IResourceRS {
             crossCounts.keySet().forEach(key -> {
                 String crossCount = crossCounts.get(key);
                 if (!obfuscatedKeys.contains(key)) {
-                    crossCounts.put(key, randomize(crossCount, requestVariance).display());
+                    crossCounts.put(key, randomize(Integer.parseInt(crossCount), requestVariance).display());
                 }
             });
         }
@@ -580,15 +580,12 @@ public class AggregateDataSharingResourceRSV3 implements IResourceRS {
             // Log the binned continuous cross counts
             logger.info("Binned continuous cross counts: {}", binnedContinuousCrossCounts);
 
-            obfuscatedCrossCount(generatedVariance, binnedContinuousCrossCounts);
-
-            return objectMapper.writeValueAsString(binnedContinuousCrossCounts);
+            return objectMapper.writeValueAsString(obfuscateCrossCount(generatedVariance, binnedContinuousCrossCounts));
         } else {
             Map<String, Map<String, Object>> continuousCrossCounts =
                 objectMapper.readValue(continuousCrossCountResponse, new TypeReference<>() {});
 
-            obfuscatedCrossCount(generatedVariance, continuousCrossCounts);
-            return objectMapper.writeValueAsString(continuousCrossCounts);
+            return objectMapper.writeValueAsString(obfuscateCrossCount(generatedVariance, continuousCrossCounts));
         }
     }
 
@@ -649,9 +646,7 @@ public class AggregateDataSharingResourceRSV3 implements IResourceRS {
         processResults(categoricalCrossCount);
 
         // Now we need to obfuscate our return data. The only consideration is do we apply < threshold or variance
-        obfuscatedCrossCount(generatedVariance, categoricalCrossCount);
-
-        return objectMapper.writeValueAsString(categoricalCrossCount);
+        return objectMapper.writeValueAsString(obfuscateCrossCount(generatedVariance, categoricalCrossCount));
     }
 
     private static void processResults(Map<String, Map<String, Object>> categoricalCrossCount) {
@@ -664,23 +659,35 @@ public class AggregateDataSharingResourceRSV3 implements IResourceRS {
     }
 
     /**
-     * This method will obfuscate the cross counts based on the generated variance. We do not have a return because we are modifying the
-     * passed crossCount object. Java passes objects by reference value, so we do not need to return.
+     * Obfuscates every value in a cross-count map. Returns a freshly constructed map keyed identically to the
+     * input but with values replaced by either a threshold-floor obfuscation (for counts below the threshold)
+     * or a variance-randomized one.
      *
      * @param generatedVariance The variance for the request
-     * @param crossCount The cross count that will be obfuscated
+     * @param crossCount The cross count to obfuscate; values are JSON-deserialized so may be Integer or String
      */
-    private void obfuscatedCrossCount(int generatedVariance, Map<String, Map<String, Object>> crossCount) {
+    private Map<String, Map<String, ObfuscatedCount>> obfuscateCrossCount(
+        int generatedVariance, Map<String, Map<String, Object>> crossCount
+    ) {
+        Map<String, Map<String, ObfuscatedCount>> result = new LinkedHashMap<>();
         crossCount.forEach((key, value) -> {
+            Map<String, ObfuscatedCount> obfuscated = new LinkedHashMap<>();
             value.forEach((innerKey, innerValue) -> {
-                Optional<ObfuscatedCount> aggregateCount = aggregateCountHelper(innerValue);
-                if (aggregateCount.isPresent()) {
-                    value.put(innerKey, aggregateCount.get());
-                } else {
-                    value.put(innerKey, randomize(innerValue.toString(), generatedVariance));
-                }
+                int count = toInt(innerValue);
+                obfuscated.put(
+                    innerKey,
+                    applyThresholdFloor(count).orElseGet(() -> randomize(count, generatedVariance))
+                );
             });
+            result.put(key, obfuscated);
         });
+        return result;
+    }
+
+    private static int toInt(Object value) {
+        if (value instanceof Integer) return (Integer) value;
+        if (value instanceof String) return Integer.parseInt((String) value);
+        throw new IllegalArgumentException("Cross-count value was neither Integer nor numeric String: " + value);
     }
 
 
@@ -724,8 +731,8 @@ public class AggregateDataSharingResourceRSV3 implements IResourceRS {
         return Math.abs((entityString + randomSalt).hashCode()) % (variance * 2 + 1) - variance;
     }
 
-    ObfuscatedCount randomize(String crossCount, int requestVariance) {
-        int randomized = Math.max((Integer.parseInt(crossCount) + requestVariance), threshold);
+    ObfuscatedCount randomize(int crossCount, int requestVariance) {
+        int randomized = Math.max(crossCount + requestVariance, threshold);
         return new ObfuscatedCount(randomized, randomized + " \u00B1" + variance);
     }
 
@@ -741,35 +748,29 @@ public class AggregateDataSharingResourceRSV3 implements IResourceRS {
     }
 
     /**
-     * Here's the core of this resource - make sure we do not return results with small (potentially identifiable) cohorts.
+     * Core privacy floor: small (potentially identifiable) cohorts get hidden behind a "< threshold" display.
+     * The numeric component is set to threshold-1 so the chart bar still renders at a visible height just under
+     * the threshold; the true count lies in [0, threshold-1] but we don't disclose which.
      *
-     * @param actualCount
-     * @return
+     * Returns empty when the value is at or above the threshold (caller should then call {@link #randomize}).
      */
-    Optional<ObfuscatedCount> aggregateCount(String actualCount) {
-        try {
-            int queryResult = Integer.parseInt(actualCount);
-            if (queryResult < threshold) {
-                return Optional.of(new ObfuscatedCount(threshold - 1, "< " + threshold));
-            }
-        } catch (NumberFormatException nfe) {
-            logger.warn("Count was not a number! " + actualCount);
+    Optional<ObfuscatedCount> applyThresholdFloor(int actualCount) {
+        if (actualCount < threshold) {
+            return Optional.of(new ObfuscatedCount(threshold - 1, "< " + threshold));
         }
         return Optional.empty();
     }
 
     /**
-     * Helper method to handle the fact that the actualCount could be an Integer or a String.
-     *
-     * @param actualCount
-     * @return
+     * String overload for callers (COUNT / CROSS_COUNT) that hold the value as a JSON string. Logs and returns
+     * empty on parse failure so the caller can fall through to its untouched-value path.
      */
-    private Optional<ObfuscatedCount> aggregateCountHelper(Object actualCount) {
-        if (actualCount instanceof Integer) {
-            return aggregateCount(actualCount.toString());
-        } else if (actualCount instanceof String) {
-            return aggregateCount((String) actualCount);
+    Optional<ObfuscatedCount> applyThresholdFloor(String actualCount) {
+        try {
+            return applyThresholdFloor(Integer.parseInt(actualCount));
+        } catch (NumberFormatException nfe) {
+            logger.warn("Count was not a number! " + actualCount);
+            return Optional.empty();
         }
-        return Optional.empty();
     }
 }

--- a/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/AggregateDataSharingResourceRSV3.java
+++ b/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/AggregateDataSharingResourceRSV3.java
@@ -32,9 +32,7 @@ import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static edu.harvard.dbmi.avillach.service.ResourceWebClient.QUERY_METADATA_FIELD;
 import static edu.harvard.dbmi.avillach.util.HttpClientUtil.closeHttpResponse;
@@ -339,10 +337,16 @@ public class AggregateDataSharingResourceRSV3 implements IResourceRS {
         String crossCountResponse;
         switch (expectedResultType) {
             case "COUNT":
-                int requestVariance = generateRequestVariance(entityString);
-                responseString = applyThresholdFloor(entityString)
-                    .map(ObfuscatedCount::display)
-                    .orElseGet(() -> randomize(Integer.parseInt(entityString), requestVariance).display());
+                try {
+                    int count = Integer.parseInt(entityString);
+                    int requestVariance = generateRequestVariance(entityString);
+                    responseString = applyThresholdFloor(count)
+                        .map(ObfuscatedCount::display)
+                        .orElseGet(() -> randomize(count, requestVariance).display());
+                } catch (NumberFormatException nfe) {
+                    logger.warn("COUNT response was not a number! " + entityString);
+                    responseString = entityString;
+                }
 
                 break;
             case "CROSS_COUNT":
@@ -505,8 +509,6 @@ public class AggregateDataSharingResourceRSV3 implements IResourceRS {
                 floored.ifPresent((x) -> obfuscatedKeys.add(key));
                 crossCounts.put(key, floored.map(ObfuscatedCount::display).orElse(crossCount));
             });
-
-            Set<String> obfuscatedParents = obfuscatedKeys.stream().flatMap(this::generateParents).collect(Collectors.toSet());
 
             crossCounts.keySet().forEach(key -> {
                 String crossCount = crossCounts.get(key);
@@ -744,17 +746,6 @@ public class AggregateDataSharingResourceRSV3 implements IResourceRS {
     ObfuscatedCount randomize(int crossCount, int requestVariance) {
         int randomized = Math.max(crossCount + requestVariance, threshold);
         return new ObfuscatedCount(randomized, randomized + " \u00B1" + variance, variance);
-    }
-
-    private Stream<String> generateParents(String key) {
-        StringJoiner stringJoiner = new StringJoiner("\\", "\\", "\\");
-
-        String[] split = key.split("\\\\");
-        if (split.length > 1) {
-            return Arrays.stream(Arrays.copyOfRange(split, 0, split.length - 1)).filter(Predicate.not(String::isEmpty))
-                .map(segment -> stringJoiner.add(segment).toString());
-        }
-        return Stream.empty();
     }
 
     /**

--- a/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/AggregateDataSharingResourceRSV3.java
+++ b/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/AggregateDataSharingResourceRSV3.java
@@ -543,16 +543,20 @@ public class AggregateDataSharingResourceRSV3 implements IResourceRS {
     }
 
     /**
-     * This method will return an obfuscated binned count of continuous crosses. Due to the format of a continuous cross count, we are
-     * unable to directly obfuscate it in its original form. First, we send the continuous cross count data to the visualization resource to
-     * group it into bins. Once the data is binned, we assess whether obfuscation is necessary for this particular continuous cross count.
-     * If obfuscation is not required, we return the data in string format. However, if obfuscation is needed, we first obfuscate the data
-     * and then return it.
+     * Returns the obfuscated continuous cross-count JSON. Continuous values can't be obfuscated directly in their
+     * raw form (one entry per distinct numeric value gives too many cells with small counts), so we first bin them
+     * via the visualization resource — when a visualization service is configured — and obfuscate the binned counts.
+     * Without a configured visualization service we obfuscate the raw per-value counts as a fallback.
+     *
+     * Either way, every value in the returned map is obfuscated through {@link #obfuscateCrossCount}: counts below
+     * the threshold collapse to {@code "< threshold"}, larger counts get variance-randomized. Returns null only when
+     * the upstream produced no data or when {@link #canShowContinuousCrossCounts} signals the cohort is too small
+     * to safely render.
      *
      * @param continuousCrossCountResponse The continuous cross count response
      * @param crossCountResponse The cross count response
      * @param queryRequest The original query request
-     * @return String The obfuscated binned continuous cross count
+     * @return String The obfuscated continuous cross count JSON, or null if not safe / nothing to return
      * @throws IOException If there is an error processing the JSON
      */
     protected String processContinuousCrossCounts(String continuousCrossCountResponse, String crossCountResponse, QueryRequest queryRequest)
@@ -684,10 +688,16 @@ public class AggregateDataSharingResourceRSV3 implements IResourceRS {
         return result;
     }
 
-    private static int toInt(Object value) {
-        if (value instanceof Integer) return (Integer) value;
+    /**
+     * Jackson hands us {@code Object}-typed values from JSON; the runtime type depends on the number's magnitude
+     * (Integer, Long, Double, BigInteger, ...) and on whether the upstream stringified it. Accept anything that
+     * represents an integral count and narrow to int. The previous shape ({@code innerValue.toString()} into
+     * {@link Integer#parseInt}) silently accepted Long/Double for free; preserve that breadth via {@link Number}.
+     */
+    static int toInt(Object value) {
+        if (value instanceof Number) return ((Number) value).intValue();
         if (value instanceof String) return Integer.parseInt((String) value);
-        throw new IllegalArgumentException("Cross-count value was neither Integer nor numeric String: " + value);
+        throw new IllegalArgumentException("Cross-count value was neither Number nor numeric String: " + value);
     }
 
 

--- a/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/AggregateDataSharingResourceRSV3.java
+++ b/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/AggregateDataSharingResourceRSV3.java
@@ -340,7 +340,9 @@ public class AggregateDataSharingResourceRSV3 implements IResourceRS {
         switch (expectedResultType) {
             case "COUNT":
                 int requestVariance = generateRequestVariance(entityString);
-                responseString = aggregateCount(entityString).orElse(randomize(entityString, requestVariance));
+                responseString = aggregateCount(entityString)
+                    .map(ObfuscatedCount::display)
+                    .orElseGet(() -> randomize(entityString, requestVariance).display());
 
                 break;
             case "CROSS_COUNT":
@@ -499,9 +501,9 @@ public class AggregateDataSharingResourceRSV3 implements IResourceRS {
         if (crossCounts != null) {
             crossCounts.keySet().forEach(key -> {
                 String crossCount = crossCounts.get(key);
-                Optional<String> aggregatedCount = aggregateCount(crossCount);
+                Optional<ObfuscatedCount> aggregatedCount = aggregateCount(crossCount);
                 aggregatedCount.ifPresent((x) -> obfuscatedKeys.add(key));
-                crossCounts.put(key, aggregatedCount.orElse(crossCount));
+                crossCounts.put(key, aggregatedCount.map(ObfuscatedCount::display).orElse(crossCount));
             });
 
             Set<String> obfuscatedParents = obfuscatedKeys.stream().flatMap(this::generateParents).collect(Collectors.toSet());
@@ -509,7 +511,7 @@ public class AggregateDataSharingResourceRSV3 implements IResourceRS {
             crossCounts.keySet().forEach(key -> {
                 String crossCount = crossCounts.get(key);
                 if (!obfuscatedKeys.contains(key)) {
-                    crossCounts.put(key, randomize(crossCount, requestVariance));
+                    crossCounts.put(key, randomize(crossCount, requestVariance).display());
                 }
             });
         }
@@ -671,7 +673,7 @@ public class AggregateDataSharingResourceRSV3 implements IResourceRS {
     private void obfuscatedCrossCount(int generatedVariance, Map<String, Map<String, Object>> crossCount) {
         crossCount.forEach((key, value) -> {
             value.forEach((innerKey, innerValue) -> {
-                Optional<String> aggregateCount = aggregateCountHelper(innerValue);
+                Optional<ObfuscatedCount> aggregateCount = aggregateCountHelper(innerValue);
                 if (aggregateCount.isPresent()) {
                     value.put(innerKey, aggregateCount.get());
                 } else {
@@ -722,8 +724,9 @@ public class AggregateDataSharingResourceRSV3 implements IResourceRS {
         return Math.abs((entityString + randomSalt).hashCode()) % (variance * 2 + 1) - variance;
     }
 
-    private String randomize(String crossCount, int requestVariance) {
-        return Math.max((Integer.parseInt(crossCount) + requestVariance), threshold) + " \u00B1" + variance;
+    ObfuscatedCount randomize(String crossCount, int requestVariance) {
+        int randomized = Math.max((Integer.parseInt(crossCount) + requestVariance), threshold);
+        return new ObfuscatedCount(randomized, randomized + " \u00B1" + variance);
     }
 
     private Stream<String> generateParents(String key) {
@@ -743,11 +746,11 @@ public class AggregateDataSharingResourceRSV3 implements IResourceRS {
      * @param actualCount
      * @return
      */
-    private Optional<String> aggregateCount(String actualCount) {
+    Optional<ObfuscatedCount> aggregateCount(String actualCount) {
         try {
             int queryResult = Integer.parseInt(actualCount);
             if (queryResult < threshold) {
-                return Optional.of("< " + threshold);
+                return Optional.of(new ObfuscatedCount(threshold - 1, "< " + threshold));
             }
         } catch (NumberFormatException nfe) {
             logger.warn("Count was not a number! " + actualCount);
@@ -761,7 +764,7 @@ public class AggregateDataSharingResourceRSV3 implements IResourceRS {
      * @param actualCount
      * @return
      */
-    private Optional<String> aggregateCountHelper(Object actualCount) {
+    private Optional<ObfuscatedCount> aggregateCountHelper(Object actualCount) {
         if (actualCount instanceof Integer) {
             return aggregateCount(actualCount.toString());
         } else if (actualCount instanceof String) {

--- a/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/AggregateDataSharingResourceRSV3.java
+++ b/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/AggregateDataSharingResourceRSV3.java
@@ -743,7 +743,7 @@ public class AggregateDataSharingResourceRSV3 implements IResourceRS {
 
     ObfuscatedCount randomize(int crossCount, int requestVariance) {
         int randomized = Math.max(crossCount + requestVariance, threshold);
-        return new ObfuscatedCount(randomized, randomized + " \u00B1" + variance);
+        return new ObfuscatedCount(randomized, randomized + " \u00B1" + variance, variance);
     }
 
     private Stream<String> generateParents(String key) {
@@ -759,14 +759,15 @@ public class AggregateDataSharingResourceRSV3 implements IResourceRS {
 
     /**
      * Core privacy floor: small (potentially identifiable) cohorts get hidden behind a "< threshold" display.
-     * The numeric component is set to threshold-1 so the chart bar still renders at a visible height just under
-     * the threshold; the true count lies in [0, threshold-1] but we don't disclose which.
+     * The value is encoded as count 0 with variance threshold-1, so consumers rendering the uncertainty band
+     * [max(0, count - variance), count + variance] draw 0..threshold-1 — the true count lies somewhere in that
+     * band but we don't disclose where.
      *
      * Returns empty when the value is at or above the threshold (caller should then call {@link #randomize}).
      */
     Optional<ObfuscatedCount> applyThresholdFloor(int actualCount) {
         if (actualCount < threshold) {
-            return Optional.of(new ObfuscatedCount(threshold - 1, "< " + threshold));
+            return Optional.of(new ObfuscatedCount(0, "< " + threshold, threshold - 1));
         }
         return Optional.empty();
     }

--- a/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/ObfuscatedCount.java
+++ b/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/ObfuscatedCount.java
@@ -13,13 +13,22 @@ public final class ObfuscatedCount {
     @JsonProperty("display")
     private final String display;
 
+    /**
+     * Half-width of the uncertainty band around {@link #count}, or null when the value is exact
+     * (authorized path). Consumers render the band as [max(0, count - variance), count + variance].
+     */
+    @JsonProperty("variance")
+    private final Integer variance;
+
     @JsonCreator
     public ObfuscatedCount(
         @JsonProperty("count") int count,
-        @JsonProperty("display") String display
+        @JsonProperty("display") String display,
+        @JsonProperty("variance") Integer variance
     ) {
         this.count = count;
         this.display = display;
+        this.variance = variance;
     }
 
     /**
@@ -28,7 +37,7 @@ public final class ObfuscatedCount {
      * where no threshold floor or variance applies.
      */
     public static ObfuscatedCount ofInt(int count) {
-        return new ObfuscatedCount(count, Integer.toString(count));
+        return new ObfuscatedCount(count, Integer.toString(count), null);
     }
 
     public int count() {
@@ -39,21 +48,25 @@ public final class ObfuscatedCount {
         return display;
     }
 
+    public Integer variance() {
+        return variance;
+    }
+
     @Override
     public boolean equals(Object other) {
         if (this == other) return true;
         if (!(other instanceof ObfuscatedCount)) return false;
         ObfuscatedCount that = (ObfuscatedCount) other;
-        return count == that.count && Objects.equals(display, that.display);
+        return count == that.count && Objects.equals(display, that.display) && Objects.equals(variance, that.variance);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(count, display);
+        return Objects.hash(count, display, variance);
     }
 
     @Override
     public String toString() {
-        return "ObfuscatedCount{count=" + count + ", display='" + display + "'}";
+        return "ObfuscatedCount{count=" + count + ", display='" + display + "', variance=" + variance + "}";
     }
 }

--- a/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/ObfuscatedCount.java
+++ b/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/ObfuscatedCount.java
@@ -2,14 +2,33 @@ package edu.harvard.hms.dbmi.avillach;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public final class ObfuscatedCount {
 
+    @JsonProperty("count")
     private final int count;
+
+    @JsonProperty("display")
     private final String display;
 
-    public ObfuscatedCount(int count, String display) {
+    @JsonCreator
+    public ObfuscatedCount(
+        @JsonProperty("count") int count,
+        @JsonProperty("display") String display
+    ) {
         this.count = count;
         this.display = display;
+    }
+
+    /**
+     * Wraps a plain (non-obfuscated) integer count. The display is just the
+     * stringified number; this is the right factory for the authorized path
+     * where no threshold floor or variance applies.
+     */
+    public static ObfuscatedCount ofInt(int count) {
+        return new ObfuscatedCount(count, Integer.toString(count));
     }
 
     public int count() {

--- a/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/ObfuscatedCount.java
+++ b/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/main/java/edu/harvard/hms/dbmi/avillach/ObfuscatedCount.java
@@ -1,0 +1,40 @@
+package edu.harvard.hms.dbmi.avillach;
+
+import java.util.Objects;
+
+public final class ObfuscatedCount {
+
+    private final int count;
+    private final String display;
+
+    public ObfuscatedCount(int count, String display) {
+        this.count = count;
+        this.display = display;
+    }
+
+    public int count() {
+        return count;
+    }
+
+    public String display() {
+        return display;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (!(other instanceof ObfuscatedCount)) return false;
+        ObfuscatedCount that = (ObfuscatedCount) other;
+        return count == that.count && Objects.equals(display, that.display);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(count, display);
+    }
+
+    @Override
+    public String toString() {
+        return "ObfuscatedCount{count=" + count + ", display='" + display + "'}";
+    }
+}

--- a/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/test/java/edu/harvard/hms/dbmi/avillach/ObfuscatedCountShapeTest.java
+++ b/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/test/java/edu/harvard/hms/dbmi/avillach/ObfuscatedCountShapeTest.java
@@ -1,0 +1,95 @@
+package edu.harvard.hms.dbmi.avillach;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Verifies that the obfuscation methods produce the rich {count, display} shape
+ * required by the visualization-resource for Plotly-compatible chart values.
+ *
+ * Exercises both V1 and V3 implementations since they carry parallel copies.
+ */
+public class ObfuscatedCountShapeTest {
+
+    private AggregateDataSharingResourceRS subject;
+    private AggregateDataSharingResourceRSV3 subjectV3;
+
+    @Before
+    public void setup() {
+        ApplicationProperties props = mock(ApplicationProperties.class);
+        when(props.getTargetPicsureObfuscationThreshold()).thenReturn(10);
+        when(props.getTargetPicsureObfuscationVariance()).thenReturn(3);
+        when(props.getTargetPicsureObfuscationSalt()).thenReturn("salt-for-test");
+        subject = new AggregateDataSharingResourceRS(props);
+        subjectV3 = new AggregateDataSharingResourceRSV3(props);
+    }
+
+    @Test
+    public void aggregateCount_belowThreshold_returnsThresholdMinusOneAndLessThanDisplay() {
+        Optional<ObfuscatedCount> result = subject.aggregateCount("3");
+
+        assertTrue("Below-threshold counts must be obfuscated", result.isPresent());
+        assertEquals(9, result.get().count());
+        assertEquals("< 10", result.get().display());
+    }
+
+    @Test
+    public void aggregateCount_zero_returnsThresholdMinusOneAndLessThanDisplay() {
+        Optional<ObfuscatedCount> result = subject.aggregateCount("0");
+
+        assertTrue("Zero is treated as below-threshold (privacy floor)", result.isPresent());
+        assertEquals(9, result.get().count());
+        assertEquals("< 10", result.get().display());
+    }
+
+    @Test
+    public void aggregateCount_atOrAboveThreshold_returnsEmpty() {
+        assertTrue(subject.aggregateCount("10").isEmpty());
+        assertTrue(subject.aggregateCount("999").isEmpty());
+    }
+
+    @Test
+    public void aggregateCount_nonNumeric_returnsEmpty() {
+        assertTrue(subject.aggregateCount("not-a-number").isEmpty());
+    }
+
+    @Test
+    public void randomize_appliesVariance_returnsBothNumericAndDisplay() {
+        ObfuscatedCount result = subject.randomize("100", 2);
+
+        assertEquals("count must be the numeric obfuscated value", 102, result.count());
+        assertEquals("display must carry the formatted variance string", "102 ±3", result.display());
+    }
+
+    @Test
+    public void randomize_floorsAtThreshold_whenVarianceTakesItBelow() {
+        ObfuscatedCount result = subject.randomize("10", -5);
+
+        assertEquals("Floored at threshold so the numeric stays >= threshold", 10, result.count());
+        assertEquals("10 ±3", result.display());
+    }
+
+    @Test
+    public void v3_aggregateCount_belowThreshold_sameContract() {
+        Optional<ObfuscatedCount> result = subjectV3.aggregateCount("5");
+
+        assertTrue(result.isPresent());
+        assertEquals(9, result.get().count());
+        assertEquals("< 10", result.get().display());
+    }
+
+    @Test
+    public void v3_randomize_sameContract() {
+        ObfuscatedCount result = subjectV3.randomize("200", 1);
+
+        assertEquals(201, result.count());
+        assertEquals("201 ±3", result.display());
+    }
+}

--- a/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/test/java/edu/harvard/hms/dbmi/avillach/ObfuscatedCountShapeTest.java
+++ b/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/test/java/edu/harvard/hms/dbmi/avillach/ObfuscatedCountShapeTest.java
@@ -97,6 +97,18 @@ public class ObfuscatedCountShapeTest {
     }
 
     @Test
+    public void toInt_acceptsAllJacksonNumberRuntimeTypes() {
+        // Jackson deserializes JSON numbers into Integer when they fit, Long for larger magnitudes, Double when
+        // decimal. The previous innerValue.toString() shape silently accepted all of these via Integer.parseInt
+        // (well, except Double — which it would have crashed on anyway). The replacement must not narrow.
+        assertEquals(42, AggregateDataSharingResourceRS.toInt(Integer.valueOf(42)));
+        assertEquals(42, AggregateDataSharingResourceRS.toInt(Long.valueOf(42L)));
+        assertEquals(42, AggregateDataSharingResourceRS.toInt(Double.valueOf(42.0)));
+        assertEquals(42, AggregateDataSharingResourceRS.toInt(Short.valueOf((short) 42)));
+        assertEquals(42, AggregateDataSharingResourceRS.toInt("42"));
+    }
+
+    @Test
     public void ofInt_factory_producesStringifiedDisplay() {
         ObfuscatedCount result = ObfuscatedCount.ofInt(45000);
 

--- a/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/test/java/edu/harvard/hms/dbmi/avillach/ObfuscatedCountShapeTest.java
+++ b/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/test/java/edu/harvard/hms/dbmi/avillach/ObfuscatedCountShapeTest.java
@@ -7,6 +7,9 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,8 +35,8 @@ public class ObfuscatedCountShapeTest {
     }
 
     @Test
-    public void aggregateCount_belowThreshold_returnsThresholdMinusOneAndLessThanDisplay() {
-        Optional<ObfuscatedCount> result = subject.aggregateCount("3");
+    public void applyThresholdFloor_belowThreshold_returnsThresholdMinusOneAndLessThanDisplay() {
+        Optional<ObfuscatedCount> result = subject.applyThresholdFloor(3);
 
         assertTrue("Below-threshold counts must be obfuscated", result.isPresent());
         assertEquals(9, result.get().count());
@@ -41,8 +44,8 @@ public class ObfuscatedCountShapeTest {
     }
 
     @Test
-    public void aggregateCount_zero_returnsThresholdMinusOneAndLessThanDisplay() {
-        Optional<ObfuscatedCount> result = subject.aggregateCount("0");
+    public void applyThresholdFloor_zero_returnsThresholdMinusOneAndLessThanDisplay() {
+        Optional<ObfuscatedCount> result = subject.applyThresholdFloor(0);
 
         assertTrue("Zero is treated as below-threshold (privacy floor)", result.isPresent());
         assertEquals(9, result.get().count());
@@ -50,19 +53,19 @@ public class ObfuscatedCountShapeTest {
     }
 
     @Test
-    public void aggregateCount_atOrAboveThreshold_returnsEmpty() {
-        assertTrue(subject.aggregateCount("10").isEmpty());
-        assertTrue(subject.aggregateCount("999").isEmpty());
+    public void applyThresholdFloor_atOrAboveThreshold_returnsEmpty() {
+        assertTrue(subject.applyThresholdFloor(10).isEmpty());
+        assertTrue(subject.applyThresholdFloor(999).isEmpty());
     }
 
     @Test
-    public void aggregateCount_nonNumeric_returnsEmpty() {
-        assertTrue(subject.aggregateCount("not-a-number").isEmpty());
+    public void applyThresholdFloor_stringOverload_nonNumeric_returnsEmpty() {
+        assertTrue(subject.applyThresholdFloor("not-a-number").isEmpty());
     }
 
     @Test
     public void randomize_appliesVariance_returnsBothNumericAndDisplay() {
-        ObfuscatedCount result = subject.randomize("100", 2);
+        ObfuscatedCount result = subject.randomize(100, 2);
 
         assertEquals("count must be the numeric obfuscated value", 102, result.count());
         assertEquals("display must carry the formatted variance string", "102 ±3", result.display());
@@ -70,15 +73,15 @@ public class ObfuscatedCountShapeTest {
 
     @Test
     public void randomize_floorsAtThreshold_whenVarianceTakesItBelow() {
-        ObfuscatedCount result = subject.randomize("10", -5);
+        ObfuscatedCount result = subject.randomize(10, -5);
 
         assertEquals("Floored at threshold so the numeric stays >= threshold", 10, result.count());
         assertEquals("10 ±3", result.display());
     }
 
     @Test
-    public void v3_aggregateCount_belowThreshold_sameContract() {
-        Optional<ObfuscatedCount> result = subjectV3.aggregateCount("5");
+    public void v3_applyThresholdFloor_belowThreshold_sameContract() {
+        Optional<ObfuscatedCount> result = subjectV3.applyThresholdFloor(5);
 
         assertTrue(result.isPresent());
         assertEquals(9, result.get().count());
@@ -87,9 +90,38 @@ public class ObfuscatedCountShapeTest {
 
     @Test
     public void v3_randomize_sameContract() {
-        ObfuscatedCount result = subjectV3.randomize("200", 1);
+        ObfuscatedCount result = subjectV3.randomize(200, 1);
 
         assertEquals(201, result.count());
         assertEquals("201 ±3", result.display());
+    }
+
+    @Test
+    public void ofInt_factory_producesStringifiedDisplay() {
+        ObfuscatedCount result = ObfuscatedCount.ofInt(45000);
+
+        assertEquals(45000, result.count());
+        assertEquals("45000", result.display());
+    }
+
+    /**
+     * Pins the JSON wire shape that visualization-resource (and any other consumer) deserializes against.
+     * If field names ever drift (e.g. someone renames the record component), this test fails BEFORE the
+     * cross-repo contract silently breaks in production.
+     */
+    @Test
+    public void jsonShape_serializesAsCountAndDisplayFields() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        ObfuscatedCount value = new ObfuscatedCount(222, "222 ±3");
+
+        String json = mapper.writeValueAsString(value);
+
+        // Exact-match assertion on serialized form. Field order is conventional for clarity but not load-bearing
+        // for consumers; we accept either ordering by JSON equality below.
+        assertEquals("{\"count\":222,\"display\":\"222 ±3\"}", json);
+
+        // Round-trip back through the mapper, asserting both fields survived.
+        ObfuscatedCount roundTripped = mapper.readValue(json, ObfuscatedCount.class);
+        assertEquals(value, roundTripped);
     }
 }

--- a/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/test/java/edu/harvard/hms/dbmi/avillach/ObfuscatedCountShapeTest.java
+++ b/pic-sure-resources/pic-sure-aggregate-data-sharing-resource/src/test/java/edu/harvard/hms/dbmi/avillach/ObfuscatedCountShapeTest.java
@@ -35,21 +35,23 @@ public class ObfuscatedCountShapeTest {
     }
 
     @Test
-    public void applyThresholdFloor_belowThreshold_returnsThresholdMinusOneAndLessThanDisplay() {
+    public void applyThresholdFloor_belowThreshold_returnsZeroCountWithThresholdBandAndLessThanDisplay() {
         Optional<ObfuscatedCount> result = subject.applyThresholdFloor(3);
 
         assertTrue("Below-threshold counts must be obfuscated", result.isPresent());
-        assertEquals(9, result.get().count());
+        assertEquals(0, result.get().count());
         assertEquals("< 10", result.get().display());
+        assertEquals("Band [max(0, 0-9), 0+9] renders 0..threshold-1", Integer.valueOf(9), result.get().variance());
     }
 
     @Test
-    public void applyThresholdFloor_zero_returnsThresholdMinusOneAndLessThanDisplay() {
+    public void applyThresholdFloor_zero_returnsZeroCountWithThresholdBandAndLessThanDisplay() {
         Optional<ObfuscatedCount> result = subject.applyThresholdFloor(0);
 
         assertTrue("Zero is treated as below-threshold (privacy floor)", result.isPresent());
-        assertEquals(9, result.get().count());
+        assertEquals(0, result.get().count());
         assertEquals("< 10", result.get().display());
+        assertEquals(Integer.valueOf(9), result.get().variance());
     }
 
     @Test
@@ -64,11 +66,12 @@ public class ObfuscatedCountShapeTest {
     }
 
     @Test
-    public void randomize_appliesVariance_returnsBothNumericAndDisplay() {
+    public void randomize_appliesVariance_returnsNumericDisplayAndVariance() {
         ObfuscatedCount result = subject.randomize(100, 2);
 
         assertEquals("count must be the numeric obfuscated value", 102, result.count());
         assertEquals("display must carry the formatted variance string", "102 ±3", result.display());
+        assertEquals("variance must carry the configured band half-width", Integer.valueOf(3), result.variance());
     }
 
     @Test
@@ -77,6 +80,7 @@ public class ObfuscatedCountShapeTest {
 
         assertEquals("Floored at threshold so the numeric stays >= threshold", 10, result.count());
         assertEquals("10 ±3", result.display());
+        assertEquals(Integer.valueOf(3), result.variance());
     }
 
     @Test
@@ -84,8 +88,9 @@ public class ObfuscatedCountShapeTest {
         Optional<ObfuscatedCount> result = subjectV3.applyThresholdFloor(5);
 
         assertTrue(result.isPresent());
-        assertEquals(9, result.get().count());
+        assertEquals(0, result.get().count());
         assertEquals("< 10", result.get().display());
+        assertEquals(Integer.valueOf(9), result.get().variance());
     }
 
     @Test
@@ -94,6 +99,7 @@ public class ObfuscatedCountShapeTest {
 
         assertEquals(201, result.count());
         assertEquals("201 ±3", result.display());
+        assertEquals(Integer.valueOf(3), result.variance());
     }
 
     @Test
@@ -109,11 +115,12 @@ public class ObfuscatedCountShapeTest {
     }
 
     @Test
-    public void ofInt_factory_producesStringifiedDisplay() {
+    public void ofInt_factory_producesStringifiedDisplayAndNullVariance() {
         ObfuscatedCount result = ObfuscatedCount.ofInt(45000);
 
         assertEquals(45000, result.count());
         assertEquals("45000", result.display());
+        assertEquals("Exact (authorized) values carry no uncertainty band", null, result.variance());
     }
 
     /**
@@ -122,18 +129,32 @@ public class ObfuscatedCountShapeTest {
      * cross-repo contract silently breaks in production.
      */
     @Test
-    public void jsonShape_serializesAsCountAndDisplayFields() throws JsonProcessingException {
+    public void jsonShape_serializesAsCountDisplayAndVarianceFields() throws JsonProcessingException {
         ObjectMapper mapper = new ObjectMapper();
-        ObfuscatedCount value = new ObfuscatedCount(222, "222 ±3");
+        ObfuscatedCount value = new ObfuscatedCount(222, "222 ±3", 3);
 
         String json = mapper.writeValueAsString(value);
 
         // Exact-match assertion on serialized form. Field order is conventional for clarity but not load-bearing
         // for consumers; we accept either ordering by JSON equality below.
-        assertEquals("{\"count\":222,\"display\":\"222 ±3\"}", json);
+        assertEquals("{\"count\":222,\"display\":\"222 ±3\",\"variance\":3}", json);
 
-        // Round-trip back through the mapper, asserting both fields survived.
+        // Round-trip back through the mapper, asserting all fields survived.
         ObfuscatedCount roundTripped = mapper.readValue(json, ObfuscatedCount.class);
         assertEquals(value, roundTripped);
+    }
+
+    /**
+     * Exact (authorized) values serialize variance as an explicit null, and below-threshold values pin
+     * the {count: 0, variance: threshold-1} encoding the frontend's band rule depends on.
+     */
+    @Test
+    public void jsonShape_nullVarianceAndBelowThresholdEncoding() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+
+        assertEquals("{\"count\":45000,\"display\":\"45000\",\"variance\":null}", mapper.writeValueAsString(ObfuscatedCount.ofInt(45000)));
+
+        ObfuscatedCount belowThreshold = subject.applyThresholdFloor(3).orElseThrow(IllegalStateException::new);
+        assertEquals("{\"count\":0,\"display\":\"< 10\",\"variance\":9}", mapper.writeValueAsString(belowThreshold));
     }
 }


### PR DESCRIPTION
**TL;DR:** Moves obfuscation ownership into the API layer. 

For CATEGORICAL_CROSS_COUNT / CONTINUOUS_CROSS_COUNT result types, agg-data-sharing now returns rich {count, display, variance} objects instead of bare display strings: count is the numeric bar value, display the human-readable label ("45000", "222 ±3", "< 10"), and variance the half-width of the uncertainty band (null for exact values; below-threshold encodes as count: 0, variance: threshold−1). 
 
**NOTE:** Plain COUNT/CROSS_COUNT responses are unchanged (still strings). Uses the existing target.picsure.obfuscation_* properties — no new config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced privacy controls for data query responses with improved threshold-based obfuscation that consistently masks counts below privacy thresholds.

* **Improvements**
  * Refined variance randomization mechanisms for consistent and predictable privacy band handling across different response types.

* **Tests**
  * Comprehensive test suite added to validate privacy obfuscation behavior and data accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->