### PR TITLE
[ALS-12024] Update to remove nested query double escaping

### DIFF
--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/JWTFilter.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/JWTFilter.java
@@ -202,7 +202,8 @@ public class JWTFilter implements ContainerRequestFilter {
                     requestContext.setProperty("username", userForLogging);
                     // TEMP DIAGNOSTIC (remove after root-causing @RolesAllowed): shows the roles string PSAMA
                     // introspection returned for this user, which is what @RolesAllowed is matched against.
-                    logger.info("Installing AuthSecurityContext for user '{}' with roles='{}'", userForLogging, authenticatedUser.getRoles());
+                    logger
+                        .info("Installing AuthSecurityContext for user '{}' with roles='{}'", userForLogging, authenticatedUser.getRoles());
                     requestContext.setSecurityContext(new AuthSecurityContext(authenticatedUser, uriInfo.getRequestUri().getScheme()));
                     logger.info("User - {} - has just passed all the authentication and authorization layers.", userForLogging);
                     auditContext.put("auth_result", "success");
@@ -296,15 +297,21 @@ public class JWTFilter implements ContainerRequestFilter {
             String sub = responseContent.get("sub") != null ? responseContent.get("sub").asText() : null;
             String email = responseContent.get("email") != null ? responseContent.get("email").asText() : null;
             String roles = responseContent.get("roles") != null ? responseContent.get("roles").asText() : null;
-            Set<String> privileges = responseContent.get("privileges") != null
-                    ? json.convertValue(responseContent.get("privileges"), new TypeReference<>() {})
+            Set<String> privileges =
+                responseContent.get("privileges") != null ? json.convertValue(responseContent.get("privileges"), new TypeReference<>() {})
                     : Collections.emptySet();
             AuthUser user = new AuthUser().setUserId(userId).setSubject(sub).setEmail(email).setRoles(roles).setPrivileges(privileges);
 
             // If there is a query in the response, PSAMA has updated the authorization filters and we must update the query
             if (responseContent.get("query") != null) {
                 QueryRequest queryObject = new ObjectMapper().readValue(requestContext.getEntityStream(), QueryRequest.class);
-                queryObject.setQuery(responseContent.get("query").asText());
+                JsonNode updatedQuery = responseContent.get("query");
+                // PSAMA sends the updated query as a JSON string; parse it back into an object instead of
+                // storing the raw text, otherwise it gets re-escaped as a string when the request is
+                // re-serialized below, and again when it's persisted, corrupting stored queries with extra slashes.
+                Object parsedQuery = updatedQuery.isTextual() ? json.readValue(updatedQuery.asText(), Object.class)
+                    : json.convertValue(updatedQuery, Object.class);
+                queryObject.setQuery(parsedQuery);
                 requestContext.setEntityStream(new ByteArrayInputStream(new ObjectMapper().writeValueAsBytes(queryObject)));
             }
             return user;

--- a/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/security/JWTFilterTest.java
+++ b/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/security/JWTFilterTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
@@ -25,6 +26,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
 import edu.harvard.dbmi.avillach.PicSureWarInit;
@@ -269,7 +271,6 @@ public class JWTFilterTest {
         when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.POST);
         when(ctx.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer USER_TOKEN");
         filter.filter(ctx);
-        ArgumentCaptor<Map> requestBody = ArgumentCaptor.forClass(Map.class);
         verify(
             postRequestedFor(urlEqualTo("/introspection_endpoint"))
                 .withRequestBody(
@@ -278,6 +279,61 @@ public class JWTFilterTest {
                 .withRequestBody(matchingJsonPath("$.request.formattedQuery", equalToJson("{\"formatted\":\"query\"}")))
                 .withRequestBody(matchingJsonPath("$.token", matching("USER_TOKEN")))
         );
+    }
+
+    /**
+     * Regression test for the double-JSON-encoding bug: when PSAMA's token introspection response carries an updated "query" (it rewrote
+     * authorizationFilters for the caller's consents), the filter must parse that value back into an object before re-attaching it to the
+     * request, not store PSAMA's raw JSON-string text. Storing it as text causes it to be JSON-escaped an extra time on every subsequent
+     * serialization - including when the query is ultimately persisted - corrupting stored queries with doubled backslashes.
+     */
+    @Test
+    public void testFilterParsesPsamaUpdatedQueryIntoObjectInsteadOfRawText() throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Map<String, Object> updatedQuery = new HashMap<>();
+        updatedQuery.put("select", java.util.List.of("\\_consents\\"));
+        updatedQuery.put("authorizationFilters", java.util.List.of());
+        String updatedQueryAsJsonString = mapper.writeValueAsString(updatedQuery);
+
+        // PSAMA's introspection contract carries the rewritten query as a JSON string value, not a nested object
+        Map<String, Object> introspectionResponse = new HashMap<>();
+        introspectionResponse.put("active", true);
+        introspectionResponse.put("sub", "TEST_USER");
+        introspectionResponse.put("email", "some@email.com");
+        introspectionResponse.put("roles", "PIC_SURE_ANY_QUERY");
+        introspectionResponse.put("tokenRefreshed", false);
+        introspectionResponse.put("query", updatedQueryAsJsonString);
+
+        stubFor(
+            post(urlEqualTo("/introspection_endpoint")).willReturn(
+                aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                    .withBody(mapper.writeValueAsString(introspectionResponse))
+            )
+        );
+
+        String originalRequestBody = "{\"query\":{\"select\":[\"\\\\_consents\\\\\"]},\"resourceUUID\":\"" + RESOURCE_UUID + "\"}";
+
+        // A mock ContainerRequestContext has no real backing field for its entity stream, so getEntityStream()
+        // has to be wired to reflect whatever setEntityStream() last stored - mirroring how the filter reads,
+        // buffers, resets, and re-reads the stream within a single filter() call.
+        byte[][] currentBody = {originalRequestBody.getBytes()};
+        ContainerRequestContext ctx = createRequestContext();
+        when(ctx.getUriInfo().getPath()).thenReturn("/query/sync");
+        when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.POST);
+        when(ctx.getEntityStream()).thenAnswer(inv -> new ByteArrayInputStream(currentBody[0]));
+        doAnswer(inv -> {
+            currentBody[0] = ((InputStream) inv.getArgument(0)).readAllBytes();
+            return null;
+        }).when(ctx).setEntityStream(any());
+        when(ctx.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer USER_TOKEN");
+
+        filter.filter(ctx);
+
+        Map<?, ?> finalRequestBody = mapper.readValue(currentBody[0], Map.class);
+        Object query = finalRequestBody.get("query");
+        assertTrue("PSAMA's updated query must be stored as a nested object, not a re-escaped JSON string", query instanceof Map);
+        assertEquals(updatedQuery, query);
     }
 
     private void queryFormatStub() {


### PR DESCRIPTION
When PSAMA's token-introspection response includes an updated query (because it rewrote consent-based authorizationFilters), the code now parses that value back into an object before re-attaching it to the request, instead of storing PSAMA's raw JSON-string text. Storing raw text let it get JSON-escaped an extra time on every subsequent serialization, including at persistence, which produced doubled backslashes in the BDC data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of token introspection responses so updated query data is parsed correctly as structured JSON instead of being treated as raw text.
  * Preserved the same authentication behavior while refining request processing for more reliable query payloads.

* **Tests**
  * Added regression coverage for updated introspection payloads to ensure query data is restored in the expected format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->