### PR TITLE
WIP: Phase 3 — Sibling service routing + deep health / system-status

### DIFF
--- a/services/pic-sure-gateway/pom.xml
+++ b/services/pic-sure-gateway/pom.xml
@@ -71,6 +71,23 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- This module has no failsafe plugin (no other module does either), so its WireMock *IT tests
+                 (e.g. SystemHealthServiceIT) are plain, fast, self-contained JUnit tests, not real
+                 integration-test-phase tests. Extend surefire's default includes with **/*IT.java so they still
+                 run under `mvn test` instead of silently never executing. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>**/Test*.java</include>
+                        <include>**/*Test.java</include>
+                        <include>**/*Tests.java</include>
+                        <include>**/*TestCase.java</include>
+                        <include>**/*IT.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/config/HealthConfig.java
+++ b/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/config/HealthConfig.java
@@ -1,0 +1,53 @@
+package edu.harvard.hms.dbmi.avillach.gateway.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.MediaType;
+import org.springframework.web.servlet.function.RequestPredicates;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.RouterFunctions;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import edu.harvard.hms.dbmi.avillach.gateway.health.DownstreamHealthProperties;
+import edu.harvard.hms.dbmi.avillach.gateway.health.SystemHealthService;
+import edu.harvard.hms.dbmi.avillach.gateway.health.SystemStatusController;
+
+/**
+ * Registers the Task-9 deep-health pieces as Spring beans so the {@code /system/status} legacy text controller (Task 10) and the
+ * {@code /actuator/health} composite (Task 12) can consume them.
+ */
+@Configuration
+@EnableConfigurationProperties(DownstreamHealthProperties.class)
+public class HealthConfig {
+
+    @Bean
+    public SystemHealthService systemHealthService(DownstreamHealthProperties props) {
+        return new SystemHealthService(props);
+    }
+
+    @Bean
+    public SystemStatusController systemStatusController(
+        SystemHealthService systemHealthService, @Value("${picsure.gateway.health.status-window-ms:60000}") long statusWindowMs
+    ) {
+        return new SystemStatusController(systemHealthService, statusWindowMs);
+    }
+
+    /**
+     * Exposes {@code GET /system/status} ahead of the Phase-1 catch-all gateway route. The gateway's own composite {@code RouterFunction}
+     * bean carries no explicit {@code @Order} (so it defaults to {@code Ordered.LOWEST_PRECEDENCE}); ordering this bean at
+     * {@code HIGHEST_PRECEDENCE} guarantees it is tried first within {@code RouterFunctionMapping}, so the request never reaches the
+     * WildFly catch-all. See {@link SystemStatusController}'s class Javadoc for the full precedence chain.
+     */
+    @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    public RouterFunction<ServerResponse> systemStatusRoute(SystemStatusController controller) {
+        return RouterFunctions.route(
+            RequestPredicates.GET("/system/status"),
+            request -> ServerResponse.ok().contentType(MediaType.TEXT_PLAIN).body(controller.status())
+        );
+    }
+}

--- a/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/health/AggregateHealth.java
+++ b/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/health/AggregateHealth.java
@@ -1,0 +1,11 @@
+package edu.harvard.hms.dbmi.avillach.gateway.health;
+
+import java.util.List;
+
+/** Rollup over all probed downstreams. */
+public record AggregateHealth(boolean running, List<DownstreamHealth> components) {
+    public static AggregateHealth from(List<DownstreamHealth> components) {
+        boolean running = components.stream().allMatch(DownstreamHealth::up);
+        return new AggregateHealth(running, components);
+    }
+}

--- a/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/health/DownstreamHealth.java
+++ b/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/health/DownstreamHealth.java
@@ -1,0 +1,5 @@
+package edu.harvard.hms.dbmi.avillach.gateway.health;
+
+/** Result of probing a single downstream. */
+public record DownstreamHealth(String name, String resolvedUrl, boolean up, String detail) {
+}

