### PR TITLE
PR15/15: build gates — enforcer convergence, Boot 3.5.16, wrapper, formatter 4.35, secrets CI, Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/github-actions-test.yml
+++ b/.github/workflows/github-actions-test.yml
@@ -13,7 +13,8 @@ jobs:
         with:
           java-version: '25'
           distribution: 'temurin'
+          cache: maven
       - name: Test with Maven
-        run: mvn --update-snapshots test
+        run: ./mvnw --update-snapshots test
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/pic-sure-auth-microapp-test.yml
+++ b/.github/workflows/pic-sure-auth-microapp-test.yml
@@ -17,6 +17,6 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Test with Maven
-        run: mvn -B -pl services/pic-sure-auth-microapp/pic-sure-auth-services -am verify
+        run: ./mvnw -B -pl services/pic-sure-auth-microapp/pic-sure-auth-services -am verify
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/pic-sure-hpds-test.yml
+++ b/.github/workflows/pic-sure-hpds-test.yml
@@ -17,6 +17,6 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Test with Maven
-        run: mvn -B -pl services/pic-sure-hpds/common,services/pic-sure-hpds/data,services/pic-sure-hpds/etl,services/pic-sure-hpds/processing,services/pic-sure-hpds/service,services/pic-sure-hpds/genomic-processor,services/pic-sure-hpds/war,services/pic-sure-hpds/docker -am verify
+        run: ./mvnw -B -pl services/pic-sure-hpds/common,services/pic-sure-hpds/data,services/pic-sure-hpds/etl,services/pic-sure-hpds/processing,services/pic-sure-hpds/service,services/pic-sure-hpds/genomic-processor,services/pic-sure-hpds/war,services/pic-sure-hpds/docker -am verify
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/pic-sure-logging-test.yml
+++ b/.github/workflows/pic-sure-logging-test.yml
@@ -17,6 +17,6 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Test with Maven
-        run: mvn -B -pl services/pic-sure-logging -am verify
+        run: ./mvnw -B -pl services/pic-sure-logging -am verify
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/pic-sure-services-test.yml
+++ b/.github/workflows/pic-sure-services-test.yml
@@ -17,6 +17,6 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Test with Maven
-        run: mvn -B -pl services/pic-sure-services/info-service,services/pic-sure-services/uploader -am verify
+        run: ./mvnw -B -pl services/pic-sure-services/info-service,services/pic-sure-services/uploader -am verify
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/picsure-dictionary-test.yml
+++ b/.github/workflows/picsure-dictionary-test.yml
@@ -17,6 +17,6 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Test with Maven
-        run: mvn -B -pl services/picsure-dictionary,services/picsure-dictionary/aggregate,services/picsure-dictionary/dictionaryweights -am verify
+        run: ./mvnw -B -pl services/picsure-dictionary,services/picsure-dictionary/aggregate,services/picsure-dictionary/dictionaryweights -am verify
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -1,0 +1,19 @@
+name: secrets scan
+on:
+  pull_request:
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Install gitleaks 8.30.1 (checksum-verified)
+        run: |
+          curl -sSfL -o /tmp/gitleaks.tar.gz https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz
+          echo "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  /tmp/gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+      - name: Scan PR commits
+        run: >
+          /tmp/gitleaks git --redact --no-banner
+          --log-opts="${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}" .

