### PR TITLE
feat: record adapter caller in audit log and forward correlation headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,8 @@ log/
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
 !/.mvn/wrapper/maven-wrapper.jar
 
+# Claude Code: local-only files, never commit (plans, specs, reviews, tickets, settings)
+.claude/
+**/.claude/
+docs/superpowers/
+

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ log/
 .claude/
 **/.claude/
 docs/superpowers/
+*.http
 

--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/AuditLoggingFilter.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/AuditLoggingFilter.java
@@ -205,14 +205,8 @@ public class AuditLoggingFilter implements ContainerRequestFilter, ContainerResp
                 metadata.put("user_email", userEmail);
             }
 
-            // Originating caller (e.g. PYTHON_ADAPTER / R_ADAPTER), set by the
-            // adapters via the X-Client-Type header. Recorded as "caller" to
-            // distinguish it from the top-level client_type, which identifies
-            // the emitting service ("api").
+            // Originating caller (e.g. PYTHON_ADAPTER / R_ADAPTER)
             String caller = httpServletRequest.getHeader("X-Client-Type");
-            if (caller != null && !caller.isEmpty()) {
-                metadata.put("caller", caller);
-            }
 
             // Session ID
             String sessionId =
@@ -240,6 +234,10 @@ public class AuditLoggingFilter implements ContainerRequestFilter, ContainerResp
             // Build the event
             LoggingEvent.Builder eventBuilder =
                 LoggingEvent.builder(eventType).action(action).sessionId(sessionId).request(requestInfo).metadata(metadata);
+
+            if (caller != null && !caller.isEmpty()) {
+                eventBuilder.caller(caller);
+            }
 
             if (errorMap != null) {
                 eventBuilder.error(errorMap);

--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/AuditLoggingFilter.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/AuditLoggingFilter.java
@@ -205,6 +205,15 @@ public class AuditLoggingFilter implements ContainerRequestFilter, ContainerResp
                 metadata.put("user_email", userEmail);
             }
 
+            // Originating caller (e.g. PYTHON_ADAPTER / R_ADAPTER), set by the
+            // adapters via the X-Client-Type header. Recorded as "caller" to
+            // distinguish it from the top-level client_type, which identifies
+            // the emitting service ("api").
+            String caller = httpServletRequest.getHeader("X-Client-Type");
+            if (caller != null && !caller.isEmpty()) {
+                metadata.put("caller", caller);
+            }
+
             // Session ID
             String sessionId =
                 SessionIdResolver.resolve(httpServletRequest.getHeader("X-Session-Id"), srcIp, httpServletRequest.getHeader("User-Agent"));

--- a/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/security/AuditLoggingFilterTest.java
+++ b/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/security/AuditLoggingFilterTest.java
@@ -546,4 +546,34 @@ public class AuditLoggingFilterTest {
         // Also has filter-level session_id
         assertNotNull(event.getSessionId());
     }
+
+    // ---- Client type (X-Client-Type header) ----
+
+    @Test
+    public void testXClientTypeHeaderRecordedInMetadata() throws IOException {
+        when(httpServletRequest.getHeader("X-Client-Type")).thenReturn("PYTHON_ADAPTER");
+
+        ContainerRequestContext reqCtx = mockRequestContext("/query", "POST");
+        ContainerResponseContext respCtx = mockResponseContext(200);
+
+        filter.filter(reqCtx, respCtx);
+
+        ArgumentCaptor<LoggingEvent> captor = ArgumentCaptor.forClass(LoggingEvent.class);
+        verify(loggingClient).send(captor.capture());
+        assertEquals("PYTHON_ADAPTER", captor.getValue().getMetadata().get("caller"));
+    }
+
+    @Test
+    public void testNoXClientTypeHeaderOmitsCallerMetadata() throws IOException {
+        when(httpServletRequest.getHeader("X-Client-Type")).thenReturn(null);
+
+        ContainerRequestContext reqCtx = mockRequestContext("/query", "POST");
+        ContainerResponseContext respCtx = mockResponseContext(200);
+
+        filter.filter(reqCtx, respCtx);
+
+        ArgumentCaptor<LoggingEvent> captor = ArgumentCaptor.forClass(LoggingEvent.class);
+        verify(loggingClient).send(captor.capture());
+        assertFalse(captor.getValue().getMetadata().containsKey("caller"));
+    }
 }

