### PR TITLE
Forward X-PICSURE-API-Key to PSAMA open-access validation

### DIFF
--- a/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/JWTFilter.java
+++ b/pic-sure-api-war/src/main/java/edu/harvard/dbmi/avillach/security/JWTFilter.java
@@ -71,6 +71,9 @@ class PathRule {
 @Provider
 @Priority(Priorities.AUTHENTICATION)
 public class JWTFilter implements ContainerRequestFilter {
+
+    static final String API_KEY_HEADER = "X-PICSURE-API-Key";
+
     private final Logger logger = LoggerFactory.getLogger(JWTFilter.class);
     private static final List<PathRule> EXCLUDED_PATHS = Arrays.asList(
         new PathRule("\\/openapi\\.json$"),
@@ -434,6 +437,12 @@ public class JWTFilter implements ContainerRequestFilter {
         // There is no user associated with open access request. In order to provide traceability,
         // we set the username to OPEN_ACCESS:<request IP>
         requestMap.put("ipAddress", "OPEN_ACCESS:" + requestContext.getUriInfo().getRequestUri().getHost());
+        // PSAMA verifies the key when its enforcement flag is on and ignores the field otherwise;
+        // the key is a secret and must never be logged here
+        String apiKey = requestContext.getHeaderString(API_KEY_HEADER);
+        if (StringUtils.isNotBlank(apiKey)) {
+            requestMap.put("apiKey", apiKey);
+        }
         ObjectMapper json = PicSureWarInit.objectMapper;
 
         StringEntity entity = null;

--- a/pic-sure-api-war/src/main/resources/wildfly-configuration/standalone.xml
+++ b/pic-sure-api-war/src/main/resources/wildfly-configuration/standalone.xml
@@ -515,7 +515,7 @@
         </subsystem>
         <filters>
             <response-header name="cors" header-name="Access-Control-Allow-Origin" header-value="*"/>
-            <response-header name="cors-headers" header-name="Access-Control-Allow-Headers" header-value="Origin, X-Requested-With, Content-Type, Accept, Authorization"/>
+            <response-header name="cors-headers" header-name="Access-Control-Allow-Headers" header-value="Origin, X-Requested-With, Content-Type, Accept, Authorization, X-PICSURE-API-Key, X-Session-Id"/>
             <response-header name="cors-methods" header-name="Access-Control-Allow-Methods" header-value="GET, POST, PUT, DELETE, OPTIONS, HEAD"/>
             <response-header name="cors-credentials" header-name="Access-Control-Allow-Credentials" header-value="true"/>
             <response-header name="cors-max-age" header-name="Access-Control-Max-Age" header-value="3600"/>

--- a/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/security/JWTFilterTest.java
+++ b/pic-sure-api-war/src/test/java/edu/harvard/dbmi/avillach/security/JWTFilterTest.java
@@ -404,4 +404,56 @@ public class JWTFilterTest {
         );
     }
 
+    private ContainerRequestContext openAccessRequestContext() {
+        when(picSureWarInit.isOpenAccessEnabled()).thenReturn(true);
+        when(picSureWarInit.getOpenAccessValidateUrl()).thenReturn("http://localhost:" + port + "/open/validate");
+        stubFor(
+            post(urlEqualTo("/open/validate"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json").withBody("true"))
+        );
+
+        ContainerRequestContext ctx = createRequestContext();
+        when(ctx.getUriInfo().getPath()).thenReturn("/query/sync");
+        when(ctx.getRequest().getMethod()).thenReturn(HttpMethod.POST);
+        when(ctx.getUriInfo().getRequestUri()).thenReturn(java.net.URI.create("http://localhost/query/sync"));
+        when(ctx.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn(null);
+        when(ctx.getEntityStream()).thenReturn(new ByteArrayInputStream("{}".getBytes()));
+        return ctx;
+    }
+
+    @Test
+    public void testOpenAccessForwardsApiKeyHeaderToValidateEndpoint() throws IOException {
+        ContainerRequestContext ctx = openAccessRequestContext();
+        when(ctx.getHeaderString(JWTFilter.API_KEY_HEADER)).thenReturn("picsure_testKeyValue123");
+
+        filter.filter(ctx);
+
+        verify(
+            postRequestedFor(urlEqualTo("/open/validate"))
+                .withRequestBody(matchingJsonPath("$.apiKey", matching("picsure_testKeyValue123")))
+                .withRequestBody(matchingJsonPath("$.request.['Target Service']", matching("/query/sync")))
+        );
+        verify(ctx).setProperty("username", "OPEN_ACCESS:localhost");
+    }
+
+    @Test
+    public void testOpenAccessOmitsApiKeyFieldWhenHeaderAbsent() throws IOException {
+        ContainerRequestContext ctx = openAccessRequestContext();
+
+        filter.filter(ctx);
+
+        verify(postRequestedFor(urlEqualTo("/open/validate")).withRequestBody(notMatching("(?s).*\"apiKey\".*")));
+        verify(ctx).setProperty("username", "OPEN_ACCESS:localhost");
+    }
+
+    @Test
+    public void testOpenAccessBlankApiKeyHeaderOmitted() throws IOException {
+        ContainerRequestContext ctx = openAccessRequestContext();
+        when(ctx.getHeaderString(JWTFilter.API_KEY_HEADER)).thenReturn("   ");
+
+        filter.filter(ctx);
+
+        verify(postRequestedFor(urlEqualTo("/open/validate")).withRequestBody(notMatching("(?s).*\"apiKey\".*")));
+    }
+
 }


### PR DESCRIPTION
## What

- `JWTFilter`: for open-access requests, copies a non-blank `X-PICSURE-API-Key` header into the `apiKey` field of the request map sent to PSAMA's `/open/validate`. PSAMA verifies it when its enforcement flag is on and ignores it otherwise, so this is inert until PSAMA enforcement is enabled (hms-dbmi/pic-sure-auth-microapp#298). The key is never logged.
- CORS allowlist gains `X-PICSURE-API-Key` (future browser-based integrators using their own keys) and `X-Session-Id` — the latter is a stowaway fix: the frontend already sends it on every request, which fails preflight in cross-origin dev setups.