--- a/.github/workflows/visualization-service-test.yml
+++ b/.github/workflows/visualization-service-test.yml
@@ -17,6 +17,6 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Test with Maven
-        run: mvn -B -pl services/pic-sure-visualization-service -am verify
+        run: ./mvnw -B -pl services/pic-sure-visualization-service -am verify
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,4 @@
+# gitleaks false-positive fingerprints — one per line:
+#   <commit>:<file>:<rule-id>:<line>
+# Put a comment above each entry explaining why the finding is safe.
+# Honored by the pre-commit hook, the pre-push hook, and the secrets-scan workflow.

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/README.md
+++ b/README.md
@@ -49,3 +49,21 @@ Formatting: Spotless (Eclipse formatter, config inherited from the root) — `mv
 ## Migration
 
 Design docs and the implementation plan live under `docs/superpowers/`. This migration is tracked under Jira epic ALS-10463 and is delivered as a stack of sequential, independently-green PRs — reviewed and merged bottom-up onto the rewrite integration branch. The legacy WildFly modules (`pic-sure-api-war`, `pic-sure-api-data`, `pic-sure-util`, `pic-sure-resources`) are removed in the final PR of the stack.
+
+## Git hooks
+
+Two optional-but-recommended local hooks live in `code-formatting/`:
+
+- `pre-commit.sh` — formats staged Java files with Spotless and blocks commits containing secrets (gitleaks).
+- `pre-push.sh` — blocks pushes whose outgoing commits contain secrets (gitleaks).
+
+Install both:
+
+```sh
+cp code-formatting/pre-commit.sh .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+cp code-formatting/pre-push.sh .git/hooks/pre-push && chmod +x .git/hooks/pre-push
+```
+
+Secret-scan false positives: add a `gitleaks:allow` trailing comment on the flagged line, or record
+the finding's fingerprint in `.gitleaksignore` with a comment explaining why it is safe. CI runs the
+same scan on every pull request (`.github/workflows/secrets-scan.yml`).

--- a/code-formatting/pre-push.sh
+++ b/code-formatting/pre-push.sh
@@ -23,7 +23,7 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
     else
         range="$remote_sha..$local_sha"
     fi
-    if ! gitleaks git --redact --no-banner --log-opts="$range"; then
+    if ! gitleaks git --redact --no-banner --log-opts="$range" </dev/null; then
         echo 'gitleaks detected a secret in outgoing commits. Push aborted.' 1>&2
         echo 'Fix the commit, or for a false positive record its fingerprint in .gitleaksignore.' 1>&2
         exit 1

--- a/code-formatting/pre-push.sh
+++ b/code-formatting/pre-push.sh
@@ -1,0 +1,32 @@
+#!/bin/sh -e
+# Git pre-push hook: block pushing commits that contain secrets.
+# Install: cp code-formatting/pre-push.sh .git/hooks/pre-push && chmod +x .git/hooks/pre-push
+# Skip once: NO_VERIFY=1 git push ...   (or git push --no-verify)
+
+if [ "$NO_VERIFY" ]; then
+    echo 'pre-push checks skipped' 1>&2
+    exit 0
+fi
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+    echo 'warning: gitleaks not installed - skipping pre-push secret scan. Install: brew install gitleaks' 1>&2
+    exit 0
+fi
+
+# stdin lines: <local ref> <local sha> <remote ref> <remote sha>
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+    # branch deletion: nothing outgoing
+    [ "$local_sha" = "0000000000000000000000000000000000000000" ] && continue
+    if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+        # new branch: scan commits not yet on any remote
+        range="$local_sha --not --remotes"
+    else
+        range="$remote_sha..$local_sha"
+    fi
+    if ! gitleaks git --redact --no-banner --log-opts="$range"; then
+        echo 'gitleaks detected a secret in outgoing commits. Push aborted.' 1>&2
+        echo 'Fix the commit, or for a false positive record its fingerprint in .gitleaksignore.' 1>&2
+        exit 1
+    fi
+done
+exit 0

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <!-- Duplicated from the root parent by design (standalone BOM cannot inherit).
              Bump these in lockstep with the root pom. -->
-        <spring-boot.version>3.5.9</spring-boot.version>
+        <spring-boot.version>3.5.16</spring-boot.version>
         <spring-cloud.version>2025.0.0</spring-cloud.version>
         <!-- Internal artifacts: the 3.0.0 Java 25 line published from this repo.
              Legacy stays pinned to the frozen Java 11 releases and never resolves these. -->

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,53 @@
                             </rules>
                         </configuration>
                     </execution>
+                    <!-- Duplicate-responsibility bans (ported from the consolidation line).
+                         A ban activates only once the last consumer converges:
+                         org.apache.httpcomponents:httpclient (HC4) is NOT banned yet — HPDS etl
+                         still declares it directly; that ban activates with the HPDS HTTP
+                         rationalization follow-on (FO-1). -->
+                    <execution>
+                        <id>ban-duplicate-responsibility-libs</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <exclude>commons-httpclient:commons-httpclient</exclude>
+                                        <exclude>org.json:json</exclude>
+                                    </excludes>
+                                    <searchTransitive>true</searchTransitive>
+                                </bannedDependencies>
+                                <dependencyConvergence/>
+                                <!-- requireUpperBoundDeps deliberately omitted: it flags every
+                                     intentional BOM pin (e.g. the Spring BOM managing snakeyaml
+                                     below a transitive expectation) as an error; convergence +
+                                     BOM pins provide the single-version guarantee. -->
+                            </rules>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>ban-direct-duplicate-libs</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <!-- direct declarations only: JUnit4 arrives transitively via
+                                             Testcontainers, OkHttp via the auth0 SDK — both accepted
+                                             as transitives, banned as direct dependencies -->
+                                        <exclude>junit:junit</exclude>
+                                        <exclude>com.squareup.okhttp3:okhttp</exclude>
+                                    </excludes>
+                                    <searchTransitive>false</searchTransitive>
+                                </bannedDependencies>
+                            </rules>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <!-- Resolves ${revision} into published/installed POMs (CI-friendly versions). -->

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
                     <configuration>
                         <java>
                             <eclipse>
-                                <version>4.26</version>
+                                <version>4.35</version>
                                 <file>${maven.multiModuleProjectDirectory}/code-formatting/eclipse-formatter.xml</file>
                             </eclipse>
                             <toggleOffOn/>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 <!--        TODO: Review why the standalone BOM cannot inherit these? -->
         <!-- Duplicated in platform/pom.xml (the standalone BOM cannot inherit these).
              Bump both files in lockstep. -->
-        <spring-boot.version>3.5.9</spring-boot.version>
+        <spring-boot.version>3.5.16</spring-boot.version>
         <spring-cloud.version>2025.0.0</spring-cloud.version>
         <spotless.version>2.46.1</spotless.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/services/pic-sure-auth-microapp/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortServiceTest.java
+++ b/services/pic-sure-auth-microapp/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortServiceTest.java
@@ -51,17 +51,18 @@ public class RASPassPortServiceTest {
 
     }
 
-    private static final String exampleRasPassport = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImRlZmF1bHRfc3NsX2tleSJ9.ew0KInN1YiI6IjJLRWthUC1SeDJGdkJCOExRVjRucjVmZXlySG4yNXEwV3hVd1kxVDIwMnMiLA0KImp0aSI6ImNiZDFjMzkyLTk0YjYtNDc2Yi1iYjA5LTk2MWY4MTM3MmE2NCIsDQoic2NvcGUiOiJvcGVuaWQgZ2E0Z2hfcGFzc3BvcnRfdjEiLA0KInR4biI6IlRsdVJ1UVcvZlZrPS5mYWJkOTdkMTdkNGM4OGFiIiwNCiJpc3MiOiAiaHR0cHM6Ly9zdHNzdGcubmloLmdvdiIsIAoiaWF0IjogMTYyMDIxMDM2MiwKImV4cCI6IDE2MjAyNTM1NjIsCiJnYTRnaF9wYXNzcG9ydF92MSIgOiBbImV3MEtJQ0FpZEhsd0lqb2dJa3BYVkNJc0RRb2dJQ0poYkdjaU9pQWlVbE15TlRZaUxBMEtJQ0FpYTJsa0lqb2dJbVJsWm1GMWJIUmZjM05zWDJ0bGVTSU5DbjAuZXcwS0lDQWlhWE56SWpvZ0ltaDBkSEJ6T2k4dmMzUnpjM1JuTG01cGFDNW5iM1lpTEEwS0lDQWljM1ZpSWpvZ0lqSkxSV3RoVUMxU2VESkdka0pDT0V4UlZqUnVjalZtWlhseVNHNHlOWEV3VjNoVmQxa3hWREl3TW5NaUxDQU5DaUFnSW1saGRDSTZJREUyTWpBeU1UQXpOaklzRFFvZ0lDSmxlSEFpT2lBeE5qSXdNalV6TlRZeUxBMEtJQ0FpYzJOdmNHVWlPaUFpYjNCbGJtbGtJR2RoTkdkb1gzQmhjM053YjNKMFgzWXhJaXdOQ2lBZ0ltcDBhU0k2SUNJNU56UTNPV0UzTXkwMFltSmxMVFJoWVdVdE9HWTFNUzAxTldVNU9UQTBZalJqT1RnaUxBMEtJQ0FpZEhodUlqb2dJbFJzZFZKMVVWY3ZabFpyUFM1bVlXSmtPVGRrTVRka05HTTRPR0ZpSWl3TkNpQWdJbWRoTkdkb1gzWnBjMkZmZGpFaU9pQjdJQTBLSUNBZ0lDQWlkSGx3WlNJNklDSm9kSFJ3Y3pvdkwzSmhjeTV1YVdndVoyOTJMM1pwYzJGekwzWXhMakVpTENBTkNpQWdJQ0FnSW1GemMyVnlkR1ZrSWpvZ01UWXlNREl4TURNMk1pd05DaUFnSUNBZ0luWmhiSFZsSWpvZ0ltaDBkSEJ6T2k4dmMzUnpjM1JuTG01cGFDNW5iM1l2Y0dGemMzQnZjblF2WkdKbllYQXZkakV1TVNJc0RRb2dJQ0FnSUNKemIzVnlZMlVpT2lBaWFIUjBjSE02THk5dVkySnBMbTVzYlM1dWFXZ3VaMjkyTDJkaGNDSXNEUW9nSUNBZ0lDSmllU0k2SUNKa1lXTWlmU3dOQ2lBZ0lDQWdJbkpoYzE5a1ltZGhjRjl3WlhKdGFYTnphVzl1Y3lJNklGc05DaUFnSUNBZ0lDQWdJQTBLZXcwS0ltTnZibk5sYm5SZmJtRnRaU0k2SWtkbGJtVnlZV3dnVW1WelpXRnlZMmdnVlhObElpd0pEUW9pY0doelgybGtJam9pY0doek1EQXdNREEySWl3TkNpSjJaWEp6YVc5dUlqb2lkakVpTEEwS0luQmhjblJwWTJsd1lXNTBYM05sZENJNkluQXhJaXdKQ1EwS0ltTnZibk5sYm5SZlozSnZkWEFpT2lKak1TSXNEUW9pY205c1pTSTZJbkJwSWl3TkNpSmxlSEJwY21GMGFXOXVJam94TmpReE1ERXpNakF3RFFwOUxBMEtldzBLSW1OdmJuTmxiblJmYm1GdFpTSTZJa1Y0WTJoaGJtZGxJRUZ5WldFaUxBa05DaUp3YUhOZmFXUWlPaUp3YUhNd01EQXpNREFpTEEwS0luWmxjbk5wYjI0aU9pSjJNU0lzRFFvaWNHRnlkR2xqYVhCaGJuUmZjMlYwSWpvaWNERWlMQWtKRFFvaVkyOXVjMlZ1ZEY5bmNtOTFjQ0k2SW1NNU9Ua2lMQTBLSW5KdmJHVWlPaUp3YVNJc0RRb2laWGh3YVhKaGRHbHZiaUk2TVRZME1UQXhNekl3TUFrTkNuME5DaUFnSUNBZ1hTQU5DbjAuTnpSOEtzZTJOOUtFOXhvLUo4dXdUaWxzUG9pYXhNWGlGR0prY0JOYTMtOGt1ZEh3MFd6U0xDM3Z3Qk4yZ3Z0RUtMZ2ZBeVpVUDZrc0ktRzlOV0NIU3Z2RG4tbFNhbjVtV1dfWEhrRVdGWGd3RXotWlNNalBvV0Vndlk1bHhSWEhxR1lhWmQ5U2puTjdsTFpUbHNQLU9pbFUxcUNyQ205YzVfcTh1YWJyZ3o0OW5PWFRGZEpKblpPT1ZzUmtkU0NjVnlHczRlbUxNSjdDdVd2ckU2RkR2Ri1QTUpGNlhHYnN3R1pjVFRPM3h0MjR6Tk1wbm5RUEVzNXQ3Tk1LZjhucEJ3czNvd0FKcklTRkExYTNmUWtJZU83dFRUUGVSX1FRVUlxYzFJRW5JdlotMGdsNE5ETEZRSjJTTS1KdUtvSWdnQWt3NVNGWDNhSk9WNC12b2JZbXhBIl0NCn0.sJwAZeR8cYyF-BCluC9fmiQAi14L7hC3DB4MoFQNNdoakUBujPZ-NlpfP2rBgJQ3CGcxsF95Vdczm6Yk4TKa68eXkKjkswjsSSQg0qErgFhN2jis9KMxnMfmfPNUfb0lioHtD-_oghRkd9239oUwLR06KB5Ux3mD4Pc0ZPbJxJcPmyP9DZ8WEHmAFIJpcoayHwJDr1jt-GbqUtaTCs1VQ9Habh8Z8fvwrlvQNj744m5eq6141bD0G15KgvbyYf9L4_PYNgMjTyUx9EGyetrxQ4XmOpDF_ZbFEhZliy80qfO2HGQzSId-dKXCvPI_SUWcCVeJqPwmXTirTt9qJ63ypw";
+    private static final String exampleRasPassport =
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImRlZmF1bHRfc3NsX2tleSJ9.ew0KInN1YiI6IjJLRWthUC1SeDJGdkJCOExRVjRucjVmZXlySG4yNXEwV3hVd1kxVDIwMnMiLA0KImp0aSI6ImNiZDFjMzkyLTk0YjYtNDc2Yi1iYjA5LTk2MWY4MTM3MmE2NCIsDQoic2NvcGUiOiJvcGVuaWQgZ2E0Z2hfcGFzc3BvcnRfdjEiLA0KInR4biI6IlRsdVJ1UVcvZlZrPS5mYWJkOTdkMTdkNGM4OGFiIiwNCiJpc3MiOiAiaHR0cHM6Ly9zdHNzdGcubmloLmdvdiIsIAoiaWF0IjogMTYyMDIxMDM2MiwKImV4cCI6IDE2MjAyNTM1NjIsCiJnYTRnaF9wYXNzcG9ydF92MSIgOiBbImV3MEtJQ0FpZEhsd0lqb2dJa3BYVkNJc0RRb2dJQ0poYkdjaU9pQWlVbE15TlRZaUxBMEtJQ0FpYTJsa0lqb2dJbVJsWm1GMWJIUmZjM05zWDJ0bGVTSU5DbjAuZXcwS0lDQWlhWE56SWpvZ0ltaDBkSEJ6T2k4dmMzUnpjM1JuTG01cGFDNW5iM1lpTEEwS0lDQWljM1ZpSWpvZ0lqSkxSV3RoVUMxU2VESkdka0pDT0V4UlZqUnVjalZtWlhseVNHNHlOWEV3VjNoVmQxa3hWREl3TW5NaUxDQU5DaUFnSW1saGRDSTZJREUyTWpBeU1UQXpOaklzRFFvZ0lDSmxlSEFpT2lBeE5qSXdNalV6TlRZeUxBMEtJQ0FpYzJOdmNHVWlPaUFpYjNCbGJtbGtJR2RoTkdkb1gzQmhjM053YjNKMFgzWXhJaXdOQ2lBZ0ltcDBhU0k2SUNJNU56UTNPV0UzTXkwMFltSmxMVFJoWVdVdE9HWTFNUzAxTldVNU9UQTBZalJqT1RnaUxBMEtJQ0FpZEhodUlqb2dJbFJzZFZKMVVWY3ZabFpyUFM1bVlXSmtPVGRrTVRka05HTTRPR0ZpSWl3TkNpQWdJbWRoTkdkb1gzWnBjMkZmZGpFaU9pQjdJQTBLSUNBZ0lDQWlkSGx3WlNJNklDSm9kSFJ3Y3pvdkwzSmhjeTV1YVdndVoyOTJMM1pwYzJGekwzWXhMakVpTENBTkNpQWdJQ0FnSW1GemMyVnlkR1ZrSWpvZ01UWXlNREl4TURNMk1pd05DaUFnSUNBZ0luWmhiSFZsSWpvZ0ltaDBkSEJ6T2k4dmMzUnpjM1JuTG01cGFDNW5iM1l2Y0dGemMzQnZjblF2WkdKbllYQXZkakV1TVNJc0RRb2dJQ0FnSUNKemIzVnlZMlVpT2lBaWFIUjBjSE02THk5dVkySnBMbTVzYlM1dWFXZ3VaMjkyTDJkaGNDSXNEUW9nSUNBZ0lDSmllU0k2SUNKa1lXTWlmU3dOQ2lBZ0lDQWdJbkpoYzE5a1ltZGhjRjl3WlhKdGFYTnphVzl1Y3lJNklGc05DaUFnSUNBZ0lDQWdJQTBLZXcwS0ltTnZibk5sYm5SZmJtRnRaU0k2SWtkbGJtVnlZV3dnVW1WelpXRnlZMmdnVlhObElpd0pEUW9pY0doelgybGtJam9pY0doek1EQXdNREEySWl3TkNpSjJaWEp6YVc5dUlqb2lkakVpTEEwS0luQmhjblJwWTJsd1lXNTBYM05sZENJNkluQXhJaXdKQ1EwS0ltTnZibk5sYm5SZlozSnZkWEFpT2lKak1TSXNEUW9pY205c1pTSTZJbkJwSWl3TkNpSmxlSEJwY21GMGFXOXVJam94TmpReE1ERXpNakF3RFFwOUxBMEtldzBLSW1OdmJuTmxiblJmYm1GdFpTSTZJa1Y0WTJoaGJtZGxJRUZ5WldFaUxBa05DaUp3YUhOZmFXUWlPaUp3YUhNd01EQXpNREFpTEEwS0luWmxjbk5wYjI0aU9pSjJNU0lzRFFvaWNHRnlkR2xqYVhCaGJuUmZjMlYwSWpvaWNERWlMQWtKRFFvaVkyOXVjMlZ1ZEY5bmNtOTFjQ0k2SW1NNU9Ua2lMQTBLSW5KdmJHVWlPaUp3YVNJc0RRb2laWGh3YVhKaGRHbHZiaUk2TVRZME1UQXhNekl3TUFrTkNuME5DaUFnSUNBZ1hTQU5DbjAuTnpSOEtzZTJOOUtFOXhvLUo4dXdUaWxzUG9pYXhNWGlGR0prY0JOYTMtOGt1ZEh3MFd6U0xDM3Z3Qk4yZ3Z0RUtMZ2ZBeVpVUDZrc0ktRzlOV0NIU3Z2RG4tbFNhbjVtV1dfWEhrRVdGWGd3RXotWlNNalBvV0Vndlk1bHhSWEhxR1lhWmQ5U2puTjdsTFpUbHNQLU9pbFUxcUNyQ205YzVfcTh1YWJyZ3o0OW5PWFRGZEpKblpPT1ZzUmtkU0NjVnlHczRlbUxNSjdDdVd2ckU2RkR2Ri1QTUpGNlhHYnN3R1pjVFRPM3h0MjR6Tk1wbm5RUEVzNXQ3Tk1LZjhucEJ3czNvd0FKcklTRkExYTNmUWtJZU83dFRUUGVSX1FRVUlxYzFJRW5JdlotMGdsNE5ETEZRSjJTTS1KdUtvSWdnQWt3NVNGWDNhSk9WNC12b2JZbXhBIl0NCn0.sJwAZeR8cYyF-BCluC9fmiQAi14L7hC3DB4MoFQNNdoakUBujPZ-NlpfP2rBgJQ3CGcxsF95Vdczm6Yk4TKa68eXkKjkswjsSSQg0qErgFhN2jis9KMxnMfmfPNUfb0lioHtD-_oghRkd9239oUwLR06KB5Ux3mD4Pc0ZPbJxJcPmyP9DZ8WEHmAFIJpcoayHwJDr1jt-GbqUtaTCs1VQ9Habh8Z8fvwrlvQNj744m5eq6141bD0G15KgvbyYf9L4_PYNgMjTyUx9EGyetrxQ4XmOpDF_ZbFEhZliy80qfO2HGQzSId-dKXCvPI_SUWcCVeJqPwmXTirTt9qJ63ypw";
 
     // Passport with two visas: LinkedIdentities (no ras_dbgap_permissions) + RAS dbGaP (with 2 permissions)
     private static final String multiVisaPassportWithPermissions = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5In0"
-            + ".eyJzdWIiOiJ0ZXN0LXN1Yi0wMDEiLCJqdGkiOiJwYXNzcG9ydC1qdGktMDAxIiwic2NvcGUiOiJvcGVuaWQgZ2E0Z2hfcGFzc3BvcnRfdjEiLCJ0eG4iOiJ0ZXN0LXR4bi0wMDEiLCJpc3MiOiJodHRwczovL3N0c3N0Zy5uaWguZ292IiwiaWF0IjoxNjIwMjEwMzYyLCJleHAiOjE2MjAyNTM1NjIsImdhNGdoX3Bhc3Nwb3J0X3YxIjpbImV5SjBlWEFpT2lKS1YxUWlMQ0poYkdjaU9pSlNVekkxTmlJc0ltdHBaQ0k2SW5SbGMzUXRhMlY1SW4wLmV5SnBjM01pT2lKb2RIUndjem92TDNOMGMzTjBaeTV1YVdndVoyOTJJaXdpYzNWaUlqb2lkR1Z6ZEMxemRXSXRNREF4SWl3aWFXRjBJam94TmpJd01qRXdNell5TENKbGVIQWlPakUyTWpBeU5UTTFOaklzSW5OamIzQmxJam9pYjNCbGJtbGtJR2RoTkdkb1gzQmhjM053YjNKMFgzWXhJaXdpYW5ScElqb2lkbWx6WVMxcWRHa3RiR2x1YTJWa0xUQXdNU0lzSW5SNGJpSTZJblJsYzNRdGRIaHVMVEF3TVNJc0ltZGhOR2RvWDNacGMyRmZkakVpT25zaWRIbHdaU0k2SWt4cGJtdGxaRWxrWlc1MGFYUnBaWE1pTENKaGMzTmxjblJsWkNJNk1UWXlNREl4TURNMk1pd2lkbUZzZFdVaU9pSjBaWE4wTFd4cGJtdGxaQzFwWkMxMllXeDFaU0lzSW5OdmRYSmpaU0k2SW1oMGRIQnpPaTh2YzNSemMzUm5MbTVwYUM1bmIzWWlMQ0ppZVNJNkltNXBhQzVuYjNZaWZYMC5mYWtlc2lnbmF0dXJlIiwiZXlKMGVYQWlPaUpLVjFRaUxDSmhiR2NpT2lKU1V6STFOaUlzSW10cFpDSTZJblJsYzNRdGEyVjVJbjAuZXlKcGMzTWlPaUpvZEhSd2N6b3ZMM04wYzNOMFp5NXVhV2d1WjI5Mklpd2ljM1ZpSWpvaWRHVnpkQzF6ZFdJdE1EQXhJaXdpYVdGMElqb3hOakl3TWpFd016WXlMQ0psZUhBaU9qRTJNakF5TlRNMU5qSXNJbk5qYjNCbElqb2liM0JsYm1sa0lHZGhOR2RvWDNCaGMzTndiM0owWDNZeElpd2lhblJwSWpvaWRtbHpZUzFxZEdrdFpHSm5ZWEF0TURBeElpd2lkSGh1SWpvaWRHVnpkQzEwZUc0dE1EQXhJaXdpWjJFMFoyaGZkbWx6WVY5Mk1TSTZleUowZVhCbElqb2lhSFIwY0hNNkx5OXlZWE11Ym1sb0xtZHZkaTkyYVhOaGN5OTJNUzR4SWl3aVlYTnpaWEowWldRaU9qRTJNakF5TVRBek5qSXNJblpoYkhWbElqb2lhSFIwY0hNNkx5OXpkSE56ZEdjdWJtbG9MbWR2ZGk5d1lYTnpjRzl5ZEM5a1ltZGhjQzkyTVM0eElpd2ljMjkxY21ObElqb2lhSFIwY0hNNkx5OXVZMkpwTG01c2JTNXVhV2d1WjI5MkwyZGhjQ0lzSW1KNUlqb2laR0ZqSW4wc0luSmhjMTlrWW1kaGNGOXdaWEp0YVhOemFXOXVjeUk2VzNzaVkyOXVjMlZ1ZEY5dVlXMWxJam9pUjJWdVpYSmhiQ0JTWlhObFlYSmphQ0JWYzJVaUxDSndhSE5mYVdRaU9pSndhSE13TURBd01EY2lMQ0oyWlhKemFXOXVJam9pZGpNeklpd2ljR0Z5ZEdsamFYQmhiblJmYzJWMElqb2ljREVpTENKamIyNXpaVzUwWDJkeWIzVndJam9pWXpFaUxDSnliMnhsSWpvaWNHa2lMQ0psZUhCcGNtRjBhVzl1SWpveE5qUXhNREV6TWpBd2ZTeDdJbU52Ym5ObGJuUmZibUZ0WlNJNklraGxZV3gwYUNCTlpXUnBZMkZzSUVKcGIyMWxaR2xqWVd3aUxDSndhSE5mYVdRaU9pSndhSE13TURBeE56a2lMQ0oyWlhKemFXOXVJam9pZGpnaUxDSndZWEowYVdOcGNHRnVkRjl6WlhRaU9pSndNaUlzSW1OdmJuTmxiblJmWjNKdmRYQWlPaUpqTWlJc0luSnZiR1VpT2lKd2FTSXNJbVY0Y0dseVlYUnBiMjRpT2pFMk5ERXdNVE15TURCOVhYMC5mYWtlc2lnbmF0dXJlIl19"
-            + ".fakesignature";
+        + ".eyJzdWIiOiJ0ZXN0LXN1Yi0wMDEiLCJqdGkiOiJwYXNzcG9ydC1qdGktMDAxIiwic2NvcGUiOiJvcGVuaWQgZ2E0Z2hfcGFzc3BvcnRfdjEiLCJ0eG4iOiJ0ZXN0LXR4bi0wMDEiLCJpc3MiOiJodHRwczovL3N0c3N0Zy5uaWguZ292IiwiaWF0IjoxNjIwMjEwMzYyLCJleHAiOjE2MjAyNTM1NjIsImdhNGdoX3Bhc3Nwb3J0X3YxIjpbImV5SjBlWEFpT2lKS1YxUWlMQ0poYkdjaU9pSlNVekkxTmlJc0ltdHBaQ0k2SW5SbGMzUXRhMlY1SW4wLmV5SnBjM01pT2lKb2RIUndjem92TDNOMGMzTjBaeTV1YVdndVoyOTJJaXdpYzNWaUlqb2lkR1Z6ZEMxemRXSXRNREF4SWl3aWFXRjBJam94TmpJd01qRXdNell5TENKbGVIQWlPakUyTWpBeU5UTTFOaklzSW5OamIzQmxJam9pYjNCbGJtbGtJR2RoTkdkb1gzQmhjM053YjNKMFgzWXhJaXdpYW5ScElqb2lkbWx6WVMxcWRHa3RiR2x1YTJWa0xUQXdNU0lzSW5SNGJpSTZJblJsYzNRdGRIaHVMVEF3TVNJc0ltZGhOR2RvWDNacGMyRmZkakVpT25zaWRIbHdaU0k2SWt4cGJtdGxaRWxrWlc1MGFYUnBaWE1pTENKaGMzTmxjblJsWkNJNk1UWXlNREl4TURNMk1pd2lkbUZzZFdVaU9pSjBaWE4wTFd4cGJtdGxaQzFwWkMxMllXeDFaU0lzSW5OdmRYSmpaU0k2SW1oMGRIQnpPaTh2YzNSemMzUm5MbTVwYUM1bmIzWWlMQ0ppZVNJNkltNXBhQzVuYjNZaWZYMC5mYWtlc2lnbmF0dXJlIiwiZXlKMGVYQWlPaUpLVjFRaUxDSmhiR2NpT2lKU1V6STFOaUlzSW10cFpDSTZJblJsYzNRdGEyVjVJbjAuZXlKcGMzTWlPaUpvZEhSd2N6b3ZMM04wYzNOMFp5NXVhV2d1WjI5Mklpd2ljM1ZpSWpvaWRHVnpkQzF6ZFdJdE1EQXhJaXdpYVdGMElqb3hOakl3TWpFd016WXlMQ0psZUhBaU9qRTJNakF5TlRNMU5qSXNJbk5qYjNCbElqb2liM0JsYm1sa0lHZGhOR2RvWDNCaGMzTndiM0owWDNZeElpd2lhblJwSWpvaWRtbHpZUzFxZEdrdFpHSm5ZWEF0TURBeElpd2lkSGh1SWpvaWRHVnpkQzEwZUc0dE1EQXhJaXdpWjJFMFoyaGZkbWx6WVY5Mk1TSTZleUowZVhCbElqb2lhSFIwY0hNNkx5OXlZWE11Ym1sb0xtZHZkaTkyYVhOaGN5OTJNUzR4SWl3aVlYTnpaWEowWldRaU9qRTJNakF5TVRBek5qSXNJblpoYkhWbElqb2lhSFIwY0hNNkx5OXpkSE56ZEdjdWJtbG9MbWR2ZGk5d1lYTnpjRzl5ZEM5a1ltZGhjQzkyTVM0eElpd2ljMjkxY21ObElqb2lhSFIwY0hNNkx5OXVZMkpwTG01c2JTNXVhV2d1WjI5MkwyZGhjQ0lzSW1KNUlqb2laR0ZqSW4wc0luSmhjMTlrWW1kaGNGOXdaWEp0YVhOemFXOXVjeUk2VzNzaVkyOXVjMlZ1ZEY5dVlXMWxJam9pUjJWdVpYSmhiQ0JTWlhObFlYSmphQ0JWYzJVaUxDSndhSE5mYVdRaU9pSndhSE13TURBd01EY2lMQ0oyWlhKemFXOXVJam9pZGpNeklpd2ljR0Z5ZEdsamFYQmhiblJmYzJWMElqb2ljREVpTENKamIyNXpaVzUwWDJkeWIzVndJam9pWXpFaUxDSnliMnhsSWpvaWNHa2lMQ0psZUhCcGNtRjBhVzl1SWpveE5qUXhNREV6TWpBd2ZTeDdJbU52Ym5ObGJuUmZibUZ0WlNJNklraGxZV3gwYUNCTlpXUnBZMkZzSUVKcGIyMWxaR2xqWVd3aUxDSndhSE5mYVdRaU9pSndhSE13TURBeE56a2lMQ0oyWlhKemFXOXVJam9pZGpnaUxDSndZWEowYVdOcGNHRnVkRjl6WlhRaU9pSndNaUlzSW1OdmJuTmxiblJmWjNKdmRYQWlPaUpqTWlJc0luSnZiR1VpT2lKd2FTSXNJbVY0Y0dseVlYUnBiMjRpT2pFMk5ERXdNVE15TURCOVhYMC5mYWtlc2lnbmF0dXJlIl19" // gitleaks:allow
+        + ".fakesignature";
 
     // Passport with two visas: LinkedIdentities (no ras_dbgap_permissions) + RAS dbGaP (empty permissions)
     private static final String multiVisaPassportWithEmptyPermissions = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5In0"
-            + ".eyJzdWIiOiJ0ZXN0LXN1Yi0wMDEiLCJqdGkiOiJwYXNzcG9ydC1qdGktMDAyIiwic2NvcGUiOiJvcGVuaWQgZ2E0Z2hfcGFzc3BvcnRfdjEiLCJ0eG4iOiJ0ZXN0LXR4bi0wMDEiLCJpc3MiOiJodHRwczovL3N0c3N0Zy5uaWguZ292IiwiaWF0IjoxNjIwMjEwMzYyLCJleHAiOjE2MjAyNTM1NjIsImdhNGdoX3Bhc3Nwb3J0X3YxIjpbImV5SjBlWEFpT2lKS1YxUWlMQ0poYkdjaU9pSlNVekkxTmlJc0ltdHBaQ0k2SW5SbGMzUXRhMlY1SW4wLmV5SnBjM01pT2lKb2RIUndjem92TDNOMGMzTjBaeTV1YVdndVoyOTJJaXdpYzNWaUlqb2lkR1Z6ZEMxemRXSXRNREF4SWl3aWFXRjBJam94TmpJd01qRXdNell5TENKbGVIQWlPakUyTWpBeU5UTTFOaklzSW5OamIzQmxJam9pYjNCbGJtbGtJR2RoTkdkb1gzQmhjM053YjNKMFgzWXhJaXdpYW5ScElqb2lkbWx6WVMxcWRHa3RiR2x1YTJWa0xUQXdNU0lzSW5SNGJpSTZJblJsYzNRdGRIaHVMVEF3TVNJc0ltZGhOR2RvWDNacGMyRmZkakVpT25zaWRIbHdaU0k2SWt4cGJtdGxaRWxrWlc1MGFYUnBaWE1pTENKaGMzTmxjblJsWkNJNk1UWXlNREl4TURNMk1pd2lkbUZzZFdVaU9pSjBaWE4wTFd4cGJtdGxaQzFwWkMxMllXeDFaU0lzSW5OdmRYSmpaU0k2SW1oMGRIQnpPaTh2YzNSemMzUm5MbTVwYUM1bmIzWWlMQ0ppZVNJNkltNXBhQzVuYjNZaWZYMC5mYWtlc2lnbmF0dXJlIiwiZXlKMGVYQWlPaUpLVjFRaUxDSmhiR2NpT2lKU1V6STFOaUlzSW10cFpDSTZJblJsYzNRdGEyVjVJbjAuZXlKcGMzTWlPaUpvZEhSd2N6b3ZMM04wYzNOMFp5NXVhV2d1WjI5Mklpd2ljM1ZpSWpvaWRHVnpkQzF6ZFdJdE1EQXhJaXdpYVdGMElqb3hOakl3TWpFd016WXlMQ0psZUhBaU9qRTJNakF5TlRNMU5qSXNJbk5qYjNCbElqb2liM0JsYm1sa0lHZGhOR2RvWDNCaGMzTndiM0owWDNZeElpd2lhblJwSWpvaWRtbHpZUzFxZEdrdFpHSm5ZWEF0Wlcxd2RIa3RNREF4SWl3aWRIaHVJam9pZEdWemRDMTBlRzR0TURBeElpd2laMkUwWjJoZmRtbHpZVjkyTVNJNmV5SjBlWEJsSWpvaWFIUjBjSE02THk5eVlYTXVibWxvTG1kdmRpOTJhWE5oY3k5Mk1TNHhJaXdpWVhOelpYSjBaV1FpT2pFMk1qQXlNVEF6TmpJc0luWmhiSFZsSWpvaWFIUjBjSE02THk5emRITnpkR2N1Ym1sb0xtZHZkaTl3WVhOemNHOXlkQzlrWW1kaGNDOTJNUzR4SWl3aWMyOTFjbU5sSWpvaWFIUjBjSE02THk5dVkySnBMbTVzYlM1dWFXZ3VaMjkyTDJkaGNDSXNJbUo1SWpvaVpHRmpJbjBzSW5KaGMxOWtZbWRoY0Y5d1pYSnRhWE56YVc5dWN5STZXMTE5LmZha2VzaWduYXR1cmUiXX0"
-            + ".fakesignature";
+        + ".eyJzdWIiOiJ0ZXN0LXN1Yi0wMDEiLCJqdGkiOiJwYXNzcG9ydC1qdGktMDAyIiwic2NvcGUiOiJvcGVuaWQgZ2E0Z2hfcGFzc3BvcnRfdjEiLCJ0eG4iOiJ0ZXN0LXR4bi0wMDEiLCJpc3MiOiJodHRwczovL3N0c3N0Zy5uaWguZ292IiwiaWF0IjoxNjIwMjEwMzYyLCJleHAiOjE2MjAyNTM1NjIsImdhNGdoX3Bhc3Nwb3J0X3YxIjpbImV5SjBlWEFpT2lKS1YxUWlMQ0poYkdjaU9pSlNVekkxTmlJc0ltdHBaQ0k2SW5SbGMzUXRhMlY1SW4wLmV5SnBjM01pT2lKb2RIUndjem92TDNOMGMzTjBaeTV1YVdndVoyOTJJaXdpYzNWaUlqb2lkR1Z6ZEMxemRXSXRNREF4SWl3aWFXRjBJam94TmpJd01qRXdNell5TENKbGVIQWlPakUyTWpBeU5UTTFOaklzSW5OamIzQmxJam9pYjNCbGJtbGtJR2RoTkdkb1gzQmhjM053YjNKMFgzWXhJaXdpYW5ScElqb2lkbWx6WVMxcWRHa3RiR2x1YTJWa0xUQXdNU0lzSW5SNGJpSTZJblJsYzNRdGRIaHVMVEF3TVNJc0ltZGhOR2RvWDNacGMyRmZkakVpT25zaWRIbHdaU0k2SWt4cGJtdGxaRWxrWlc1MGFYUnBaWE1pTENKaGMzTmxjblJsWkNJNk1UWXlNREl4TURNMk1pd2lkbUZzZFdVaU9pSjBaWE4wTFd4cGJtdGxaQzFwWkMxMllXeDFaU0lzSW5OdmRYSmpaU0k2SW1oMGRIQnpPaTh2YzNSemMzUm5MbTVwYUM1bmIzWWlMQ0ppZVNJNkltNXBhQzVuYjNZaWZYMC5mYWtlc2lnbmF0dXJlIiwiZXlKMGVYQWlPaUpLVjFRaUxDSmhiR2NpT2lKU1V6STFOaUlzSW10cFpDSTZJblJsYzNRdGEyVjVJbjAuZXlKcGMzTWlPaUpvZEhSd2N6b3ZMM04wYzNOMFp5NXVhV2d1WjI5Mklpd2ljM1ZpSWpvaWRHVnpkQzF6ZFdJdE1EQXhJaXdpYVdGMElqb3hOakl3TWpFd016WXlMQ0psZUhBaU9qRTJNakF5TlRNMU5qSXNJbk5qYjNCbElqb2liM0JsYm1sa0lHZGhOR2RvWDNCaGMzTndiM0owWDNZeElpd2lhblJwSWpvaWRtbHpZUzFxZEdrdFpHSm5ZWEF0Wlcxd2RIa3RNREF4SWl3aWRIaHVJam9pZEdWemRDMTBlRzR0TURBeElpd2laMkUwWjJoZmRtbHpZVjkyTVNJNmV5SjBlWEJsSWpvaWFIUjBjSE02THk5eVlYTXVibWxvTG1kdmRpOTJhWE5oY3k5Mk1TNHhJaXdpWVhOelpYSjBaV1FpT2pFMk1qQXlNVEF6TmpJc0luWmhiSFZsSWpvaWFIUjBjSE02THk5emRITnpkR2N1Ym1sb0xtZHZkaTl3WVhOemNHOXlkQzlrWW1kaGNDOTJNUzR4SWl3aWMyOTFjbU5sSWpvaWFIUjBjSE02THk5dVkySnBMbTVzYlM1dWFXZ3VaMjkyTDJkaGNDSXNJbUo1SWpvaVpHRmpJbjBzSW5KaGMxOWtZbWRoY0Y5d1pYSnRhWE56YVc5dWN5STZXMTE5LmZha2VzaWduYXR1cmUiXX0" // gitleaks:allow
+        + ".fakesignature";
 
     @Test
     public void testGa4ghPassPortStudies_IsNull() {
@@ -72,7 +73,8 @@ public class RASPassPortServiceTest {
     @Test
     public void testGa4gpPassportStudies_IsNotNull_And_ExpiredPermissionsExcluded() {
         Optional<Passport> passport = JWTUtil.parsePassportJWTV11(exampleRasPassport);
-        Set<Optional<Ga4ghPassportV1>> ga4ghPassports = passport.get().getGa4ghPassportV1().stream().map(JWTUtil::parseGa4ghPassportV1).filter(Optional::isPresent).collect(Collectors.toSet());
+        Set<Optional<Ga4ghPassportV1>> ga4ghPassports = passport.get().getGa4ghPassportV1().stream().map(JWTUtil::parseGa4ghPassportV1)
+            .filter(Optional::isPresent).collect(Collectors.toSet());
         Set<RasDbgapPermission> permissions = rasPassPortService.ga4ghPassportToRasDbgapPermissions(ga4ghPassports);
         assertNotNull(permissions);
         assertTrue(permissions.isEmpty());
@@ -85,17 +87,15 @@ public class RASPassPortServiceTest {
 
         // Update the expiry date of each permission in our test passport. All permissions in the example passport
         // expired in 2022.
-        Set<Optional<Ga4ghPassportV1>> ga4ghPassports = passport.get().getGa4ghPassportV1().stream()
-                .map(JWTUtil::parseGa4ghPassportV1)
-                .filter(Optional::isPresent)
-                .map(optionalPassport -> {
-                    Ga4ghPassportV1 ga4ghPassportV1 = optionalPassport.get();
-                    List<RasDbgapPermission> rasDbgapPermissions = ga4ghPassportV1.getRasDbgagPermissions();
-                    List<RasDbgapPermission> newExpires = rasDbgapPermissions.stream().peek(rasDbgapPermission -> rasDbgapPermission.setExpiration(futureDate)).toList();
-                    ga4ghPassportV1.setRasDbgapPermissions(newExpires);
-                    return Optional.of(ga4ghPassportV1);
-                })
-                .collect(Collectors.toSet());
+        Set<Optional<Ga4ghPassportV1>> ga4ghPassports = passport.get().getGa4ghPassportV1().stream().map(JWTUtil::parseGa4ghPassportV1)
+            .filter(Optional::isPresent).map(optionalPassport -> {
+                Ga4ghPassportV1 ga4ghPassportV1 = optionalPassport.get();
+                List<RasDbgapPermission> rasDbgapPermissions = ga4ghPassportV1.getRasDbgagPermissions();
+                List<RasDbgapPermission> newExpires =
+                    rasDbgapPermissions.stream().peek(rasDbgapPermission -> rasDbgapPermission.setExpiration(futureDate)).toList();
+                ga4ghPassportV1.setRasDbgapPermissions(newExpires);
+                return Optional.of(ga4ghPassportV1);
+            }).collect(Collectors.toSet());
 
         Set<RasDbgapPermission> permissions = rasPassPortService.ga4ghPassportToRasDbgapPermissions(ga4ghPassports);
 
@@ -114,32 +114,27 @@ public class RASPassPortServiceTest {
         List<String> validPHS = new ArrayList<>();
         // Update the expiry date of each permission in our test passport.
         // We alternate: even-indexed permissions become valid, odd-indexed ones remain (or become) invalid.
-        Set<Optional<Ga4ghPassportV1>> ga4ghPassports = passport.get().getGa4ghPassportV1().stream()
-                .map(JWTUtil::parseGa4ghPassportV1)
-                .filter(Optional::isPresent)
-                .map(optionalPassport -> {
-                    Ga4ghPassportV1 ga4ghPassportV1 = optionalPassport.get();
-                    List<RasDbgapPermission> rasDbgapPermissions = ga4ghPassportV1.getRasDbgagPermissions();
+        Set<Optional<Ga4ghPassportV1>> ga4ghPassports = passport.get().getGa4ghPassportV1().stream().map(JWTUtil::parseGa4ghPassportV1)
+            .filter(Optional::isPresent).map(optionalPassport -> {
+                Ga4ghPassportV1 ga4ghPassportV1 = optionalPassport.get();
+                List<RasDbgapPermission> rasDbgapPermissions = ga4ghPassportV1.getRasDbgagPermissions();
 
-                    AtomicInteger index = new AtomicInteger();
-                    List<RasDbgapPermission> updatedPermissions = rasDbgapPermissions.stream()
-                            .peek(permission -> {
-                                if (index.getAndIncrement() % 2 == 0) {
-                                    // For even indices, use a valid future expiration.
-                                    permission.setExpiration(futureDate);
-                                    validPHS.add(permission.getPhsId());
-                                } else {
-                                    // For odd indices, use an expired (invalid) timestamp.
-                                    permission.setExpiration(pastDate);
-                                    expiredPHS.add(permission.getPhsId());
-                                }
-                            })
-                            .collect(Collectors.toList());
+                AtomicInteger index = new AtomicInteger();
+                List<RasDbgapPermission> updatedPermissions = rasDbgapPermissions.stream().peek(permission -> {
+                    if (index.getAndIncrement() % 2 == 0) {
+                        // For even indices, use a valid future expiration.
+                        permission.setExpiration(futureDate);
+                        validPHS.add(permission.getPhsId());
+                    } else {
+                        // For odd indices, use an expired (invalid) timestamp.
+                        permission.setExpiration(pastDate);
+                        expiredPHS.add(permission.getPhsId());
+                    }
+                }).collect(Collectors.toList());
 
-                    ga4ghPassportV1.setRasDbgapPermissions(updatedPermissions);
-                    return Optional.of(ga4ghPassportV1);
-                })
-                .collect(Collectors.toSet());
+                ga4ghPassportV1.setRasDbgapPermissions(updatedPermissions);
+                return Optional.of(ga4ghPassportV1);
+            }).collect(Collectors.toSet());
 
         // Convert the GA4GH passports to RAS DbGaP permissions. The underlying conversion
         // should filter out the ones with invalid expiration dates.
@@ -153,14 +148,14 @@ public class RASPassPortServiceTest {
         assertEquals(finalPHS, validPHS, "The valid phs ids do not match the expected values.");
 
         // verify no expired permissions are in the passport.
-        expiredPHS.forEach(phs -> assertFalse(finalPHS.contains(phs), "Expired phs id " + phs + " should not appear in the valid permissions."));
+        expiredPHS
+            .forEach(phs -> assertFalse(finalPHS.contains(phs), "Expired phs id " + phs + " should not appear in the valid permissions."));
     }
 
 
     @Test
     public void testValidateVisa_Valid() {
-        when(restClientUtil.retrievePostResponse(any(String.class), any()))
-                .thenReturn(new ResponseEntity<>("Valid", HttpStatus.OK));
+        when(restClientUtil.retrievePostResponse(any(String.class), any())).thenReturn(new ResponseEntity<>("Valid", HttpStatus.OK));
         Optional<String> response = rasPassPortService.validateVisa(visa);
         assertTrue(response.isPresent());
         assertEquals(PassportValidationResponse.VALID.getValue(), response.get());
@@ -168,8 +163,7 @@ public class RASPassPortServiceTest {
 
     @Test
     public void testValidateVisa_Invalid() {
-        when(restClientUtil.retrievePostResponse(any(String.class), any()))
-                .thenReturn(new ResponseEntity<>("Invalid", HttpStatus.OK));
+        when(restClientUtil.retrievePostResponse(any(String.class), any())).thenReturn(new ResponseEntity<>("Invalid", HttpStatus.OK));
         Optional<String> response = rasPassPortService.validateVisa(visa);
         assertTrue(response.isPresent());
         assertEquals(PassportValidationResponse.INVALID.getValue(), response.get());
@@ -177,8 +171,7 @@ public class RASPassPortServiceTest {
 
     @Test
     public void testValidateVisa_Missing() {
-        when(restClientUtil.retrievePostResponse(any(String.class), any()))
-                .thenReturn(new ResponseEntity<>("Missing", HttpStatus.OK));
+        when(restClientUtil.retrievePostResponse(any(String.class), any())).thenReturn(new ResponseEntity<>("Missing", HttpStatus.OK));
         Optional<String> response = rasPassPortService.validateVisa(visa);
         assertTrue(response.isPresent());
         assertEquals(PassportValidationResponse.MISSING.getValue(), response.get());
@@ -187,7 +180,7 @@ public class RASPassPortServiceTest {
     @Test
     public void testValidatePassport_InvalidVisa() {
         when(restClientUtil.retrievePostResponse(any(String.class), any()))
-                .thenReturn(new ResponseEntity<>("Invalid Passport", HttpStatus.OK));
+            .thenReturn(new ResponseEntity<>("Invalid Passport", HttpStatus.OK));
         Optional<String> response = rasPassPortService.validateVisa(visa);
         assertTrue(response.isPresent());
         assertEquals(PassportValidationResponse.INVALID_PASSPORT.getValue(), response.get());
@@ -195,8 +188,7 @@ public class RASPassPortServiceTest {
 
     @Test
     public void testValidateVisa_VisaExpired() {
-        when(restClientUtil.retrievePostResponse(any(String.class), any()))
-                .thenReturn(new ResponseEntity<>("Visa Expired", HttpStatus.OK));
+        when(restClientUtil.retrievePostResponse(any(String.class), any())).thenReturn(new ResponseEntity<>("Visa Expired", HttpStatus.OK));
         Optional<String> response = rasPassPortService.validateVisa(visa);
         assertTrue(response.isPresent());
         assertEquals(PassportValidationResponse.VISA_EXPIRED.getValue(), response.get());
@@ -204,8 +196,7 @@ public class RASPassPortServiceTest {
 
     @Test
     public void testValidateVisa_TxnError() {
-        when(restClientUtil.retrievePostResponse(any(String.class), any()))
-                .thenReturn(new ResponseEntity<>("Txn Error", HttpStatus.OK));
+        when(restClientUtil.retrievePostResponse(any(String.class), any())).thenReturn(new ResponseEntity<>("Txn Error", HttpStatus.OK));
         Optional<String> response = rasPassPortService.validateVisa(visa);
         assertTrue(response.isPresent());
         assertEquals(PassportValidationResponse.TXN_ERROR.getValue(), response.get());
@@ -214,7 +205,7 @@ public class RASPassPortServiceTest {
     @Test
     public void testValidateVisa_ExpirationError() {
         when(restClientUtil.retrievePostResponse(any(String.class), any()))
-                .thenReturn(new ResponseEntity<>("Expiration Error", HttpStatus.OK));
+            .thenReturn(new ResponseEntity<>("Expiration Error", HttpStatus.OK));
         Optional<String> response = rasPassPortService.validateVisa(visa);
         assertTrue(response.isPresent());
         assertEquals(PassportValidationResponse.EXPIRATION_ERROR.getValue(), response.get());
@@ -223,7 +214,7 @@ public class RASPassPortServiceTest {
     @Test
     public void testValidateVisa_ValidationError() {
         when(restClientUtil.retrievePostResponse(any(String.class), any()))
-                .thenReturn(new ResponseEntity<>("Validation Error", HttpStatus.OK));
+            .thenReturn(new ResponseEntity<>("Validation Error", HttpStatus.OK));
         Optional<String> response = rasPassPortService.validateVisa(visa);
         assertTrue(response.isPresent());
         assertEquals(PassportValidationResponse.VALIDATION_ERROR.getValue(), response.get());
@@ -232,7 +223,7 @@ public class RASPassPortServiceTest {
     @Test
     public void testValidateVisa_ExpiredPolling() {
         when(restClientUtil.retrievePostResponse(any(String.class), any()))
-                .thenReturn(new ResponseEntity<>("Expired Polling", HttpStatus.OK));
+            .thenReturn(new ResponseEntity<>("Expired Polling", HttpStatus.OK));
         Optional<String> response = rasPassPortService.validateVisa(visa);
         assertTrue(response.isPresent());
         assertEquals(PassportValidationResponse.EXPIRED_POLLING.getValue(), response.get());
@@ -241,7 +232,7 @@ public class RASPassPortServiceTest {
     @Test
     public void testValidateVisa_PermissionUpdate() {
         when(restClientUtil.retrievePostResponse(any(String.class), any()))
-                .thenReturn(new ResponseEntity<>("Permission Update", HttpStatus.OK));
+            .thenReturn(new ResponseEntity<>("Permission Update", HttpStatus.OK));
         Optional<String> response = rasPassPortService.validateVisa(visa);
         assertTrue(response.isPresent());
         assertEquals(PassportValidationResponse.PERMISSION_UPDATE.getValue(), response.get());
@@ -253,10 +244,8 @@ public class RASPassPortServiceTest {
         assertTrue(passport.isPresent());
         assertEquals(2, passport.get().getGa4ghPassportV1().size());
 
-        Set<Optional<Ga4ghPassportV1>> ga4ghPassports = passport.get().getGa4ghPassportV1().stream()
-                .map(JWTUtil::parseGa4ghPassportV1)
-                .filter(Optional::isPresent)
-                .collect(Collectors.toSet());
+        Set<Optional<Ga4ghPassportV1>> ga4ghPassports = passport.get().getGa4ghPassportV1().stream().map(JWTUtil::parseGa4ghPassportV1)
+            .filter(Optional::isPresent).collect(Collectors.toSet());
 
         // Should not throw NPE even though LinkedIdentities visa has no ras_dbgap_permissions
         Set<RasDbgapPermission> permissions = rasPassPortService.ga4ghPassportToRasDbgapPermissions(ga4ghPassports);
@@ -272,19 +261,15 @@ public class RASPassPortServiceTest {
 
         long futureDate = (Instant.now().toEpochMilli() / 1000) + 100000;
 
-        Set<Optional<Ga4ghPassportV1>> ga4ghPassports = passport.get().getGa4ghPassportV1().stream()
-                .map(JWTUtil::parseGa4ghPassportV1)
-                .filter(Optional::isPresent)
-                .map(optionalPassport -> {
-                    Ga4ghPassportV1 ga4ghPassportV1 = optionalPassport.get();
-                    List<RasDbgapPermission> rasDbgapPermissions = ga4ghPassportV1.getRasDbgagPermissions();
-                    List<RasDbgapPermission> newExpires = rasDbgapPermissions.stream()
-                            .peek(rasDbgapPermission -> rasDbgapPermission.setExpiration(futureDate))
-                            .toList();
-                    ga4ghPassportV1.setRasDbgapPermissions(newExpires);
-                    return Optional.of(ga4ghPassportV1);
-                })
-                .collect(Collectors.toSet());
+        Set<Optional<Ga4ghPassportV1>> ga4ghPassports = passport.get().getGa4ghPassportV1().stream().map(JWTUtil::parseGa4ghPassportV1)
+            .filter(Optional::isPresent).map(optionalPassport -> {
+                Ga4ghPassportV1 ga4ghPassportV1 = optionalPassport.get();
+                List<RasDbgapPermission> rasDbgapPermissions = ga4ghPassportV1.getRasDbgagPermissions();
+                List<RasDbgapPermission> newExpires =
+                    rasDbgapPermissions.stream().peek(rasDbgapPermission -> rasDbgapPermission.setExpiration(futureDate)).toList();
+                ga4ghPassportV1.setRasDbgapPermissions(newExpires);
+                return Optional.of(ga4ghPassportV1);
+            }).collect(Collectors.toSet());
 
         Set<RasDbgapPermission> permissions = rasPassPortService.ga4ghPassportToRasDbgapPermissions(ga4ghPassports);
 


### PR DESCRIPTION
Follow-up governance PR closing out the consolidation stack — one commit per concern:

- **Enforcer gates**: `dependencyConvergence` + duplicate-responsibility bans (transitive: commons-httpclient, org.json; direct: junit:junit, okhttp).
-  **Maven wrapper** (3.9.9).
-  **Workflows run `./mvnw`**; the catch-all workflow gains dependency caching.
-  **Spotless Eclipse formatter 4.26 → 4.35 + reactor normalization** — resolves the documented PR #272 exception (4.26 crashed on psama's Java 21 guarded patterns): psama fully normalized (85 files), 5 files of drift elsewhere. `spotless:check` is now green on every module. Two synthetic test JWTs in `RASPassPortServiceTest.java` gained `// gitleaks:allow` trailing comments (repo false-positive convention) when the reformat re-touched their lines.
-  **Secrets gate persisted**: checksum-pinned gitleaks PR scan workflow, optional pre-push hook mirroring the pre-commit convention, `.gitleaksignore` scaffold.
-  **Consolidated root `dependabot.yml`** (maven reactor + github-actions). Old-layout Dependabot PRs #231/#247/#251 to be closed after the stack merges.

Verified: full-reactor `./mvnw -T1C clean verify` green at tip; reactor-wide `spotless:check` green; gitleaks clean over the whole range; only the style commit touches service trees, Java files only.