--- a/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/health/DownstreamHealthContributor.java
+++ b/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/health/DownstreamHealthContributor.java
@@ -1,0 +1,49 @@
+package edu.harvard.hms.dbmi.avillach.gateway.health;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.boot.actuate.health.CompositeHealthContributor;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthContributor;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.NamedContributor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Surfaces each monitored downstream as a component under {@code /actuator/health}. One aggregate probe per scrape (the
+ * {@code /system/status} throttle does not apply here; Actuator's scrape interval governs frequency). Unaffected by the Phase-1 catch-all
+ * gateway route: Actuator's own {@code WebMvcEndpointHandlerMapping} is order -100, ahead of the gateway's {@code RouterFunctionMapping}
+ * (order -1).
+ */
+@Component("downstreams")
+public class DownstreamHealthContributor implements CompositeHealthContributor {
+
+    private final SystemHealthService health;
+
+    public DownstreamHealthContributor(SystemHealthService health) {
+        this.health = health;
+    }
+
+    private Map<String, HealthContributor> snapshot() {
+        Map<String, HealthContributor> map = new LinkedHashMap<>();
+        for (DownstreamHealth c : health.check().components()) {
+            HealthIndicator indicator =
+                () -> (c.up() ? Health.up() : Health.down()).withDetail("url", c.resolvedUrl()).withDetail("detail", c.detail()).build();
+            map.put(c.name(), indicator);
+        }
+        return map;
+    }
+
+    @Override
+    public HealthContributor getContributor(String name) {
+        return snapshot().get(name);
+    }
+
+    @Override
+    public Iterator<NamedContributor<HealthContributor>> iterator() {
+        Map<String, HealthContributor> map = snapshot();
+        return map.entrySet().stream().map(e -> NamedContributor.of(e.getKey(), e.getValue())).iterator();
+    }
+}

--- a/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/health/DownstreamHealthProperties.java
+++ b/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/health/DownstreamHealthProperties.java
@@ -1,0 +1,24 @@
+package edu.harvard.hms.dbmi.avillach.gateway.health;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Config-driven list of downstreams the gateway's deep-health composer probes, bound from {@code picsure.gateway.health.*}. Backs
+ * {@link SystemHealthService}.
+ */
+@ConfigurationProperties(prefix = "picsure.gateway.health")
+public record DownstreamHealthProperties(
+    List<MonitoredDownstream> downstreams, Integer connectTimeoutMs, Integer readTimeoutMs, String applicationToken
+) {
+    public DownstreamHealthProperties {
+        downstreams = downstreams == null ? List.of() : List.copyOf(downstreams);
+        if (connectTimeoutMs == null) {
+            connectTimeoutMs = 1000;
+        }
+        if (readTimeoutMs == null) {
+            readTimeoutMs = 2000;
+        }
+    }
+}

--- a/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/health/MonitoredDownstream.java
+++ b/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/health/MonitoredDownstream.java
@@ -1,0 +1,37 @@
+package edu.harvard.hms.dbmi.avillach.gateway.health;
+
+/**
+ * One monitored downstream (spec 3.8).
+ *
+ * @param name component name surfaced in /actuator/health and logs
+ * @param baseUrl base URL (reuse the routing env-var URL)
+ * @param healthPath path appended to baseUrl; default "/actuator/health", overridable (logging -> "/health"; an interim non-Actuator
+ *        service -> "/info")
+ * @param method HTTP method for the probe ("GET" or "POST"); default GET
+ * @param requestBody body sent for POST probes (e.g. "{}" for a PSAMA introspection fallback)
+ * @param sendAppToken whether to send the application/service bearer on the probe (Phase 6 detail)
+ * @param successStatus expected HTTP status for "up" (default 200)
+ * @param requireStatusUp if true, also require an Actuator body of {"status":"UP"}
+ */
+public record MonitoredDownstream(
+    String name, String baseUrl, String healthPath, String method, String requestBody, boolean sendAppToken, Integer successStatus,
+    boolean requireStatusUp
+) {
+    public MonitoredDownstream {
+        if (healthPath == null || healthPath.isBlank()) {
+            healthPath = "/actuator/health";
+        }
+        if (method == null || method.isBlank()) {
+            method = "GET";
+        }
+        if (successStatus == null) {
+            successStatus = 200;
+        }
+    }
+
+    public String resolvedUrl() {
+        String base = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+        String path = healthPath.startsWith("/") ? healthPath : "/" + healthPath;
+        return base + path;
+    }
+}

--- a/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/health/SystemHealthService.java
+++ b/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/health/SystemHealthService.java
@@ -1,0 +1,103 @@
+package edu.harvard.hms.dbmi.avillach.gateway.health;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
+import org.springframework.boot.http.client.ClientHttpRequestFactorySettings;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Pings each configured downstream in parallel, dedups by resolved URL, and rolls the results up into an aggregate RUNNING/DEGRADED verdict
+ * (spec 3.8). One ping per service (no cascade): each service's own deep {@code /actuator/health} already covers its dependencies, so the
+ * gateway does not double-probe a backend another service fronts. Downstreams that resolve to the same URL (e.g. hpds-open / hpds-auth
+ * collapsing onto a single HPDS instance in an AIO deployment) are probed once and the result is fanned back out to every name sharing that
+ * URL.
+ */
+public class SystemHealthService {
+
+    private static final Logger log = LoggerFactory.getLogger(SystemHealthService.class);
+
+    private final DownstreamHealthProperties props;
+    private final RestClient http;
+    private final ObjectMapper json = new ObjectMapper();
+
+    public SystemHealthService(DownstreamHealthProperties props) {
+        this.props = props;
+        // Health probes run off the request path (a background composer), but a slow/hanging downstream must still
+        // not tie up the aggregator indefinitely -- short, bounded connect/read timeouts, same pattern as
+        // SecurityConfig's auth-boundary clients.
+        ClientHttpRequestFactorySettings settings = ClientHttpRequestFactorySettings.defaults()
+            .withConnectTimeout(Duration.ofMillis(props.connectTimeoutMs())).withReadTimeout(Duration.ofMillis(props.readTimeoutMs()));
+        this.http = RestClient.builder().requestFactory(ClientHttpRequestFactoryBuilder.detect().build(settings)).build();
+    }
+
+    public AggregateHealth check() {
+        // Group entries by resolved URL so a shared backend is probed once.
+        Map<String, List<MonitoredDownstream>> byUrl = new LinkedHashMap<>();
+        for (MonitoredDownstream d : props.downstreams()) {
+            byUrl.computeIfAbsent(d.resolvedUrl(), k -> new ArrayList<>()).add(d);
+        }
+
+        List<CompletableFuture<List<DownstreamHealth>>> futures = new ArrayList<>();
+        for (Map.Entry<String, List<MonitoredDownstream>> e : byUrl.entrySet()) {
+            List<MonitoredDownstream> sharing = e.getValue();
+            MonitoredDownstream representative = sharing.get(0);
+            futures.add(CompletableFuture.supplyAsync(() -> {
+                boolean up = probe(representative);
+                String detail = up ? "up" : "unreachable";
+                List<DownstreamHealth> results = new ArrayList<>();
+                for (MonitoredDownstream d : sharing) {
+                    results.add(new DownstreamHealth(d.name(), d.resolvedUrl(), up, detail));
+                }
+                return results;
+            }));
+        }
+
+        List<DownstreamHealth> components = new ArrayList<>();
+        for (CompletableFuture<List<DownstreamHealth>> f : futures) {
+            components.addAll(f.join());
+        }
+        return AggregateHealth.from(components);
+    }
+
+    /** Probe a single downstream. Returns true iff it is considered up. Overridable for unit tests. */
+    protected boolean probe(MonitoredDownstream d) {
+        try {
+            RestClient.RequestBodySpec spec = http.method(HttpMethod.valueOf(d.method())).uri(d.resolvedUrl());
+            if (d.sendAppToken() && props.applicationToken() != null) {
+                spec = spec.header("Authorization", "Bearer " + props.applicationToken());
+            }
+            if ("POST".equalsIgnoreCase(d.method())) {
+                spec = spec.contentType(MediaType.APPLICATION_JSON).body(d.requestBody() == null ? "{}" : d.requestBody());
+            }
+            var response = spec.retrieve().toEntity(String.class);
+            if (response.getStatusCode().value() != d.successStatus()) {
+                return false;
+            }
+            if (d.requireStatusUp()) {
+                String body = response.getBody();
+                if (body == null) {
+                    return false;
+                }
+                JsonNode node = json.readTree(body);
+                return node.hasNonNull("status") && "UP".equalsIgnoreCase(node.get("status").asText());
+            }
+            return true;
+        } catch (Exception ex) {
+            log.warn("Health probe failed for {} ({}): {}", d.name(), d.resolvedUrl(), ex.getMessage());
+            return false;
+        }
+    }
+}

--- a/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/health/SystemStatusController.java
+++ b/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/health/SystemStatusController.java
@@ -1,0 +1,53 @@
+package edu.harvard.hms.dbmi.avillach.gateway.health;
+
+/**
+ * Backward-compatible replacement for the WAR's SystemService {@code /system/status}. Plain-text, unauthenticated (allow-listed in Task 3),
+ * throttled to one real deep check per window with a cached last result to avoid a DoS via the deep probes (spec 3.8).
+ *
+ * <p> Deliberately <em>not</em> a {@code @RestController}/{@code @GetMapping}: this monorepo's Phase-1 catch-all gateway route
+ * ({@code Path=/**} in application.yml) is registered as a {@code RouterFunction} bean, and Spring wires {@code RouterFunctionMapping} at
+ * order -1 -- ahead of {@code RequestMappingHandlerMapping} (order 0). An annotated controller mapping here would be silently shadowed and
+ * proxied to WildFly instead of answering locally. See {@link edu.harvard.hms.dbmi.avillach.gateway.config.HealthConfig} for the
+ * higher-precedence {@code RouterFunction} that actually exposes this at {@code GET /system/status}. (Actuator's own endpoints are
+ * unaffected: {@code WebMvcEndpointHandlerMapping} is order -100, ahead of the gateway route.)
+ */
+public class SystemStatusController {
+
+    static final String RUNNING = "RUNNING";
+    static final String DEGRADED = "ONE OR MORE COMPONENTS DEGRADED";
+
+    private final SystemHealthService health;
+    private final long windowMs;
+
+    private volatile String lastStatus = "UNTESTED";
+    private volatile long lastCheck = 0L;
+
+    public SystemStatusController(SystemHealthService health, long windowMs) {
+        this.health = health;
+        this.windowMs = windowMs;
+    }
+
+    public String status() {
+        long now = System.currentTimeMillis();
+        if (now - lastCheck < windowMs && lastCheck != 0L) {
+            return lastStatus;
+        }
+        synchronized (this) {
+            if (now - lastCheck < windowMs && lastCheck != 0L) {
+                return lastStatus;
+            }
+            lastCheck = now;
+            try {
+                lastStatus = health.check().running() ? RUNNING : DEGRADED;
+            } catch (Exception e) {
+                lastStatus = DEGRADED;
+            }
+            return lastStatus;
+        }
+    }
+
+    /** Test hook: reset the throttle window so the next call re-checks. */
+    void expireCacheForTest() {
+        this.lastCheck = 0L;
+    }
+}

--- a/services/pic-sure-gateway/src/main/resources/application-aio.yml
+++ b/services/pic-sure-gateway/src/main/resources/application-aio.yml
@@ -20,13 +20,13 @@ picsure:
       application-token: ${TOKEN_INTROSPECTION_TOKEN:}
       downstreams:
         - name: psama
+          # PSAMA now ships Actuator (Task 4); use its real deep /auth/actuator/health
+          # (db indicator). context-path is /auth. The transitional introspection-ping
+          # (POST /auth/token/inspect, {}, app token) is retained in git history as the
+          # fallback if a PSAMA deploy ever lags the actuator rollout.
           base-url: ${PSAMA_URL:http://psama:8090}
-          health-path: /auth/token/inspect
-          method: POST
-          request-body: "{}"
-          send-app-token: true
-          success-status: 200
-          require-status-up: false
+          health-path: /auth/actuator/health
+          require-status-up: true
         - name: visualization
           base-url: ${VISUALIZATION_URL:http://visualization}
           health-path: /actuator/health

--- a/services/pic-sure-gateway/src/main/resources/application-aio.yml
+++ b/services/pic-sure-gateway/src/main/resources/application-aio.yml
@@ -40,6 +40,6 @@ picsure:
           health-path: /actuator/health
           require-status-up: true
         - name: dictionary
-          base-url: ${DICTIONARY_URL:http://dictionary-api:8080}
+          base-url: ${DICTIONARY_URL:http://dictionary-api}
           health-path: /actuator/health
           require-status-up: true

--- a/services/pic-sure-gateway/src/main/resources/application-aio.yml
+++ b/services/pic-sure-gateway/src/main/resources/application-aio.yml
@@ -9,3 +9,37 @@ picsure:
     security:
       introspection-url: ${TOKEN_INTROSPECTION_URL:http://psama:8090/auth/token/inspect}
       open-access-validate-url: ${OPEN_ACCESS_VALIDATE_URL:http://psama:8090/auth/open/validate}
+    # Phase 3 (Task 13) — deep-health downstream list the gateway aggregates into
+    # /system/status and /actuator/health. AIO service DNS on the picsure network.
+    # PSAMA uses the transitional introspection-ping (active:false = reachable) until
+    # its Actuator lands (Task 4); HPDS/dictionary report DOWN until their Actuator
+    # (Tasks 5/6). visualization + logging already expose health today.
+    health:
+      connect-timeout-ms: 2000
+      read-timeout-ms: 3000
+      application-token: ${TOKEN_INTROSPECTION_TOKEN:}
+      downstreams:
+        - name: psama
+          base-url: ${PSAMA_URL:http://psama:8090}
+          health-path: /auth/token/inspect
+          method: POST
+          request-body: "{}"
+          send-app-token: true
+          success-status: 200
+          require-status-up: false
+        - name: visualization
+          base-url: ${VISUALIZATION_URL:http://visualization}
+          health-path: /actuator/health
+          require-status-up: true
+        - name: logging
+          base-url: ${LOGGING_HEALTH_URL:http://pic-sure-logging}
+          health-path: /health
+          require-status-up: false
+        - name: hpds
+          base-url: ${HPDS_URL:http://hpds:8080}
+          health-path: /actuator/health
+          require-status-up: true
+        - name: dictionary
+          base-url: ${DICTIONARY_URL:http://dictionary-api:8080}
+          health-path: /actuator/health
+          require-status-up: true

--- a/services/pic-sure-gateway/src/main/resources/application.yml
+++ b/services/pic-sure-gateway/src/main/resources/application.yml
@@ -6,6 +6,23 @@ spring:
       server:
         webmvc:
           routes:
+            # Phase 3 (Task 1): explicit clean-prefix route for the logging service,
+            # replacing the legacy /proxy/pic-sure-logging relay. order 100 < 1000 so it
+            # wins over the catch-all. StripPrefix=1 drops the leading /logging segment
+            # because the logging service (Javalin) serves its API at root (/audit,
+            # /health, /info) — mirroring the old /proxy relay's prefix strip. /logging is
+            # on the Phase-2 introspection allow-list, so it is not authenticated.
+            # NOTE: /dictionary and /uploader are intentionally NOT added yet — they are
+            # authenticated and require the PSAMA access-rule migration to the new path
+            # shapes first (otherwise a /dictionary/x request is denied). /hpds and
+            # /visualization are out of scope (Phase 4 query-service ingress / dead WAR).
+            - id: logging
+              uri: ${LOGGING_URL:http://pic-sure-logging}
+              order: 100
+              predicates:
+                - Path=/logging/**
+              filters:
+                - StripPrefix=1
             # Phase 1: single low-priority catch-all — everything forwards to WildFly
             # with the legacy context path re-prefixed. Public URLs are unchanged.
             - id: legacy-wildfly-catchall

--- a/services/pic-sure-gateway/src/main/resources/application.yml
+++ b/services/pic-sure-gateway/src/main/resources/application.yml
@@ -12,15 +12,31 @@ spring:
             # because the logging service (Javalin) serves its API at root (/audit,
             # /health, /info) — mirroring the old /proxy relay's prefix strip. /logging is
             # on the Phase-2 introspection allow-list, so it is not authenticated.
-            # NOTE: /dictionary and /uploader are intentionally NOT added yet — they are
-            # authenticated and require the PSAMA access-rule migration to the new path
-            # shapes first (otherwise a /dictionary/x request is denied). /hpds and
-            # /visualization are out of scope (Phase 4 query-service ingress / dead WAR).
+            # /dictionary and /uploader are AUTHENTICATED (not on the allow-list): the
+            # introspection filter runs on the pre-strip public path (Target Service =
+            # /dictionary/x), which the Phase-3 PSAMA access-rule migration now authorizes
+            # (^/dictionary(/.*)?$ / ^/uploader(/.*)?$). Same StripPrefix=1 as /logging
+            # (dictionary-api + uploader serve their APIs at root). /hpds and /visualization
+            # remain out of scope (Phase 4 query-service ingress / dead WAR).
             - id: logging
               uri: ${LOGGING_URL:http://pic-sure-logging}
               order: 100
               predicates:
                 - Path=/logging/**
+              filters:
+                - StripPrefix=1
+            - id: dictionary
+              uri: ${DICTIONARY_URL:http://dictionary-api}
+              order: 100
+              predicates:
+                - Path=/dictionary/**
+              filters:
+                - StripPrefix=1
+            - id: uploader
+              uri: ${UPLOADER_URL:http://uploader:8080}
+              order: 100
+              predicates:
+                - Path=/uploader/**
               filters:
                 - StripPrefix=1
             # Phase 1: single low-priority catch-all — everything forwards to WildFly

--- a/services/pic-sure-gateway/src/main/resources/application.yml
+++ b/services/pic-sure-gateway/src/main/resources/application.yml
@@ -26,6 +26,11 @@ management:
       show-details: when_authorized # detail gated; Phase 6 supplies the app token
       probes:
         enabled: true # /actuator/health/liveness stays shallow-open
+      group:
+        liveness:
+          include: livenessState # pin liveness to the app's own state; downstreams
+          # (registered as the "downstreams" top-level contributor) must never flip
+          # this probe DOWN -- deploy/container healthchecks poll this endpoint.
   health:
     defaults:
       enabled: true

--- a/services/pic-sure-gateway/src/main/resources/application.yml
+++ b/services/pic-sure-gateway/src/main/resources/application.yml
@@ -23,8 +23,12 @@ management:
         include: health,info,prometheus,metrics
   endpoint:
     health:
+      show-details: when_authorized # detail gated; Phase 6 supplies the app token
       probes:
-        enabled: true
+        enabled: true # /actuator/health/liveness stays shallow-open
+  health:
+    defaults:
+      enabled: true
   metrics:
     distribution:
       # Publish client-observable latency percentiles per route for the Phase-1

--- a/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/config/HealthConfigTest.java
+++ b/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/config/HealthConfigTest.java
@@ -1,0 +1,27 @@
+package edu.harvard.hms.dbmi.avillach.gateway.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import edu.harvard.hms.dbmi.avillach.gateway.health.DownstreamHealthProperties;
+import edu.harvard.hms.dbmi.avillach.gateway.health.SystemHealthService;
+
+/** Proves HealthConfig registers the Task-9 beans so the /system/status controller and the actuator composite can consume them. */
+@SpringBootTest
+class HealthConfigTest {
+
+    @Autowired
+    private SystemHealthService systemHealthService;
+
+    @Autowired
+    private DownstreamHealthProperties downstreamHealthProperties;
+
+    @Test
+    void registersHealthBeans() {
+        assertThat(systemHealthService).isNotNull();
+        assertThat(downstreamHealthProperties).isNotNull();
+    }
+}

--- a/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/health/ActuatorHealthEndpointIT.java
+++ b/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/health/ActuatorHealthEndpointIT.java
@@ -1,0 +1,70 @@
+package edu.harvard.hms.dbmi.avillach.gateway.health;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+/**
+ * End-to-end: hits the real {@code GET /actuator/health} HTTP endpoint (not just the {@link DownstreamHealthContributor} bean directly, as
+ * {@link ActuatorHealthIT} does) and asserts the JSON composite shows the "hpds" component DOWN. {@code show-details} is forced to
+ * {@code always} for this test context only -- production defaults to {@code when_authorized} (Phase 6 gates detail by app token; see
+ * application.yml).
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = "management.endpoint.health.show-details=always")
+class ActuatorHealthEndpointIT {
+
+    static WireMockServer hpds;
+
+    @Autowired
+    private TestRestTemplate rest;
+
+    @BeforeAll
+    static void start() {
+        hpds = new WireMockServer(options().dynamicPort().http2PlainDisabled(true));
+        hpds.start();
+        hpds.stubFor(get(urlEqualTo("/actuator/health")).willReturn(aResponse().withStatus(503)));
+    }
+
+    @AfterAll
+    static void stop() {
+        hpds.stop();
+    }
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry r) {
+        r.add("picsure.gateway.health.downstreams[0].name", () -> "hpds");
+        r.add("picsure.gateway.health.downstreams[0].base-url", () -> "http://localhost:" + hpds.port());
+        r.add("picsure.gateway.health.downstreams[0].require-status-up", () -> "true");
+    }
+
+    @Test
+    void actuatorHealthShowsDownDownstreamAsDown() throws Exception {
+        ResponseEntity<String> response = rest.getForEntity("/actuator/health", String.class);
+
+        JsonNode body = new ObjectMapper().readTree(response.getBody());
+        JsonNode hpdsComponent = body.path("components").path("downstreams").path("components").path("hpds");
+
+        assertThat(hpdsComponent.path("status").asText()).isEqualTo("DOWN");
+        assertThat(body.path("status").asText()).isEqualTo("DOWN");
+    }
+}

--- a/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/health/ActuatorHealthEndpointIT.java
+++ b/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/health/ActuatorHealthEndpointIT.java
@@ -67,4 +67,21 @@ class ActuatorHealthEndpointIT {
         assertThat(hpdsComponent.path("status").asText()).isEqualTo("DOWN");
         assertThat(body.path("status").asText()).isEqualTo("DOWN");
     }
+
+    /**
+     * Pins the operational invariant this class exists to guard: {@code downstreams} is a top-level composite contributor, so a single DOWN
+     * sibling flips the ROOT {@code /actuator/health} to DOWN (asserted above) -- but {@code /actuator/health/liveness} is pinned via
+     * {@code management.endpoint.health.group.liveness.include: livenessState} (application.yml) and must stay UP regardless. Deploy
+     * smoke-polls and container healthchecks must probe this shallow endpoint, not the aggregate root, or a degraded/restarting downstream
+     * (e.g. HPDS) would fail the gateway's own healthcheck and could kill the container.
+     */
+    @Test
+    void livenessStaysUpWhenDownstreamIsDown() throws Exception {
+        ResponseEntity<String> response = rest.getForEntity("/actuator/health/liveness", String.class);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+
+        JsonNode body = new ObjectMapper().readTree(response.getBody());
+        assertThat(body.path("status").asText()).isEqualTo("UP");
+    }
 }

--- a/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/health/ActuatorHealthIT.java
+++ b/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/health/ActuatorHealthIT.java
@@ -1,0 +1,74 @@
+package edu.harvard.hms.dbmi.avillach.gateway.health;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.HealthContributor;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+/**
+ * Proves {@link DownstreamHealthContributor} surfaces each monitored downstream as its own health component, driven by real HTTP probes
+ * (via WireMock) through the real Spring context -- an up downstream reports UP, a down downstream reports DOWN.
+ */
+@SpringBootTest
+class ActuatorHealthIT {
+
+    static WireMockServer hpds;
+    static WireMockServer psama;
+
+    @Autowired
+    DownstreamHealthContributor contributor;
+
+    @BeforeAll
+    static void start() {
+        hpds = new WireMockServer(options().dynamicPort().http2PlainDisabled(true));
+        psama = new WireMockServer(options().dynamicPort().http2PlainDisabled(true));
+        hpds.start();
+        psama.start();
+        hpds.stubFor(get(urlEqualTo("/actuator/health")).willReturn(okJson("{\"status\":\"UP\"}")));
+        psama.stubFor(get(urlEqualTo("/actuator/health")).willReturn(aResponse().withStatus(503)));
+    }
+
+    @AfterAll
+    static void stop() {
+        hpds.stop();
+        psama.stop();
+    }
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry r) {
+        r.add("picsure.gateway.health.downstreams[0].name", () -> "hpds");
+        r.add("picsure.gateway.health.downstreams[0].base-url", () -> "http://localhost:" + hpds.port());
+        r.add("picsure.gateway.health.downstreams[0].require-status-up", () -> "true");
+        r.add("picsure.gateway.health.downstreams[1].name", () -> "psama");
+        r.add("picsure.gateway.health.downstreams[1].base-url", () -> "http://localhost:" + psama.port());
+        r.add("picsure.gateway.health.downstreams[1].require-status-up", () -> "true");
+    }
+
+    @Test
+    void exposesDownstreamAsHealthComponent() {
+        HealthContributor c = contributor.getContributor("hpds");
+        assertThat(c).isInstanceOf(HealthIndicator.class);
+        assertThat(((HealthIndicator) c).health().getStatus().getCode()).isEqualTo("UP");
+    }
+
+    @Test
+    void exposesDownDownstreamAsDown() {
+        HealthContributor c = contributor.getContributor("psama");
+        assertThat(c).isInstanceOf(HealthIndicator.class);
+        assertThat(((HealthIndicator) c).health().getStatus().getCode()).isEqualTo("DOWN");
+    }
+}

--- a/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/health/RecordingSystemHealthService.java
+++ b/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/health/RecordingSystemHealthService.java
@@ -1,0 +1,70 @@
+package edu.harvard.hms.dbmi.avillach.gateway.health;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Test-only {@link SystemHealthService} subclass that overrides the protected {@code probe} override point so unit tests can exercise dedup
+ * / rollup semantics without any real HTTP traffic. The real HTTP path is covered by {@link SystemHealthServiceIT} via WireMock.
+ */
+class RecordingSystemHealthService extends SystemHealthService {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final List<String> probedUrls = new CopyOnWriteArrayList<>();
+    private final Set<String> downUrls = ConcurrentHashMap.newKeySet();
+    private final Map<String, Stub> stubs = new ConcurrentHashMap<>();
+
+    RecordingSystemHealthService(DownstreamHealthProperties props) {
+        super(props);
+    }
+
+    List<String> probedUrls() {
+        return Collections.unmodifiableList(probedUrls);
+    }
+
+    void markDown(String resolvedUrl) {
+        downUrls.add(resolvedUrl);
+    }
+
+    void stub(String resolvedUrl, int status, String body) {
+        stubs.put(resolvedUrl, new Stub(status, body));
+    }
+
+    @Override
+    protected boolean probe(MonitoredDownstream d) {
+        String url = d.resolvedUrl();
+        probedUrls.add(url);
+
+        if (downUrls.contains(url)) {
+            return false;
+        }
+
+        Stub stub = stubs.get(url);
+        if (stub == null) {
+            return true;
+        }
+        if (stub.status() != d.successStatus()) {
+            return false;
+        }
+        if (d.requireStatusUp()) {
+            try {
+                JsonNode node = MAPPER.readTree(stub.body());
+                return node.hasNonNull("status") && "UP".equalsIgnoreCase(node.get("status").asText());
+            } catch (Exception ex) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private record Stub(int status, String body) {
+    }
+}

--- a/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/health/SystemHealthServiceIT.java
+++ b/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/health/SystemHealthServiceIT.java
@@ -1,0 +1,68 @@
+package edu.harvard.hms.dbmi.avillach.gateway.health;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+/**
+ * Exercises the real HTTP path (unlike {@link SystemHealthServiceTest}, which stubs {@code probe} directly): a Spring Boot Actuator-style
+ * sibling ({@code {"status":"UP"}}), a Javalin-logging-style {@code /health} (200 with a differently-shaped body, no status predicate), and
+ * a downstream that is down.
+ */
+class SystemHealthServiceIT {
+
+    static WireMockServer actuatorUp; // Spring Boot sibling: {"status":"UP"}
+    static WireMockServer loggingUp; // Javalin /health: 200 {"status":"healthy"}
+    static WireMockServer down;
+
+    @BeforeAll
+    static void start() {
+        // http2PlainDisabled avoids a known JDK HttpClient <-> WireMock(Jetty) h2c upgrade bug that manifests as
+        // "RST_STREAM: Stream cancelled" when RestClient's default JDK-backed request factory is used.
+        actuatorUp = new WireMockServer(options().dynamicPort().http2PlainDisabled(true));
+        loggingUp = new WireMockServer(options().dynamicPort().http2PlainDisabled(true));
+        down = new WireMockServer(options().dynamicPort().http2PlainDisabled(true));
+        actuatorUp.start();
+        loggingUp.start();
+        down.start();
+        actuatorUp.stubFor(get(urlEqualTo("/actuator/health")).willReturn(okJson("{\"status\":\"UP\"}")));
+        loggingUp.stubFor(get(urlEqualTo("/health")).willReturn(okJson("{\"status\":\"healthy\"}")));
+        down.stubFor(get(urlEqualTo("/actuator/health")).willReturn(aResponse().withStatus(503)));
+    }
+
+    @AfterAll
+    static void stop() {
+        actuatorUp.stop();
+        loggingUp.stop();
+        down.stop();
+    }
+
+    @Test
+    void aggregatesDeepActuatorAndJavalinHealthAndOneDownDegradesIt() {
+        DownstreamHealthProperties props = new DownstreamHealthProperties(
+            List.of(
+                new MonitoredDownstream("psama", "http://localhost:" + actuatorUp.port(), null, null, null, false, 200, true),
+                new MonitoredDownstream("logging", "http://localhost:" + loggingUp.port(), "/health", null, null, false, 200, false),
+                new MonitoredDownstream("hpds", "http://localhost:" + down.port(), null, null, null, false, 200, true)
+            ), 500, 1000, null
+        );
+
+        AggregateHealth agg = new SystemHealthService(props).check();
+
+        assertThat(agg.running()).isFalse(); // hpds down -> DEGRADED
+        assertThat(agg.components()).filteredOn(c -> c.name().equals("psama")).allMatch(DownstreamHealth::up);
+        assertThat(agg.components()).filteredOn(c -> c.name().equals("logging")).allMatch(DownstreamHealth::up);
+        assertThat(agg.components()).filteredOn(c -> c.name().equals("hpds")).noneMatch(DownstreamHealth::up);
+    }
+}

--- a/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/health/SystemHealthServiceTest.java
+++ b/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/health/SystemHealthServiceTest.java
@@ -1,0 +1,52 @@
+package edu.harvard.hms.dbmi.avillach.gateway.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class SystemHealthServiceTest {
+
+    private MonitoredDownstream up(String name, String url) {
+        return new MonitoredDownstream(name, url, "/actuator/health", "GET", null, false, 200, false);
+    }
+
+    @Test
+    void dedupsByResolvedUrl() {
+        // In single-HPDS envs the open and auth HPDS collapse onto one URL.
+        DownstreamHealthProperties props = new DownstreamHealthProperties(
+            List.of(up("hpds-open", "http://hpds:8080"), up("hpds-auth", "http://hpds:8080")), 1000, 2000, null
+        );
+        RecordingSystemHealthService svc = new RecordingSystemHealthService(props);
+        AggregateHealth agg = svc.check();
+        assertThat(svc.probedUrls()).containsExactly("http://hpds:8080/actuator/health");
+        assertThat(agg.components()).extracting(DownstreamHealth::name).containsExactlyInAnyOrder("hpds-open", "hpds-auth");
+        assertThat(agg.running()).isTrue();
+    }
+
+    @Test
+    void oneDownMakesAggregateDegraded() {
+        DownstreamHealthProperties props =
+            new DownstreamHealthProperties(List.of(up("a", "http://a:8080"), up("b", "http://b:8080")), 1000, 2000, null);
+        RecordingSystemHealthService svc = new RecordingSystemHealthService(props);
+        svc.markDown("http://b:8080/actuator/health");
+        AggregateHealth agg = svc.check();
+        assertThat(agg.running()).isFalse();
+        assertThat(agg.components()).anySatisfy(c -> {
+            assertThat(c.name()).isEqualTo("b");
+            assertThat(c.up()).isFalse();
+        });
+    }
+
+    @Test
+    void successPredicateRequiresStatusUpBody() {
+        MonitoredDownstream strict = new MonitoredDownstream("dict", "http://dict:8080", "/actuator/health", "GET", null, false, 200, true);
+        RecordingSystemHealthService svc =
+            new RecordingSystemHealthService(new DownstreamHealthProperties(List.of(strict), 1000, 2000, null));
+        svc.stub("http://dict:8080/actuator/health", 200, "{\"status\":\"DOWN\"}");
+        assertThat(svc.check().running()).isFalse();
+        svc.stub("http://dict:8080/actuator/health", 200, "{\"status\":\"UP\"}");
+        assertThat(svc.check().running()).isTrue();
+    }
+}

--- a/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/health/SystemStatusControllerTest.java
+++ b/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/health/SystemStatusControllerTest.java
@@ -1,0 +1,52 @@
+package edu.harvard.hms.dbmi.avillach.gateway.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+class SystemStatusControllerTest {
+
+    /** Counts how many times the underlying aggregate check runs, to prove throttling. */
+    static class CountingHealthService extends SystemHealthService {
+        final AtomicInteger calls = new AtomicInteger();
+        volatile boolean running = true;
+
+        CountingHealthService() {
+            super(new DownstreamHealthProperties(List.of(), 1000, 2000, null));
+        }
+
+        @Override
+        public AggregateHealth check() {
+            calls.incrementAndGet();
+            return new AggregateHealth(running, List.of());
+        }
+    }
+
+    @Test
+    void mapsRunningAndDegradedStrings() {
+        CountingHealthService svc = new CountingHealthService();
+        SystemStatusController controller = new SystemStatusController(svc, 60_000L);
+
+        svc.running = true;
+        assertThat(controller.status()).isEqualTo("RUNNING");
+
+        controller.expireCacheForTest();
+        svc.running = false;
+        assertThat(controller.status()).isEqualTo("ONE OR MORE COMPONENTS DEGRADED");
+    }
+
+    @Test
+    void throttlesRepeatedCallsToOnePerWindow() {
+        CountingHealthService svc = new CountingHealthService();
+        SystemStatusController controller = new SystemStatusController(svc, 60_000L);
+
+        controller.status();
+        controller.status();
+        controller.status();
+
+        assertThat(svc.calls.get()).isEqualTo(1);
+    }
+}

--- a/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/health/SystemStatusEndpointIT.java
+++ b/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/health/SystemStatusEndpointIT.java
@@ -1,0 +1,64 @@
+package edu.harvard.hms.dbmi.avillach.gateway.health;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+/**
+ * End-to-end wiring check over real HTTP: {@code /system/status} composed through the real Spring context (HealthConfig bean ->
+ * SystemHealthService -> SystemStatusController), against a WireMock downstream that is down, proving the legacy plain-text DEGRADED
+ * contract survives the full stack, not just the unit-level fake in {@link SystemStatusControllerTest}.
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class SystemStatusEndpointIT {
+
+    static WireMockServer down;
+
+    @Autowired
+    private TestRestTemplate rest;
+
+    @BeforeAll
+    static void start() {
+        down = new WireMockServer(options().dynamicPort().http2PlainDisabled(true));
+        down.start();
+        down.stubFor(get(urlEqualTo("/actuator/health")).willReturn(aResponse().withStatus(503)));
+    }
+
+    @AfterAll
+    static void stop() {
+        down.stop();
+    }
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry r) {
+        r.add("picsure.gateway.health.downstreams[0].name", () -> "hpds");
+        r.add("picsure.gateway.health.downstreams[0].base-url", () -> "http://localhost:" + down.port());
+        r.add("picsure.gateway.health.downstreams[0].require-status-up", () -> "true");
+    }
+
+    @Test
+    void reportsDegradedTextOverHttpWhenADownstreamIsDown() {
+        ResponseEntity<String> response = rest.getForEntity("/system/status", String.class);
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getHeaders().getContentType()).isNotNull().matches(t -> t.isCompatibleWith(MediaType.TEXT_PLAIN));
+        assertThat(response.getBody()).isEqualTo("ONE OR MORE COMPONENTS DEGRADED");
+    }
+}

--- a/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/routing/LoggingRouteTest.java
+++ b/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/routing/LoggingRouteTest.java
@@ -1,0 +1,66 @@
+package edu.harvard.hms.dbmi.avillach.gateway.routing;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+/**
+ * Phase 3 (Task 1): the explicit {@code /logging/**} route forwards to the logging service with the leading
+ * {@code /logging} segment stripped (the logging service serves its API at root — {@code /audit}, {@code /health}).
+ * This replaces the legacy {@code /proxy/pic-sure-logging} relay. The request must reach the logging stub, NOT the
+ * WildFly catch-all — proving the higher-priority route (order 100) wins.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class LoggingRouteTest {
+
+    static WireMockServer loggingStub;
+
+    @DynamicPropertySource
+    static void loggingUrl(DynamicPropertyRegistry registry) {
+        loggingStub = new WireMockServer(options().dynamicPort().http2PlainDisabled(true));
+        loggingStub.start();
+        registry.add("LOGGING_URL", loggingStub::baseUrl);
+    }
+
+    @AfterAll
+    static void stopStub() {
+        loggingStub.stop();
+    }
+
+    @BeforeEach
+    void resetStub() {
+        loggingStub.resetAll();
+        // The logging service serves at root, so after StripPrefix the gateway forwards to /audit.
+        loggingStub.stubFor(get(urlPathEqualTo("/audit"))
+            .willReturn(aResponse().withStatus(200).withBody("logging-ok")));
+    }
+
+    @Autowired
+    private TestRestTemplate rest;
+
+    @Test
+    void forwardsLoggingPathToLoggingServiceWithPrefixStripped() {
+        ResponseEntity<String> response = rest.getForEntity("/logging/audit", String.class);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isEqualTo("logging-ok");
+        // The /logging prefix was stripped: the logging service saw /audit, never /logging/audit.
+        loggingStub.verify(getRequestedFor(urlEqualTo("/audit")));
+    }
+}

--- a/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/routing/NoRegistryRouteTest.java
+++ b/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/routing/NoRegistryRouteTest.java
@@ -19,9 +19,8 @@ import org.springframework.core.env.Environment;
  * (behavior-pinning, not a weak bean-name check) — the gateway exposes NO {@code /info/resources} or
  * {@code /resource} route. Those paths fall through to the WildFly catch-all until decommission.
  *
- * <p>Phase-3 configured routes today: {@code logging} (Task 1) + {@code legacy-wildfly-catchall} (Phase 1).
- * {@code dictionary}/{@code uploader} are deferred until the PSAMA access-rule migration, so they are not yet
- * present — the load-bearing assertion is that no registry id ever appears.
+ * <p>Phase-3 configured routes: {@code logging}, {@code dictionary}, {@code uploader} (Task 1) +
+ * {@code legacy-wildfly-catchall} (Phase 1). The load-bearing assertion is that no registry id ever appears.
  */
 @SpringBootTest
 class NoRegistryRouteTest {
@@ -41,7 +40,7 @@ class NoRegistryRouteTest {
     @Test
     void exposesOnlyTheExpectedRouteIdsAndNoRegistryRoute() {
         Set<String> ids = configuredRouteIds();
-        assertThat(ids).containsExactlyInAnyOrder("logging", "legacy-wildfly-catchall");
+        assertThat(ids).containsExactlyInAnyOrder("logging", "dictionary", "uploader", "legacy-wildfly-catchall");
         assertThat(ids).noneMatch(id -> {
             String lower = id.toLowerCase();
             return lower.contains("resource") || lower.contains("info-resources");

--- a/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/routing/NoRegistryRouteTest.java
+++ b/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/routing/NoRegistryRouteTest.java
@@ -1,0 +1,50 @@
+package edu.harvard.hms.dbmi.avillach.gateway.routing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
+
+/**
+ * Spec 3.3 + review P-mi5: the resource registry is removed. Assert on the configured route IDS
+ * (behavior-pinning, not a weak bean-name check) — the gateway exposes NO {@code /info/resources} or
+ * {@code /resource} route. Those paths fall through to the WildFly catch-all until decommission.
+ *
+ * <p>Phase-3 configured routes today: {@code logging} (Task 1) + {@code legacy-wildfly-catchall} (Phase 1).
+ * {@code dictionary}/{@code uploader} are deferred until the PSAMA access-rule migration, so they are not yet
+ * present — the load-bearing assertion is that no registry id ever appears.
+ */
+@SpringBootTest
+class NoRegistryRouteTest {
+
+    @Autowired
+    Environment env;
+
+    @SuppressWarnings("unchecked")
+    private Set<String> configuredRouteIds() {
+        List<Map<String, Object>> routes = Binder.get(env)
+            .bind("spring.cloud.gateway.server.webmvc.routes",
+                Bindable.listOf((Class<Map<String, Object>>) (Class<?>) Map.class))
+            .orElse(List.of());
+        return routes.stream().map(r -> String.valueOf(r.get("id"))).collect(Collectors.toSet());
+    }
+
+    @Test
+    void exposesOnlyTheExpectedRouteIdsAndNoRegistryRoute() {
+        Set<String> ids = configuredRouteIds();
+        assertThat(ids).containsExactlyInAnyOrder("logging", "legacy-wildfly-catchall");
+        assertThat(ids).noneMatch(id -> {
+            String lower = id.toLowerCase();
+            return lower.contains("resource") || lower.contains("info-resources");
+        });
+    }
+}


### PR DESCRIPTION
**WIP / draft** — Phase 3 of the SCG-MVC gateway migration. Stacked per the design spec §9 (Branching & Delivery Strategy).

**Base:** `pic_sure_api_rewrite` (integration branch, currently Phases 0–2). Diff = Phase 3 only.

**In this PR so far (gateway health cluster — complete, 79 tests):**
- `SystemHealthService` — config-driven deep-health composition with downstream URL dedup, DOWN-if-any rollup, bounded probe timeouts.
- `/system/status` — legacy throttled plain-text contract, served locally (high-precedence `RouterFunction` so the catch-all can't shadow it).
- `/actuator/health` — composite surfacing each downstream as a component; `/actuator/health/liveness` pinned shallow so a degraded sibling can't fail the gateway container/deploy.

**Still to come in Phase 3 (WIP):** `/logging` clean-prefix route; sibling deep-health actuator adds (PSAMA, HPDS, dictionary, visualization; confirm Javalin logging `/health`); the health-list wiring; PSAMA access-rule migration + the authenticated `/dictionary` `/uploader` routes; registry-removal assertion.