--- a/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/security/AuditLoggingFilterTest.java
+++ b/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/security/AuditLoggingFilterTest.java
@@ -550,7 +550,7 @@ public class AuditLoggingFilterTest {
     // ---- Client type (X-Client-Type header) ----
 
     @Test
-    public void testXClientTypeHeaderRecordedInMetadata() throws IOException {
+    public void testXClientTypeHeaderRecordedAsCaller() throws IOException {
         when(httpServletRequest.getHeader("X-Client-Type")).thenReturn("PYTHON_ADAPTER");
 
         ContainerRequestContext reqCtx = mockRequestContext("/query", "POST");
@@ -560,11 +560,11 @@ public class AuditLoggingFilterTest {
 
         ArgumentCaptor<LoggingEvent> captor = ArgumentCaptor.forClass(LoggingEvent.class);
         verify(loggingClient).send(captor.capture());
-        assertEquals("PYTHON_ADAPTER", captor.getValue().getMetadata().get("caller"));
+        assertEquals("PYTHON_ADAPTER", captor.getValue().getCaller());
     }
 
     @Test
-    public void testNoXClientTypeHeaderOmitsCallerMetadata() throws IOException {
+    public void testNoXClientTypeHeaderOmitsCaller() throws IOException {
         when(httpServletRequest.getHeader("X-Client-Type")).thenReturn(null);
 
         ContainerRequestContext reqCtx = mockRequestContext("/query", "POST");
@@ -574,6 +574,6 @@ public class AuditLoggingFilterTest {
 
         ArgumentCaptor<LoggingEvent> captor = ArgumentCaptor.forClass(LoggingEvent.class);
         verify(loggingClient).send(captor.capture());
-        assertFalse(captor.getValue().getMetadata().containsKey("caller"));
+        assertNull(captor.getValue().getCaller());
     }
 }

--- a/pic-sure-resources/pic-sure-resource-api/src/main/java/edu/harvard/dbmi/avillach/service/ProxyWebClient.java
+++ b/pic-sure-resources/pic-sure-resource-api/src/main/java/edu/harvard/dbmi/avillach/service/ProxyWebClient.java
@@ -109,7 +109,7 @@ public class ProxyWebClient {
             .toArray(NameValuePair[]::new);
     }
 
-    private static final String DEFAULT_FORWARDED_HEADERS = "authorization,x-api-key,x-request-id";
+    private static final String DEFAULT_FORWARDED_HEADERS = "authorization,x-api-key,x-request-id,x-session-id,x-client-type";
 
     private static final Set<String> FORWARDED_HEADERS = initForwardedHeaders();
 

--- a/pic-sure-resources/pic-sure-resource-api/src/test/java/edu/harvard/dbmi/avillach/service/ProxyWebClientTest.java
+++ b/pic-sure-resources/pic-sure-resource-api/src/test/java/edu/harvard/dbmi/avillach/service/ProxyWebClientTest.java
@@ -147,6 +147,54 @@ public class ProxyWebClientTest {
     }
 
     @Test
+    public void shouldForwardSessionIdHeader() throws IOException {
+        Mockito.when(resourceRepository.getByColumn("name", "foo")).thenReturn(List.of(new Resource()));
+        Mockito.when(client.execute(Mockito.argThat(request -> {
+            if (request instanceof HttpPost) {
+                HttpPost post = (HttpPost) request;
+                return post.getFirstHeader("x-session-id") != null
+                    && "sess-abc-123".equals(post.getFirstHeader("x-session-id").getValue());
+            }
+            return false;
+        }))).thenReturn(response);
+        Mockito.when(response.getStatusLine()).thenReturn(statusLine);
+        Mockito.when(statusLine.getStatusCode()).thenReturn(200);
+        Mockito.when(response.getEntity()).thenReturn(entity);
+        Mockito.when(entity.getContent()).thenReturn(new ByteArrayInputStream("{}".getBytes()));
+        subject.client = client;
+
+        HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+        Mockito.when(headers.getRequestHeader("x-session-id")).thenReturn(List.of("sess-abc-123"));
+
+        Response actual = subject.postProxy("foo", "/audit", "{}", new MultivaluedHashMap<>(), headers);
+        assertEquals(200, actual.getStatus());
+    }
+
+    @Test
+    public void shouldForwardClientTypeHeader() throws IOException {
+        Mockito.when(resourceRepository.getByColumn("name", "foo")).thenReturn(List.of(new Resource()));
+        Mockito.when(client.execute(Mockito.argThat(request -> {
+            if (request instanceof HttpPost) {
+                HttpPost post = (HttpPost) request;
+                return post.getFirstHeader("x-client-type") != null
+                    && "PYTHON_ADAPTER".equals(post.getFirstHeader("x-client-type").getValue());
+            }
+            return false;
+        }))).thenReturn(response);
+        Mockito.when(response.getStatusLine()).thenReturn(statusLine);
+        Mockito.when(statusLine.getStatusCode()).thenReturn(200);
+        Mockito.when(response.getEntity()).thenReturn(entity);
+        Mockito.when(entity.getContent()).thenReturn(new ByteArrayInputStream("{}".getBytes()));
+        subject.client = client;
+
+        HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+        Mockito.when(headers.getRequestHeader("x-client-type")).thenReturn(List.of("PYTHON_ADAPTER"));
+
+        Response actual = subject.postProxy("foo", "/audit", "{}", new MultivaluedHashMap<>(), headers);
+        assertEquals(200, actual.getStatus());
+    }
+
+    @Test
     public void shouldNotFailWithNullHeaders() throws IOException {
         Mockito.when(client.execute(Mockito.any(HttpPost.class))).thenReturn(response);
         Mockito.when(response.getStatusLine()).thenReturn(statusLine);

--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
       <dependency>
         <groupId>edu.harvard.dbmi.avillach</groupId>
         <artifactId>pic-sure-logging-client</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
AuditLoggingFilter records the X-Client-Type header as metadata.caller. ProxyWebClient forwards x-session-id and x-client-type to proxied services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit logs can now record the client type from the `X-Client-Type` request header.
  * Proxying now forwards `x-client-type` and `x-session-id` by default (when using default forwarded headers).
* **Tests**
  * Added assertions that audit logging captures (or omits) client type correctly.
  * Added tests that verify header forwarding for client type and session ID.
* **Chores**
  * Updated the managed logging client dependency.
  * Updated local development ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->