### PR TITLE
Review-feedback remediation for the merged PSAR stack (PR1-7 feedback)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # pic-sure (monorepo)
 
-Maven monorepo for the PIC-SURE API platform — the gateway rewrite lands here as modules, replacing the WildFly-deployed `pic-sure-api-war` incrementally (strangler-fig). The legacy WAR remains in-repo but quarantined until decommission.
+Maven monorepo for the PIC-SURE API platform. A Spring Cloud Gateway front door plus focused Spring Boot services replace the removed
+WildFly-deployed `pic-sure-api-war` and resource modules.
 
 ## Layout
 
@@ -11,9 +12,10 @@ pic-sure/                       root pom — PARENT + aggregator
 ├── libs/
 │   ├── pic-sure-commons/       pic-sure-common aggregator (subtree of hms-dbmi/pic-sure-common)
 │   │   ├── pic-sure-api-model/     domain DTOs   (pkg edu.harvard.dbmi.avillach.{domain,util})
-│   │   └── pic-sure-hpds-model/    HPDS query model (groupId …avillach.hpds — frozen)
-│   └── pic-sure-logging-client/ audit/logging client (groupId edu.harvard.dbmi.avillach — frozen)
-├── services/
+│   │   └── pic-sure-hpds-model/    HPDS query model (groupId …avillach.hpds)
+│   ├── pic-sure-logging-client/ audit/logging client (groupId edu.harvard.dbmi.avillach)
+│   └── pic-sure-spring-commons/ DB-free shared Spring library
+└── services/
 │   ├── pic-sure-gateway/       Spring Cloud Gateway MVC front door
 │   ├── pic-sure-operations-service/    reactor module
 │   ├── pic-sure-hpds-query-service/    reactor module
@@ -22,14 +24,11 @@ pic-sure/                       root pom — PARENT + aggregator
 │   ├── pic-sure-logging/               reactor module (imported from hms-dbmi/PIC-SURE-Logging)
 │   ├── picsure-dictionary/             reactor module (imported from hms-dbmi/picsure-dictionary)
 │   └── pic-sure-visualization-service/ reactor module (imported from hms-dbmi/PIC-SURE-Visualization)
-├── pic-sure-shadow-reconciler/ reactor module (parity verification tooling)
-└── pic-sure-legacy/            QUARANTINED — WildFly WAR, Java 11/javax, own parent pom,
-                                NOT aggregated; builds independently
 ```
 
 The imported services arrived as-is with full history (`git filter-repo` merge, consolidation
-Phase 1) and were adopted onto the root parent + BOM + Java 25 in Phase 4. Only
-pic-sure-legacy remains QUARANTINED: own parent POM/JDK, builds independently, not aggregated.
+Phase 1) and were adopted onto the root parent + BOM + Java 25 in Phase 4. The legacy
+WildFly modules have since been removed; every remaining service is part of this reactor.
 
 ## Modules
 
@@ -45,21 +44,18 @@ pic-sure-legacy remains QUARANTINED: own parent POM/JDK, builds independently, n
 | services/pic-sure-logging | reactor | 25 (Javalin) | PIC-SURE Logging Build and Deploy / PIC-SURE Logging Build | done |
 | services/picsure-dictionary | reactor | 25 | PIC-SURE Dictionary API Build and Deploy (+3 DB jobs) / PIC-SURE Dictionary Build | done |
 | services/pic-sure-visualization-service | reactor | 25 | PIC-SURE Visualization Build and Deploy / PIC-SURE Visualization Build | done |
-| pic-sure-legacy/ | quarantined | 11 | PIC-SURE-API Build / PIC-SURE API Build | decommission (rewrite Phase 7) |
 
-Frozen shared libs: RETIRED (consolidation Phase 4 complete) — every service resolves the
-`3.0.0` reactor line; the Jenkins install jobs are deleted. The local `frozen/legacy-java11`
-branches in pic-sure-common / PIC-SURE-Logging-Client remain unpushed history only; the
-sibling lib repos get archived at push day. pic-sure-legacy still pins the released
-`1.0.0` artifacts from GitHub Packages (unaffected).
+Standalone shared-library release jobs are retired: every service resolves the `3.0.0`
+modules from this reactor. Previously published `1.x` artifacts remain immutable for
+historical external consumers.
 
 ## Version strategy
 
 | Line | Meaning |
 |---|---|
 | `3.0.0` (`${revision}`) | The monorepo line — Java 25, everything in the new reactor. Never publish it from the sibling repos. |
-| `2.x` | The legacy WAR family (`pic-sure-legacy` parent is `pic-sure-api:2.2.0-SNAPSHOT`). |
-| `1.x` | Frozen Java 11 releases the legacy WAR pins (e.g. `pic-sure-api-model:1.0.0`, `pic-sure-logging-client:1.0.0`). Immutable — the frozen and `3.0.0` lines must never share a coordinate+version. |
+| `2.x` | Historical legacy-WAR releases; those modules are no longer in this repository. |
+| `1.x` | Historical Java 11 shared-library releases (e.g. `pic-sure-api-model:1.0.0`, `pic-sure-logging-client:1.0.0`). Immutable — the `1.x` and `3.0.0` lines must never share a coordinate+version. |
 
 Versions are CI-friendly (`${revision}` + `flatten-maven-plugin`). Dependency versions come from the `platform` BOM (`pic-sure-bom`), which imports the Spring Boot 3.5.x and Spring Cloud 2025.0.x BOMs. Internal modules inherit everything through the root parent; **external consumers import the published `pic-sure-bom` directly** instead of inheriting the parent (see `platform/README.md`).
 
@@ -67,23 +63,16 @@ Versions are CI-friendly (`${revision}` + `flatten-maven-plugin`). Dependency ve
 
 ## Toolchain
 
-**Java 25 is the standard and is enforced** (maven-enforcer requires JDK 25 at build time, compiler `--release 25`). `.sdkmanrc` pins `25.0.3-tem` (`sdk env` to activate). The quarantined legacy tree pins its own `pic-sure-legacy/.sdkmanrc` (`11.0.30-tem`).
+**Java 25 is the standard and is enforced** (maven-enforcer requires JDK 25 at build time, compiler `--release 25`). `.sdkmanrc` pins `25.0.3-tem` (`sdk env` to activate).
 
 ## Build
 
 ```bash
-# whole new reactor (platform + libs + services); legacy is NOT included
+# whole reactor (platform + libs + services)
 mvn verify
 
 # just the gateway (and what it needs)
 mvn -pl services/pic-sure-gateway -am verify
-
-# legacy WAR (independent build, JDK 11)
-cd pic-sure-legacy && mvn package
 ```
 
 Formatting: Spotless (Eclipse formatter, config inherited from the root) — `mvn spotless:apply`.
-
-## Gateway migration
-
-Design docs live in `docs/superpowers/` (local-only, gitignored). The migration is tracked under Jira epic ALS-10463; work happens on the long-lived `pic_sure_api_rewrite` branch, merged when complete.

--- a/libs/pic-sure-commons/pic-sure-hpds-model/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/translation/QueryTranslator.java
+++ b/libs/pic-sure-commons/pic-sure-hpds-model/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/translation/QueryTranslator.java
@@ -22,9 +22,11 @@ import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.Query;
 
 /**
  * Translates a legacy (v1) {@link edu.harvard.hms.dbmi.avillach.hpds.data.query.Query} into the v3 {@link Query} shape. Pure function, no
- * I/O. Faithful to v1 semantics: each any-record-of list is an OR of its paths, and the whole query is an AND of every filter family.
- * Multiple non-empty {@code variantInfoFilters} groups (an OR the flat v3 genomic list cannot express) raise
- * {@link UntranslatableQueryException} rather than being silently merged.
+ * I/O. Preserves the v1 boolean structure: each any-record-of group is an OR of its paths, and the whole query is an AND of every filter
+ * family. One deliberate semantic deviation: any-record-of paths adopt v3 subtree matching (every concept whose path starts with the filter
+ * path), where v1 matched each path as an exact concept lookup, so a non-leaf path now matches its descendants too. Multiple non-empty
+ * {@code variantInfoFilters} groups (an OR the flat v3 genomic list cannot express) raise {@link UntranslatableQueryException} rather than
+ * being silently merged.
  */
 public class QueryTranslator {
 

--- a/libs/pic-sure-commons/pic-sure-hpds-model/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/translation/QueryTranslator.java
+++ b/libs/pic-sure-commons/pic-sure-hpds-model/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/translation/QueryTranslator.java
@@ -95,21 +95,34 @@ public class QueryTranslator {
     }
 
     /**
-     * Expands a v1 any-record-of list into one {@code ANY_RECORD_OF} filter per path, OR'd together, rather than collapsing the list to a
-     * single "highest level" concept path. Collapsing (suggested in review, since v3 HPDS matches all concepts below an ANY_RECORD_OF path)
-     * is only equivalent when the list happens to be an ancestor plus its own descendants; v1 lists can contain unrelated branches, where a
-     * single-path collapse would change results. The full expansion is faithful in both cases, at the cost of some redundancy in the
-     * ancestor+descendants case.
+     * Emits one {@code ANY_RECORD_OF} filter per maximal path in the group, OR'd together (adopted from review, ramari16 on PR #265). v3
+     * HPDS evaluates {@code ANY_RECORD_OF} by matching every concept whose path starts with the filter path, so a path that starts with
+     * another listed path matches a subset of what that other path matches and can be dropped without changing the result. An ancestor plus
+     * its own descendants collapses to just the ancestor; unrelated branches all survive. Domination is the same raw
+     * {@link String#startsWith} relation the v3 evaluator uses, which keeps the collapse exact even where string prefix and path-segment
+     * ancestry disagree.
      */
     private static PhenotypicClause anyRecordOfClause(List<String> paths) {
         List<PhenotypicClause> filters = new ArrayList<>();
-        for (String path : paths) {
+        for (String path : maximalPrefixes(paths)) {
             filters.add(new PhenotypicFilter(PhenotypicFilterType.ANY_RECORD_OF, path, null, null, null, false));
         }
         if (filters.size() == 1) {
             return filters.get(0);
         }
         return new PhenotypicSubquery(false, filters, Operator.OR);
+    }
+
+    private static List<String> maximalPrefixes(List<String> paths) {
+        LinkedHashSet<String> distinct = new LinkedHashSet<>(paths);
+        List<String> maximal = new ArrayList<>();
+        for (String path : distinct) {
+            boolean dominated = distinct.stream().anyMatch(other -> !other.equals(path) && path.startsWith(other));
+            if (!dominated) {
+                maximal.add(path);
+            }
+        }
+        return maximal;
     }
 
     private static List<GenomicFilter> buildGenomicFilters(edu.harvard.hms.dbmi.avillach.hpds.data.query.Query v1)

--- a/libs/pic-sure-commons/pic-sure-hpds-model/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/translation/QueryTranslator.java
+++ b/libs/pic-sure-commons/pic-sure-hpds-model/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/translation/QueryTranslator.java
@@ -94,6 +94,13 @@ public class QueryTranslator {
         return groups;
     }
 
+    /**
+     * Expands a v1 any-record-of list into one {@code ANY_RECORD_OF} filter per path, OR'd together, rather than collapsing the list to a
+     * single "highest level" concept path. Collapsing (suggested in review, since v3 HPDS matches all concepts below an ANY_RECORD_OF path)
+     * is only equivalent when the list happens to be an ancestor plus its own descendants; v1 lists can contain unrelated branches, where a
+     * single-path collapse would change results. The full expansion is faithful in both cases, at the cost of some redundancy in the
+     * ancestor+descendants case.
+     */
     private static PhenotypicClause anyRecordOfClause(List<String> paths) {
         List<PhenotypicClause> filters = new ArrayList<>();
         for (String path : paths) {

--- a/libs/pic-sure-commons/pic-sure-hpds-model/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/v3/PhenotypicSubquery.java
+++ b/libs/pic-sure-commons/pic-sure-hpds-model/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/v3/PhenotypicSubquery.java
@@ -11,4 +11,13 @@ public record PhenotypicSubquery(
     ) List<PhenotypicClause> phenotypicClauses,
     @Schema(description = "Specifies logic to combine `phenotypicClauses` in this subquery") Operator operator
 ) implements PhenotypicClause {
+
+    /**
+     * Null-safe: a deserialized subquery may omit {@code phenotypicClauses} entirely; treat that as no clauses so consumers like
+     * {@link Query#allFilters()} do not NPE on client-supplied JSON.
+     */
+    @Override
+    public List<PhenotypicClause> phenotypicClauses() {
+        return phenotypicClauses == null ? List.of() : phenotypicClauses;
+    }
 }

--- a/libs/pic-sure-commons/pic-sure-hpds-model/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/v3/Query.java
+++ b/libs/pic-sure-commons/pic-sure-hpds-model/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/v3/Query.java
@@ -64,8 +64,14 @@ public record Query(
     }
 
     /**
-     * Creates a UUID for this query if it does not already exist. Note: this behavior is different than previously, I do not believe there
-     * is ever a valid reason to change the id once it is set, we should verify this with full regression testing in all environments.
+     * Returns this query with a non-null {@link #id()}, generating one only when absent.
+     *
+     * <p>Semantics: the v3 {@code id} is a per-query-instance RANDOM identifier, not a stable content-derived key. It is assigned at most
+     * once — an existing id (e.g. one carried through from v1 translation by {@code QueryTranslator}) is never replaced — and is used for
+     * correlation only: HPDS log lines and file-sharing result lookup. It is deliberately NOT a dedup/caching key: HPDS derives its
+     * result-cache key separately as a UUIDv5 content hash of the query (see {@code QueryV3Service.initializeResult} in pic-sure-hpds),
+     * matching v1's {@code QueryDecorator#setId} behavior. Two identical query bodies submitted without ids therefore get different
+     * {@code id}s but the same content-hash cache key.
      *
      * @return this query or a copy of this query with the UUID set
      */

--- a/libs/pic-sure-commons/pic-sure-hpds-model/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/translation/QueryTranslatorTest.java
+++ b/libs/pic-sure-commons/pic-sure-hpds-model/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/translation/QueryTranslatorTest.java
@@ -279,30 +279,62 @@ class QueryTranslatorTest {
     }
 
     /**
-     * Pins the review question (ramari16, PR #265): even when the list is an ancestor plus its own descendants -- the one case where
-     * collapsing to the highest-level path WOULD be safe under v3 HPDS's match-all-below semantics -- the translator keeps the full
-     * one-filter-per-path expansion. Redundant, but uniformly faithful.
+     * Pins the collapse adopted from review (ramari16, PR #265): v3 HPDS evaluates ANY_RECORD_OF by matching every concept whose path
+     * starts with the filter path, so within a group any path that starts with another listed path is redundant. An ancestor plus its own
+     * descendants collapses to just the ancestor.
      */
     @Test
-    void anyRecordOfAncestorPlusDescendantsKeepsFullExpansion() throws Exception {
+    void anyRecordOfAncestorPlusDescendantsCollapsesToAncestor() throws Exception {
         Query q = v1();
         q.setAnyRecordOf(List.of("\\lab\\", "\\lab\\blood\\", "\\lab\\blood\\type\\"));
-        PhenotypicSubquery sub = asSub(QueryTranslator.translate(q).phenotypicClause());
-        assertThat(sub.operator()).isEqualTo(Operator.OR);
-        assertThat(sub.phenotypicClauses()).hasSize(3);
-        assertThat(sub.phenotypicClauses()).allSatisfy(c -> {
-            assertThat(asFilter(c).phenotypicFilterType()).isEqualTo(PhenotypicFilterType.ANY_RECORD_OF);
-            assertThat(asFilter(c).values()).isNull();
-            assertThat(asFilter(c).min()).isNull();
-            assertThat(asFilter(c).max()).isNull();
-        });
-        assertThat(sub.phenotypicClauses()).extracting(c -> asFilter(c).conceptPath())
-            .containsExactly("\\lab\\", "\\lab\\blood\\", "\\lab\\blood\\type\\");
+        PhenotypicFilter f = asFilter(QueryTranslator.translate(q).phenotypicClause());
+        assertThat(f.phenotypicFilterType()).isEqualTo(PhenotypicFilterType.ANY_RECORD_OF);
+        assertThat(f.conceptPath()).isEqualTo("\\lab\\");
+        assertThat(f.values()).isNull();
+        assertThat(f.min()).isNull();
+        assertThat(f.max()).isNull();
     }
 
     /**
-     * The reason the expansion above cannot be replaced by a highest-level-path collapse: v1 lists may span unrelated branches, where no
-     * single path covers the union. Each unrelated path must survive as its own OR'd filter.
+     * Duplicate paths and paths dominated by another listed path are dropped; survivors keep first-appearance order.
+     */
+    @Test
+    void anyRecordOfDominatedAndDuplicatePathsAreDropped() throws Exception {
+        Query q = v1();
+        q.setAnyRecordOf(List.of("\\lab\\blood\\", "\\demographics\\", "\\lab\\", "\\lab\\", "\\demographics\\age\\"));
+        PhenotypicSubquery sub = asSub(QueryTranslator.translate(q).phenotypicClause());
+        assertThat(sub.operator()).isEqualTo(Operator.OR);
+        assertThat(sub.phenotypicClauses()).extracting(c -> asFilter(c).conceptPath()).containsExactly("\\demographics\\", "\\lab\\");
+    }
+
+    /**
+     * Domination is raw string prefix, mirroring v3 evaluation exactly (PhenotypeMetaStore matches concepts by startsWith), not tree-aware
+     * path segmentation.
+     */
+    @Test
+    void anyRecordOfStringPrefixDominationMirrorsV3Matching() throws Exception {
+        Query q = v1();
+        q.setAnyRecordOf(List.of("\\lab\\hgb", "\\lab\\hgb_adjusted\\"));
+        PhenotypicFilter f = asFilter(QueryTranslator.translate(q).phenotypicClause());
+        assertThat(f.conceptPath()).isEqualTo("\\lab\\hgb");
+    }
+
+    /**
+     * The collapse is per group only. Groups are AND'd, so a path in one group must never be dropped because of a path in another.
+     */
+    @Test
+    void anyRecordOfCollapseAppliesPerGroup() throws Exception {
+        Query q = v1();
+        q.setAnyRecordOfMulti(List.of(List.of("\\a\\", "\\a\\b\\"), List.of("\\a\\c\\", "\\d\\")));
+        PhenotypicSubquery top = asSub(QueryTranslator.translate(q).phenotypicClause());
+        assertThat(top.operator()).isEqualTo(Operator.AND);
+        assertThat(asFilter(top.phenotypicClauses().get(0)).conceptPath()).isEqualTo("\\a\\");
+        PhenotypicSubquery g2 = asSub(top.phenotypicClauses().get(1));
+        assertThat(g2.phenotypicClauses()).extracting(c -> asFilter(c).conceptPath()).containsExactly("\\a\\c\\", "\\d\\");
+    }
+
+    /**
+     * Unrelated branches are all maximal, so each survives as its own OR'd filter; no single path covers the union.
      */
     @Test
     void anyRecordOfUnrelatedBranchesEachGetOwnFilter() throws Exception {

--- a/libs/pic-sure-commons/pic-sure-hpds-model/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/translation/QueryTranslatorTest.java
+++ b/libs/pic-sure-commons/pic-sure-hpds-model/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/translation/QueryTranslatorTest.java
@@ -278,6 +278,70 @@ class QueryTranslatorTest {
         assertThat(asFilter(top.phenotypicClauses().get(1)).conceptPath()).isEqualTo("\\x\\");
     }
 
+    /**
+     * Pins the review question (ramari16, PR #265): even when the list is an ancestor plus its own descendants -- the one case where
+     * collapsing to the highest-level path WOULD be safe under v3 HPDS's match-all-below semantics -- the translator keeps the full
+     * one-filter-per-path expansion. Redundant, but uniformly faithful.
+     */
+    @Test
+    void anyRecordOfAncestorPlusDescendantsKeepsFullExpansion() throws Exception {
+        Query q = v1();
+        q.setAnyRecordOf(List.of("\\lab\\", "\\lab\\blood\\", "\\lab\\blood\\type\\"));
+        PhenotypicSubquery sub = asSub(QueryTranslator.translate(q).phenotypicClause());
+        assertThat(sub.operator()).isEqualTo(Operator.OR);
+        assertThat(sub.phenotypicClauses()).hasSize(3);
+        assertThat(sub.phenotypicClauses()).allSatisfy(c -> {
+            assertThat(asFilter(c).phenotypicFilterType()).isEqualTo(PhenotypicFilterType.ANY_RECORD_OF);
+            assertThat(asFilter(c).values()).isNull();
+            assertThat(asFilter(c).min()).isNull();
+            assertThat(asFilter(c).max()).isNull();
+        });
+        assertThat(sub.phenotypicClauses()).extracting(c -> asFilter(c).conceptPath())
+            .containsExactly("\\lab\\", "\\lab\\blood\\", "\\lab\\blood\\type\\");
+    }
+
+    /**
+     * The reason the expansion above cannot be replaced by a highest-level-path collapse: v1 lists may span unrelated branches, where no
+     * single path covers the union. Each unrelated path must survive as its own OR'd filter.
+     */
+    @Test
+    void anyRecordOfUnrelatedBranchesEachGetOwnFilter() throws Exception {
+        Query q = v1();
+        q.setAnyRecordOf(List.of("\\demographics\\age\\", "\\lab\\blood\\", "\\imaging\\mri\\"));
+        PhenotypicSubquery sub = asSub(QueryTranslator.translate(q).phenotypicClause());
+        assertThat(sub.operator()).isEqualTo(Operator.OR);
+        assertThat(sub.phenotypicClauses()).extracting(c -> asFilter(c).conceptPath())
+            .containsExactly("\\demographics\\age\\", "\\lab\\blood\\", "\\imaging\\mri\\");
+    }
+
+    @Test
+    void anyRecordOfMultiNullInnerListIsSkipped() throws Exception {
+        Query q = v1();
+        List<List<String>> multi = new ArrayList<>();
+        multi.add(null);
+        multi.add(List.of("\\kept\\"));
+        q.setAnyRecordOfMulti(multi);
+        // null group skipped -> only the single-path group survives -> bare filter, no wrapper
+        PhenotypicFilter f = asFilter(QueryTranslator.translate(q).phenotypicClause());
+        assertThat(f.phenotypicFilterType()).isEqualTo(PhenotypicFilterType.ANY_RECORD_OF);
+        assertThat(f.conceptPath()).isEqualTo("\\kept\\");
+    }
+
+    @Test
+    void multipleAnyRecordOfMultiGroupsFormAndOfOrsInListOrder() throws Exception {
+        Query q = v1();
+        q.setAnyRecordOfMulti(List.of(List.of("\\g1a\\", "\\g1b\\"), List.of("\\g2a\\", "\\g2b\\")));
+        PhenotypicSubquery top = asSub(QueryTranslator.translate(q).phenotypicClause());
+        assertThat(top.operator()).isEqualTo(Operator.AND);
+        assertThat(top.phenotypicClauses()).hasSize(2);
+        PhenotypicSubquery first = asSub(top.phenotypicClauses().get(0));
+        PhenotypicSubquery second = asSub(top.phenotypicClauses().get(1));
+        assertThat(first.operator()).isEqualTo(Operator.OR);
+        assertThat(first.phenotypicClauses()).extracting(c -> asFilter(c).conceptPath()).containsExactly("\\g1a\\", "\\g1b\\");
+        assertThat(second.operator()).isEqualTo(Operator.OR);
+        assertThat(second.phenotypicClauses()).extracting(c -> asFilter(c).conceptPath()).containsExactly("\\g2a\\", "\\g2b\\");
+    }
+
     @Test
     void anyRecordOfGroupCombinesWithCategoryUnderAnd() throws Exception {
         Query q = v1();
@@ -287,6 +351,25 @@ class QueryTranslatorTest {
         assertThat(top.operator()).isEqualTo(Operator.AND);
         assertThat(asFilter(top.phenotypicClauses().get(0)).phenotypicFilterType()).isEqualTo(PhenotypicFilterType.FILTER);
         assertThat(asSub(top.phenotypicClauses().get(1)).operator()).isEqualTo(Operator.OR);
+    }
+
+    @Test
+    void categoryFilterWithNullValuesArrayYieldsNullValues() throws Exception {
+        Query q = v1();
+        Map<String, String[]> cats = new TreeMap<>();
+        cats.put("\\nullvals\\", null);
+        q.setCategoryFilters(cats);
+        PhenotypicFilter f = asFilter(QueryTranslator.translate(q).phenotypicClause());
+        assertThat(f.phenotypicFilterType()).isEqualTo(PhenotypicFilterType.FILTER);
+        assertThat(f.values()).isNull();
+    }
+
+    @Test
+    void categoryValuesAreDedupedPreservingFirstOccurrenceOrder() throws Exception {
+        Query q = v1();
+        q.setCategoryFilters(Map.of("\\sex\\", new String[] {"M", "F", "M"}));
+        PhenotypicFilter f = asFilter(QueryTranslator.translate(q).phenotypicClause());
+        assertThat(f.values()).containsExactly("M", "F");
     }
 
     // ---------- genomic ----------

--- a/libs/pic-sure-commons/pic-sure-hpds-model/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/v3/QueryTest.java
+++ b/libs/pic-sure-commons/pic-sure-hpds-model/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/v3/QueryTest.java
@@ -83,6 +83,32 @@ public class QueryTest {
     }
 
     @Test
+    public void allFilters_nullPhenotypicClausesListFromJson_returnsEmptyInsteadOfNpe() throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        // A client can legally omit phenotypicClauses on a subquery; that must not NPE downstream.
+        String json = "{\"phenotypicClause\":{\"phenotypicClauses\":null,\"operator\":\"AND\"},\"expectedResultType\":\"COUNT\"}";
+
+        Query deserialized = objectMapper.readValue(json, Query.class);
+
+        assertEquals(List.of(), deserialized.allFilters());
+        PhenotypicSubquery sub = (PhenotypicSubquery) deserialized.phenotypicClause();
+        assertEquals(List.of(), sub.phenotypicClauses());
+    }
+
+    @Test
+    public void allFilters_nullElementInPhenotypicClausesFromJson_isIgnored() throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        String json = "{\"phenotypicClause\":{\"phenotypicClauses\":[null,"
+            + "{\"phenotypicFilterType\":\"FILTER\",\"conceptPath\":\"\\\\abc\\\\\",\"min\":1.0}],\"operator\":\"AND\"}}";
+
+        Query deserialized = objectMapper.readValue(json, Query.class);
+
+        List<PhenotypicFilter> filters = deserialized.allFilters();
+        assertEquals(1, filters.size());
+        assertEquals("\\abc\\", filters.get(0).conceptPath());
+    }
+
+    @Test
     public void generateId_nullId_createNewId() {
         Query query = new Query(List.of("PATIENT_ID"), List.of(), null, List.of(), ResultType.COUNT, null, null);
 

--- a/libs/pic-sure-logging-client/src/main/java/edu/harvard/dbmi/avillach/logging/JdkHttpSender.java
+++ b/libs/pic-sure-logging-client/src/main/java/edu/harvard/dbmi/avillach/logging/JdkHttpSender.java
@@ -4,21 +4,49 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 final class JdkHttpSender implements Sender {
 
     private static final Logger LOG = LoggerFactory.getLogger(LoggingClient.class);
 
+    /**
+     * Maximum sends awaiting completion before new events are dropped (drop-newest). Combined with the per-request timeout this bounds the
+     * memory a slow or downed logging service can pin in the calling service; the caller is never blocked.
+     */
+    static final int DEFAULT_MAX_IN_FLIGHT = 1000;
+
+    private static final long DROP_WARN_INTERVAL_NANOS = TimeUnit.SECONDS.toNanos(10);
+
     private final java.net.http.HttpClient httpClient;
+    private final int maxInFlight;
+    private final Semaphore inFlight;
+    private final AtomicLong dropped = new AtomicLong();
+    private final AtomicLong lastDropWarnNanos;
 
     JdkHttpSender(LoggingClientConfig config) {
+        this(config, DEFAULT_MAX_IN_FLIGHT);
+    }
+
+    JdkHttpSender(LoggingClientConfig config, int maxInFlight) {
         this.httpClient = java.net.http.HttpClient.newBuilder().connectTimeout(config.getConnectTimeout()).build();
+        this.maxInFlight = maxInFlight;
+        this.inFlight = new Semaphore(maxInFlight);
+        // Seed one interval in the past so the very first drop is warned about immediately.
+        this.lastDropWarnNanos = new AtomicLong(System.nanoTime() - DROP_WARN_INTERVAL_NANOS);
     }
 
     @Override
     public void send(
         byte[] body, URI auditEndpoint, LoggingClientConfig config, LoggingEvent resolved, String bearerToken, String requestId
     ) {
+
+        if (!inFlight.tryAcquire()) {
+            recordDrop(resolved);
+            return;
+        }
 
         java.net.http.HttpRequest.Builder requestBuilder = java.net.http.HttpRequest.newBuilder().uri(auditEndpoint)
             .timeout(config.getRequestTimeout()).header("Content-Type", "application/json").header("X-API-Key", config.getApiKey())
@@ -31,16 +59,46 @@ final class JdkHttpSender implements Sender {
             requestBuilder.header("X-Request-Id", requestId);
         }
 
-        httpClient.sendAsync(requestBuilder.build(), java.net.http.HttpResponse.BodyHandlers.discarding()).thenAccept(response -> {
-            if (response.statusCode() >= 300) {
-                LOG.warn("logging-client: server returned {} for event_type={}", response.statusCode(), resolved.getEventType());
-            }
-        }).exceptionally(throwable -> {
+        try {
+            httpClient.sendAsync(requestBuilder.build(), java.net.http.HttpResponse.BodyHandlers.discarding())
+                .whenComplete((response, throwable) -> {
+                    inFlight.release();
+                    if (throwable != null) {
+                        LOG.warn(
+                            "logging-client: failed to send event_type={}: {} - {}", resolved.getEventType(),
+                            throwable.getClass().getSimpleName(), LoggingClient.sanitizeExceptionMessageForSender(throwable)
+                        );
+                    } else if (response.statusCode() >= 300) {
+                        LOG.warn("logging-client: server returned {} for event_type={}", response.statusCode(), resolved.getEventType());
+                    }
+                });
+        } catch (RuntimeException e) {
+            inFlight.release();
             LOG.warn(
-                "logging-client: failed to send event_type={}: {} - {}", resolved.getEventType(), throwable.getClass().getSimpleName(),
-                LoggingClient.sanitizeExceptionMessageForSender(throwable)
+                "logging-client: failed to submit event_type={}: {} - {}", resolved.getEventType(), e.getClass().getSimpleName(),
+                LoggingClient.sanitizeExceptionMessageForSender(e)
             );
-            return null;
-        });
+        }
+    }
+
+    /** Drop-newest under backpressure; warn at most once per interval, carrying a running total so drops stay visible without log spam. */
+    private void recordDrop(LoggingEvent resolved) {
+        long droppedSoFar = dropped.incrementAndGet();
+        long now = System.nanoTime();
+        long last = lastDropWarnNanos.get();
+        if (now - last >= DROP_WARN_INTERVAL_NANOS && lastDropWarnNanos.compareAndSet(last, now)) {
+            LOG.warn(
+                "logging-client: dropping event_type={} - {} sends already in flight ({} events dropped so far)", resolved.getEventType(),
+                maxInFlight, droppedSoFar
+            );
+        }
+    }
+
+    long droppedCount() {
+        return dropped.get();
+    }
+
+    int availablePermits() {
+        return inFlight.availablePermits();
     }
 }

--- a/libs/pic-sure-logging-client/src/main/java/edu/harvard/dbmi/avillach/logging/LoggingClientConfig.java
+++ b/libs/pic-sure-logging-client/src/main/java/edu/harvard/dbmi/avillach/logging/LoggingClientConfig.java
@@ -1,5 +1,7 @@
 package edu.harvard.dbmi.avillach.logging;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.Duration;
 
 /**
@@ -59,7 +61,33 @@ public final class LoggingClientConfig {
         if (apiKey == null || apiKey.trim().isEmpty()) {
             throw new IllegalArgumentException("apiKey is required");
         }
+        requireHttpUrl(baseUrl);
         return new Builder(baseUrl, apiKey);
+    }
+
+    /**
+     * A scheme-less or malformed baseUrl would otherwise surface only at send time ({@code HttpRequest} rejects non-absolute URIs), turning
+     * every fire-and-forget send into a synchronous exception. Fail at construction with a clear message instead.
+     */
+    private static void requireHttpUrl(String baseUrl) {
+        URI uri;
+        try {
+            uri = new URI(baseUrl.trim());
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("baseUrl is not a valid URL: " + baseUrl, e);
+        }
+        String scheme = uri.getScheme();
+        boolean http = "http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme);
+        if (!http || uri.getHost() == null) {
+            throw new IllegalArgumentException("baseUrl must be an absolute http(s) URL with a host, got: " + baseUrl);
+        }
+    }
+
+    private static Duration requirePositive(Duration duration, String name) {
+        if (duration == null || duration.isZero() || duration.isNegative()) {
+            throw new IllegalArgumentException(name + " must be a positive duration, got: " + duration);
+        }
+        return duration;
     }
 
     public static final class Builder {
@@ -80,12 +108,12 @@ public final class LoggingClientConfig {
         }
 
         public Builder connectTimeout(Duration connectTimeout) {
-            this.connectTimeout = connectTimeout;
+            this.connectTimeout = requirePositive(connectTimeout, "connectTimeout");
             return this;
         }
 
         public Builder requestTimeout(Duration requestTimeout) {
-            this.requestTimeout = requestTimeout;
+            this.requestTimeout = requirePositive(requestTimeout, "requestTimeout");
             return this;
         }
 

--- a/libs/pic-sure-logging-client/src/main/java/edu/harvard/dbmi/avillach/logging/SessionIdResolver.java
+++ b/libs/pic-sure-logging-client/src/main/java/edu/harvard/dbmi/avillach/logging/SessionIdResolver.java
@@ -16,22 +16,45 @@ public final class SessionIdResolver {
     private static final int HASH_HEX_LENGTH = 16;
     private static final char[] HEX = "0123456789abcdef".toCharArray();
 
+    /** Cap on client-supplied session ids; anything a well-behaved client sends (UUIDs, opaque tokens) fits comfortably. */
+    static final int MAX_SESSION_ID_LENGTH = 128;
+
     private SessionIdResolver() {}
 
     /**
      * Resolve a session identifier.
      *
+     * <p>The header value is client-controlled and flows into audit events, so it is sanitized before use: control characters (log/JSON
+     * injection vectors such as CR/LF) are stripped and the result is truncated to {@link #MAX_SESSION_ID_LENGTH} characters. If nothing
+     * survives sanitization, the hash fallback is used.
+     *
      * @param sessionIdHeader the value of the {@code X-Session-Id} header (may be null or empty)
      * @param srcIp the client IP address (may be null)
      * @param userAgent the {@code User-Agent} header value (may be null)
-     * @return a non-null session identifier — either the header value or a 16-char hex SHA-256 hash of IP + User-Agent
+     * @return a non-null session identifier — either the sanitized header value or a 16-char hex SHA-256 hash of IP + User-Agent
      */
     public static String resolve(String sessionIdHeader, String srcIp, String userAgent) {
-        if (sessionIdHeader != null && !sessionIdHeader.isEmpty()) {
-            return sessionIdHeader;
+        String sanitized = sanitize(sessionIdHeader);
+        if (sanitized != null) {
+            return sanitized;
         }
         String raw = (srcIp != null ? srcIp : "") + "|" + (userAgent != null ? userAgent : "");
         return sha256Hex(raw, HASH_HEX_LENGTH);
+    }
+
+    /** Strips ISO control characters and caps length; returns null when nothing usable remains. */
+    private static String sanitize(String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder(Math.min(value.length(), MAX_SESSION_ID_LENGTH));
+        for (int i = 0; i < value.length() && sb.length() < MAX_SESSION_ID_LENGTH; i++) {
+            char c = value.charAt(i);
+            if (!Character.isISOControl(c)) {
+                sb.append(c);
+            }
+        }
+        return sb.length() == 0 ? null : sb.toString();
     }
 
     static String sha256Hex(String input, int hexLength) {

--- a/libs/pic-sure-logging-client/src/test/java/edu/harvard/dbmi/avillach/logging/JdkHttpSenderTest.java
+++ b/libs/pic-sure-logging-client/src/test/java/edu/harvard/dbmi/avillach/logging/JdkHttpSenderTest.java
@@ -1,0 +1,59 @@
+package edu.harvard.dbmi.avillach.logging;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.ServerSocket;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JdkHttpSenderTest {
+
+    private static final byte[] BODY = "{}".getBytes(StandardCharsets.UTF_8);
+
+    private static LoggingClientConfig config(String baseUrl, Duration connect, Duration request) {
+        return LoggingClientConfig.builder(baseUrl, "test-key").connectTimeout(connect).requestTimeout(request).build();
+    }
+
+    @Test
+    void dropsNewestWhenInFlightCapIsReached() throws Exception {
+        // A ServerSocket that is never accepted from: the TCP handshake succeeds (backlog) but no HTTP
+        // response ever arrives, so the first send parks in flight until the request timeout.
+        try (ServerSocket server = new ServerSocket(0)) {
+            LoggingClientConfig config = config("http://127.0.0.1:" + server.getLocalPort(), Duration.ofSeconds(2), Duration.ofSeconds(10));
+            JdkHttpSender sender = new JdkHttpSender(config, 1);
+            URI endpoint = URI.create(config.getBaseUrl() + "/audit");
+            LoggingEvent event = LoggingEvent.builder("TEST").build();
+
+            sender.send(BODY, endpoint, config, event, null, null); // occupies the single permit
+            sender.send(BODY, endpoint, config, event, null, null);
+            sender.send(BODY, endpoint, config, event, null, null);
+
+            assertEquals(2, sender.droppedCount(), "sends past the in-flight cap should be dropped, not queued");
+            assertEquals(0, sender.availablePermits());
+        }
+    }
+
+    @Test
+    void releasesPermitWhenSendCompletesExceptionally() throws Exception {
+        // Connection refused: the async send completes exceptionally almost immediately and MUST return its permit.
+        int refusedPort;
+        try (ServerSocket probe = new ServerSocket(0)) {
+            refusedPort = probe.getLocalPort();
+        }
+        LoggingClientConfig config = config("http://127.0.0.1:" + refusedPort, Duration.ofMillis(500), Duration.ofSeconds(1));
+        JdkHttpSender sender = new JdkHttpSender(config, 1);
+        URI endpoint = URI.create(config.getBaseUrl() + "/audit");
+
+        sender.send(BODY, endpoint, config, LoggingEvent.builder("TEST").build(), null, null);
+
+        long deadline = System.currentTimeMillis() + 5000;
+        while (sender.availablePermits() < 1 && System.currentTimeMillis() < deadline) {
+            Thread.sleep(20);
+        }
+        assertEquals(1, sender.availablePermits(), "permit should be released after exceptional completion");
+        assertEquals(0, sender.droppedCount());
+    }
+}

--- a/libs/pic-sure-logging-client/src/test/java/edu/harvard/dbmi/avillach/logging/LoggingClientConfigTest.java
+++ b/libs/pic-sure-logging-client/src/test/java/edu/harvard/dbmi/avillach/logging/LoggingClientConfigTest.java
@@ -1,0 +1,55 @@
+package edu.harvard.dbmi.avillach.logging;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LoggingClientConfigTest {
+
+    @Test
+    void buildsWithValidValues() {
+        LoggingClientConfig config = LoggingClientConfig.builder("http://pic-sure-logging:80/", "key").clientType("api")
+            .connectTimeout(Duration.ofSeconds(1)).requestTimeout(Duration.ofSeconds(2)).build();
+
+        assertEquals("http://pic-sure-logging:80", config.getBaseUrl(), "trailing slash should be normalized away");
+        assertEquals(Duration.ofSeconds(1), config.getConnectTimeout());
+        assertEquals(Duration.ofSeconds(2), config.getRequestTimeout());
+    }
+
+    @Test
+    void rejectsNullOrBlankBaseUrlAndApiKey() {
+        assertThrows(IllegalArgumentException.class, () -> LoggingClientConfig.builder(null, "key"));
+        assertThrows(IllegalArgumentException.class, () -> LoggingClientConfig.builder("  ", "key"));
+        assertThrows(IllegalArgumentException.class, () -> LoggingClientConfig.builder("http://host", null));
+        assertThrows(IllegalArgumentException.class, () -> LoggingClientConfig.builder("http://host", "  "));
+    }
+
+    @Test
+    void rejectsSchemelessOrNonHttpBaseUrl() {
+        // Would otherwise only fail at send time: HttpRequest requires an absolute URI.
+        assertThrows(IllegalArgumentException.class, () -> LoggingClientConfig.builder("pic-sure-logging:80", "key"));
+        assertThrows(IllegalArgumentException.class, () -> LoggingClientConfig.builder("logging-service", "key"));
+        assertThrows(IllegalArgumentException.class, () -> LoggingClientConfig.builder("ftp://host/audit", "key"));
+    }
+
+    @Test
+    void rejectsMalformedBaseUrl() {
+        IllegalArgumentException e =
+            assertThrows(IllegalArgumentException.class, () -> LoggingClientConfig.builder("http://host with spaces", "key"));
+        assertTrue(e.getMessage().contains("baseUrl"), "message should name the bad field, got: " + e.getMessage());
+    }
+
+    @Test
+    void rejectsNullZeroOrNegativeTimeouts() {
+        LoggingClientConfig.Builder builder = LoggingClientConfig.builder("http://host", "key");
+
+        assertThrows(IllegalArgumentException.class, () -> builder.connectTimeout(null));
+        assertThrows(IllegalArgumentException.class, () -> builder.connectTimeout(Duration.ZERO));
+        assertThrows(IllegalArgumentException.class, () -> builder.connectTimeout(Duration.ofSeconds(-1)));
+        assertThrows(IllegalArgumentException.class, () -> builder.requestTimeout(null));
+        assertThrows(IllegalArgumentException.class, () -> builder.requestTimeout(Duration.ZERO));
+        assertThrows(IllegalArgumentException.class, () -> builder.requestTimeout(Duration.ofSeconds(-1)));
+    }
+}

--- a/libs/pic-sure-logging-client/src/test/java/edu/harvard/dbmi/avillach/logging/SessionIdResolverTest.java
+++ b/libs/pic-sure-logging-client/src/test/java/edu/harvard/dbmi/avillach/logging/SessionIdResolverTest.java
@@ -51,6 +51,27 @@ class SessionIdResolverTest {
     }
 
     @Test
+    void truncatesOverlongHeaderValues() {
+        String longId = "a".repeat(500);
+        String result = SessionIdResolver.resolve(longId, "10.0.0.1", "Mozilla/5.0");
+        assertEquals(SessionIdResolver.MAX_SESSION_ID_LENGTH, result.length());
+        assertEquals("a".repeat(SessionIdResolver.MAX_SESSION_ID_LENGTH), result);
+    }
+
+    @Test
+    void stripsControlCharactersFromHeaderValue() {
+        String result = SessionIdResolver.resolve("abc\r\n123\txyz", "10.0.0.1", "Mozilla/5.0");
+        assertEquals("abc123xyz", result);
+    }
+
+    @Test
+    void fallsBackToHashWhenHeaderIsOnlyControlCharacters() {
+        String result = SessionIdResolver.resolve("\r\n\t", "10.0.0.1", "Mozilla/5.0");
+        assertEquals(SessionIdResolver.resolve(null, "10.0.0.1", "Mozilla/5.0"), result);
+        assertEquals(16, result.length());
+    }
+
+    @Test
     void hashIsLowercaseHex() {
         String result = SessionIdResolver.resolve(null, "10.0.0.1", "Mozilla/5.0");
         assertTrue(result.matches("[0-9a-f]{16}"), "Hash should be 16 lowercase hex characters, got: " + result);

--- a/libs/pic-sure-spring-commons/src/main/java/edu/harvard/hms/dbmi/avillach/commons/audit/AuditContext.java
+++ b/libs/pic-sure-spring-commons/src/main/java/edu/harvard/hms/dbmi/avillach/commons/audit/AuditContext.java
@@ -1,5 +1,6 @@
 package edu.harvard.hms.dbmi.avillach.commons.audit;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -19,7 +20,8 @@ public class AuditContext {
         }
     }
 
+    /** Read-only live view of the accumulated metadata; use {@link #put(String, Object)} to add entries. */
     public Map<String, Object> getMetadata() {
-        return metadata;
+        return Collections.unmodifiableMap(metadata);
     }
 }

--- a/libs/pic-sure-spring-commons/src/main/java/edu/harvard/hms/dbmi/avillach/commons/audit/AuditLoggingFilter.java
+++ b/libs/pic-sure-spring-commons/src/main/java/edu/harvard/hms/dbmi/avillach/commons/audit/AuditLoggingFilter.java
@@ -126,10 +126,16 @@ public class AuditLoggingFilter extends OncePerRequestFilter {
         }
     }
 
+    /**
+     * Takes the RIGHTMOST X-Forwarded-For entry, not the leftmost: clients can send an arbitrary XFF header of their own, and the trusted
+     * front proxy (AIO httpd) APPENDS the address it saw -- so the rightmost entry is the nearest trusted hop and cannot be client-forged,
+     * while the leftmost is whatever the client chose to send.
+     */
     private String resolveSourceIp(HttpServletRequest request) {
         String forwardedFor = request.getHeader("X-Forwarded-For");
         if (forwardedFor != null && !forwardedFor.isBlank()) {
-            return forwardedFor.split(",")[0].trim();
+            String[] hops = forwardedFor.split(",");
+            return hops[hops.length - 1].trim();
         }
         return request.getRemoteAddr();
     }

--- a/libs/pic-sure-spring-commons/src/test/java/edu/harvard/hms/dbmi/avillach/commons/audit/AuditContextTest.java
+++ b/libs/pic-sure-spring-commons/src/test/java/edu/harvard/hms/dbmi/avillach/commons/audit/AuditContextTest.java
@@ -1,6 +1,9 @@
 package edu.harvard.hms.dbmi.avillach.commons.audit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -31,5 +34,21 @@ class AuditContextTest {
         context.put("key", null);
 
         assertThat(context.getMetadata()).isEmpty();
+    }
+
+    @Test
+    void getMetadataIsAnUnmodifiableLiveView() {
+        AuditContext context = new AuditContext();
+        context.put("resource_id", "abc-123");
+
+        Map<String, Object> view = context.getMetadata();
+
+        assertThatThrownBy(() -> view.put("injected", "x")).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> view.remove("resource_id")).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(view::clear).isInstanceOf(UnsupportedOperationException.class);
+        assertThat(context.getMetadata()).containsEntry("resource_id", "abc-123");
+
+        context.put("username", "researcher1");
+        assertThat(view).containsEntry("username", "researcher1");
     }
 }

--- a/libs/pic-sure-spring-commons/src/test/java/edu/harvard/hms/dbmi/avillach/commons/audit/AuditLoggingFilterTest.java
+++ b/libs/pic-sure-spring-commons/src/test/java/edu/harvard/hms/dbmi/avillach/commons/audit/AuditLoggingFilterTest.java
@@ -109,6 +109,43 @@ class AuditLoggingFilterTest {
         assertThat(event.getRequest().getReferrer()).isEqualTo("https://picsure.example.org/explore");
     }
 
+    void srcIpIsTheRightmostXffEntrySoAClientSuppliedLeadingEntryIsNeverUsed() throws Exception {
+        LoggingClient client = mock(LoggingClient.class);
+        when(client.isEnabled()).thenReturn(true);
+        AuditLoggingFilter filter = new AuditLoggingFilter(client, routes, new AuditContext(), List.of());
+
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/query/sync");
+        // A client can send its own X-Forwarded-For; the trusted front proxy APPENDS the address it
+        // actually saw, so only the rightmost entry is trustworthy.
+        request.addHeader("X-Forwarded-For", "6.6.6.6, 203.0.113.9");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        response.setStatus(200);
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        ArgumentCaptor<LoggingEvent> eventCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
+        verify(client, times(1)).send(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().getRequest().getSrcIp()).isEqualTo("203.0.113.9");
+    }
+
+    @Test
+    void srcIpFallsBackToRemoteAddrWithoutAnXffHeader() throws Exception {
+        LoggingClient client = mock(LoggingClient.class);
+        when(client.isEnabled()).thenReturn(true);
+        AuditLoggingFilter filter = new AuditLoggingFilter(client, routes, new AuditContext(), List.of());
+
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/query/sync");
+        request.setRemoteAddr("192.0.2.44");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        response.setStatus(200);
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        ArgumentCaptor<LoggingEvent> eventCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
+        verify(client, times(1)).send(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().getRequest().getSrcIp()).isEqualTo("192.0.2.44");
+    }
+
     @Test
     void doesNotEmitWhenTheRequestIsSkipped() throws Exception {
         LoggingClient client = mock(LoggingClient.class);

--- a/services/pic-sure-gateway/Dockerfile
+++ b/services/pic-sure-gateway/Dockerfile
@@ -2,4 +2,7 @@ FROM amazoncorretto:25
 WORKDIR /app
 COPY target/pic-sure-gateway-*.jar /app/app.jar
 EXPOSE 8080
+
+# run unprivileged: the image only reads the root-owned jar, so a bare numeric non-root UID suffices (satisfies runAsNonRoot)
+USER 1000:1000
 ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} -jar /app/app.jar --spring.profiles.active=${SPRING_PROFILE:-aio}"]

--- a/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/GatewayApplication.java
+++ b/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/GatewayApplication.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class GatewayApplication {
 
-    static void main(String[] args) {
+    public static void main(String[] args) {
         SpringApplication.run(GatewayApplication.class, args);
     }
 }

--- a/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/config/GatewaySecurityProperties.java
+++ b/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/config/GatewaySecurityProperties.java
@@ -10,7 +10,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  */
 @ConfigurationProperties(prefix = "picsure.gateway.security")
 public record GatewaySecurityProperties(
-    List<String> allowListPrefixes, boolean openAccessEnabled, String userIdClaim,
+    List<String> allowListPrefixes, boolean openAccessEnabled,
     // GATEWAY_AUTH_MAX_BODY_BYTES -- auth-buffering cap; 413 over it
     int maxBodyBytes, String introspectionUrl, String openAccessValidateUrl, String serviceToken,
     // OPERATIONS_SERVICE_URL -- for QueryAuthFetcher dispatch (dispatch lives on operations-service,
@@ -21,9 +21,6 @@ public record GatewaySecurityProperties(
 ) {
     public GatewaySecurityProperties {
         allowListPrefixes = allowListPrefixes == null ? List.of() : List.copyOf(allowListPrefixes);
-        if (userIdClaim == null) {
-            userIdClaim = "userId";
-        }
         if (maxBodyBytes <= 0) {
             maxBodyBytes = 10_485_760; // 10 MiB default (GATEWAY_AUTH_MAX_BODY_BYTES)
         }

--- a/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/config/ObservabilityConfig.java
+++ b/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/config/ObservabilityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.core.Ordered;
 import edu.harvard.hms.dbmi.avillach.commons.request.RequestIdFilter;
 import edu.harvard.hms.dbmi.avillach.gateway.request.AccessLogFilter;
 import edu.harvard.hms.dbmi.avillach.gateway.request.InboundIdentityHeaderSanitizingFilter;
+import edu.harvard.hms.dbmi.avillach.gateway.request.InternalEndpointGuardFilter;
 
 @Configuration
 public class ObservabilityConfig {
@@ -37,6 +38,17 @@ public class ObservabilityConfig {
         FilterRegistrationBean<InboundIdentityHeaderSanitizingFilter> registration =
             new FilterRegistrationBean<>(new InboundIdentityHeaderSanitizingFilter());
         registration.setOrder(Ordered.HIGHEST_PRECEDENCE + 2);
+        return registration;
+    }
+
+    /**
+     * Also registered UNCONDITIONALLY, right after the sanitizer: {@code /operations/internal/**} is service-to-service only and must never
+     * be reachable through the public gateway. See {@link InternalEndpointGuardFilter}'s Javadoc.
+     */
+    @Bean
+    public FilterRegistrationBean<InternalEndpointGuardFilter> internalEndpointGuardFilter() {
+        FilterRegistrationBean<InternalEndpointGuardFilter> registration = new FilterRegistrationBean<>(new InternalEndpointGuardFilter());
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE + 3);
         return registration;
     }
 }

--- a/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/config/SecurityConfig.java
+++ b/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/config/SecurityConfig.java
@@ -114,9 +114,7 @@ public class SecurityConfig {
     FilterRegistrationBean<PsamaIntrospectionFilter> introspectionFilter(
         PsamaClient client, AuditContext audit, ObjectMapper json, QueryAuthFetcher fetcher, GatewaySecurityProperties props
     ) {
-        var r = new FilterRegistrationBean<>(
-            new PsamaIntrospectionFilter(client, audit, json, fetcher, props.allowListPrefixes(), props.userIdClaim())
-        );
+        var r = new FilterRegistrationBean<>(new PsamaIntrospectionFilter(client, audit, json, fetcher, props.allowListPrefixes()));
         r.setOrder(30);
         r.addUrlPatterns("/*");
         return r;

--- a/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/filter/OpenAccessFilter.java
+++ b/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/filter/OpenAccessFilter.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -38,6 +40,8 @@ public class OpenAccessFilter extends OncePerRequestFilter {
      */
     public static final String ATTR_OPEN_ACCESS_GRANTED = OpenAccessFilter.class.getName() + ".granted";
 
+    private static final Logger log = LoggerFactory.getLogger(OpenAccessFilter.class);
+
     private final PsamaClient psama;
     private final AuditContext audit;
     private final ObjectMapper json;
@@ -67,7 +71,20 @@ public class OpenAccessFilter extends OncePerRequestFilter {
         String hostMarker = openAccessIpAddress(req);
         body.put("ipAddress", hostMarker); // NO token field (JWTFilter.java:389-394)
 
-        if (!psama.validateOpenAccess(body)) {
+        boolean granted;
+        try {
+            granted = psama.validateOpenAccess(body);
+        } catch (Exception e) {
+            // Mirror PsamaIntrospectionFilter's transport-failure handling: keep the gateway error shape
+            // (rather than Spring's default 500) and record the same audit failure the deny path records.
+            log.error("PSAMA open-access validation failed", e);
+            audit.put("auth_result", "failure");
+            audit.put("auth_action", "open_access.denied");
+            audit.put("auth_failure_reason", "open_access_unreachable");
+            GatewayErrors.write(resp, HttpStatus.BAD_GATEWAY, "open_access_unreachable", "Open access validation failed.");
+            return;
+        }
+        if (!granted) {
             audit.put("auth_result", "failure");
             audit.put("auth_action", "open_access.denied");
             GatewayErrors.write(resp, HttpStatus.UNAUTHORIZED, "unauthorized", "User is not authorized.");

--- a/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/filter/PsamaIntrospectionFilter.java
+++ b/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/filter/PsamaIntrospectionFilter.java
@@ -105,7 +105,7 @@ public class PsamaIntrospectionFilter extends OncePerRequestFilter {
         String path = req.getRequestURI() == null ? "" : req.getRequestURI();
         String method = req.getMethod();
 
-        if ("GET".equals(method) && (path.equals("/system/status") || path.equals("/v3/system/status"))) {
+        if ("GET".equals(method) && path.equals("/system/status")) {
             audit.put("username", "SYSTEM_MONITOR");
             chain.doFilter(req, resp);
             return;

--- a/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/filter/PsamaIntrospectionFilter.java
+++ b/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/filter/PsamaIntrospectionFilter.java
@@ -64,18 +64,15 @@ public class PsamaIntrospectionFilter extends OncePerRequestFilter {
     private final ObjectMapper json;
     private final QueryAuthFetcher queryAuthFetcher;
     private final List<String> allowListPrefixes;
-    private final String userIdClaim;
 
     public PsamaIntrospectionFilter(
-        PsamaClient psama, AuditContext audit, ObjectMapper json, QueryAuthFetcher queryAuthFetcher, List<String> allowListPrefixes,
-        String userIdClaim
+        PsamaClient psama, AuditContext audit, ObjectMapper json, QueryAuthFetcher queryAuthFetcher, List<String> allowListPrefixes
     ) {
         this.psama = psama;
         this.audit = audit;
         this.json = json;
         this.queryAuthFetcher = queryAuthFetcher;
         this.allowListPrefixes = List.copyOf(allowListPrefixes);
-        this.userIdClaim = userIdClaim;
     }
 
     @Override

--- a/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/request/InboundIdentityHeaderSanitizingFilter.java
+++ b/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/request/InboundIdentityHeaderSanitizingFilter.java
@@ -18,15 +18,18 @@ import jakarta.servlet.http.HttpServletResponse;
 /**
  * Defense-in-depth, registered UNCONDITIONALLY (see {@code ObservabilityConfig}): strips the five gateway-owned {@code X-User-*} identity
  * headers ({@link GatewayUserResolver#HEADER_USER_ID}, {@code _SUBJECT}, {@code _EMAIL}, {@code _ROLES}, {@code _PRIVILEGES}) and
- * {@link GatewayUserResolver#HEADER_ACCESS_TYPE} from every inbound CLIENT request before anything downstream -- routing, the auth chain,
- * or the WildFly proxy -- can ever see a client-supplied value. <p>
- * {@link edu.harvard.hms.dbmi.avillach.gateway.filter.IdentityPropagationFilter} already hides these headers from the client, but this
- * filter exists as an independent trust boundary: even if the DB-free auth chain were ever bypassed, misconfigured, or WildFly is
- * nonetheless configured to trust these headers directly from the gateway (its {@code GatewayHeaderFilter}), a client's own
- * {@code X-User-Id}/{@code X-User-Privileges}/etc. must never pass through untouched -- that would be an identity/privilege-spoofing hole.
- * This filter closes that hole unconditionally, independent of anything the auth chain does. <p> Runs at
- * {@link org.springframework.core.Ordered#HIGHEST_PRECEDENCE} {@code + 2}: right after the commons {@code RequestIdFilter} (+0) and
- * {@code AccessLogFilter} (+1), and before the DB-free auth chain (order 10+).
+ * {@link GatewayUserResolver#HEADER_ACCESS_TYPE}, the spoofable source-address headers {@code X-Real-IP} and {@code Forwarded}, and the
+ * service-to-service {@code X-PIC-SURE-INTERNAL-TOKEN} (a client-presented internal token must never transit the gateway) from every
+ * inbound CLIENT request before anything downstream -- routing, the auth chain, or proxied services -- can ever see a client-supplied
+ * value. <p> {@code X-Forwarded-For} is deliberately NOT stripped: the trusted front proxy legitimately appends to it, and consumers
+ * ({@code AuditLoggingFilter}) take the RIGHTMOST entry -- the nearest trusted hop -- rather than the client-forgeable leftmost one.
+ * {@code X-Session-Id}, {@code X-Client-Type}, and {@code request-source} are also deliberately left unstripped: they are intentionally
+ * client-supplied telemetry, never authorization inputs. <p> {@link edu.harvard.hms.dbmi.avillach.gateway.filter.IdentityPropagationFilter}
+ * already hides the identity headers from the client, but this filter exists as an independent trust boundary: even if the DB-free auth
+ * chain were ever bypassed or misconfigured, a client's own {@code X-User-Id}/{@code X-User-Privileges}/etc. must never pass through
+ * untouched -- that would be an identity/privilege-spoofing hole. This filter closes that hole unconditionally, independent of anything the
+ * auth chain does. <p> Runs at {@link org.springframework.core.Ordered#HIGHEST_PRECEDENCE} {@code + 2}: right after the commons
+ * {@code RequestIdFilter} (+0) and {@code AccessLogFilter} (+1), and before the DB-free auth chain (order 10+).
  * {@link edu.harvard.hms.dbmi.avillach.gateway.filter.IdentityPropagationFilter} (order 50) still runs afterward and sets the
  * gateway-resolved values on its own wrapper, which never falls through to the (already-sanitized) client request for these names -- so
  * normal propagation of resolved identity is unaffected by this filter running first.
@@ -41,10 +44,14 @@ public class InboundIdentityHeaderSanitizingFilter extends OncePerRequestFilter 
 
     static class SanitizedIdentityHeadersRequest extends HttpServletRequestWrapper {
 
-        /** Gateway-owned identity headers: always hidden from the raw client request, regardless of name casing. */
+        /**
+         * Gateway-owned identity headers, spoofable source-address headers, and the internal service token: always hidden from the raw
+         * client request, regardless of name casing.
+         */
         private static final Set<String> STRIPPED_HEADERS = Set.of(
             GatewayUserResolver.HEADER_USER_ID, GatewayUserResolver.HEADER_USER_SUBJECT, GatewayUserResolver.HEADER_USER_EMAIL,
-            GatewayUserResolver.HEADER_USER_ROLES, GatewayUserResolver.HEADER_USER_PRIVILEGES, GatewayUserResolver.HEADER_ACCESS_TYPE
+            GatewayUserResolver.HEADER_USER_ROLES, GatewayUserResolver.HEADER_USER_PRIVILEGES, "X-Real-IP", "Forwarded",
+            "X-PIC-SURE-INTERNAL-TOKEN", GatewayUserResolver.HEADER_ACCESS_TYPE
         );
 
         SanitizedIdentityHeadersRequest(HttpServletRequest request) {

--- a/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/request/InternalEndpointGuardFilter.java
+++ b/services/pic-sure-gateway/src/main/java/edu/harvard/hms/dbmi/avillach/gateway/request/InternalEndpointGuardFilter.java
@@ -1,0 +1,33 @@
+package edu.harvard.hms.dbmi.avillach.gateway.request;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import edu.harvard.hms.dbmi.avillach.gateway.error.GatewayErrors;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Edge guard, registered UNCONDITIONALLY right after {@link InboundIdentityHeaderSanitizingFilter} (see {@code ObservabilityConfig}):
+ * rejects any request targeting {@code /operations/internal/**} (any depth) with the structured gateway 404 BEFORE routing or the auth
+ * chain ever sees it. Those endpoints (e.g. the query-auth dispatch API {@code QueryAuthFetcher} calls) are service-to-service only, gated
+ * by {@code X-PIC-SURE-INTERNAL-TOKEN} -- they must not be reachable through the public gateway even with a stolen token. A 404 (rather
+ * than 403) deliberately does not confirm the endpoint exists.
+ */
+public class InternalEndpointGuardFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse resp, FilterChain chain)
+        throws ServletException, IOException {
+        String path = req.getRequestURI() == null ? "" : req.getRequestURI();
+        if (path.equals("/operations/internal") || path.startsWith("/operations/internal/")) {
+            GatewayErrors.write(resp, HttpStatus.NOT_FOUND, "not_found", "Not found.");
+            return;
+        }
+        chain.doFilter(req, resp);
+    }
+}

--- a/services/pic-sure-gateway/src/main/resources/application.yml
+++ b/services/pic-sure-gateway/src/main/resources/application.yml
@@ -113,7 +113,6 @@ picsure:
   gateway:
     security:
       open-access-enabled: ${GATEWAY_OPEN_ACCESS_ENABLED:false}
-      user-id-claim: sub
       max-body-bytes: ${GATEWAY_AUTH_MAX_BODY_BYTES:10485760}
       introspection-url: ${TOKEN_INTROSPECTION_URL:}
       open-access-validate-url: ${OPEN_ACCESS_VALIDATE_URL:}

--- a/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/config/SecurityConfigTest.java
+++ b/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/config/SecurityConfigTest.java
@@ -29,7 +29,7 @@ class SecurityConfigTest {
     void psamaClientAndQueryAuthFetcherBeansBuildSuccessfullyWithTimeoutBoundedClients() {
         SecurityConfig config = new SecurityConfig();
         GatewaySecurityProperties props = new GatewaySecurityProperties(
-            List.of(), false, "userId", 1024, "http://psama.local/introspect", "http://psama.local/open-access", "svc-token",
+            List.of(), false, 1024, "http://psama.local/introspect", "http://psama.local/open-access", "svc-token",
             "http://operations.local", "internal-token"
         );
 

--- a/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/filter/OpenAccessFilterTest.java
+++ b/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/filter/OpenAccessFilterTest.java
@@ -17,6 +17,8 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.client.RestClientException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -151,6 +153,24 @@ class OpenAccessFilterTest {
         verify(resp).setStatus(401);
         verify(chain, never()).doFilter(any(), any());
         assertThat(ctx.getMetadata()).containsEntry("auth_action", "open_access.denied");
+    }
+
+    @Test
+    void psamaTransportFailureYields502StructuredErrorWithoutPropagating() throws Exception {
+        PsamaClient client = mock(PsamaClient.class);
+        when(client.validateOpenAccess(any())).thenThrow(new RestClientException("connection refused"));
+        AuditContext ctx = new AuditContext();
+        OpenAccessFilter f = filter(client, ctx, true);
+
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+        f.doFilter(wrap(null), resp, chain); // must not propagate the RestClientException
+
+        assertThat(resp.getStatus()).isEqualTo(502);
+        assertThat(resp.getContentAsString()).contains("\"errorType\":\"open_access_unreachable\"");
+        verify(chain, never()).doFilter(any(), any());
+        assertThat(ctx.getMetadata()).containsEntry("auth_result", "failure")
+            .containsEntry("auth_failure_reason", "open_access_unreachable");
     }
 
     private static BufferedRequestWrapper wrap(String authHeader) {

--- a/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/filter/PsamaIntrospectionFilterTest.java
+++ b/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/filter/PsamaIntrospectionFilterTest.java
@@ -36,7 +36,7 @@ class PsamaIntrospectionFilterTest {
 
     private PsamaIntrospectionFilter filter(PsamaClient client, AuditContext ctx, QueryAuthFetcher fetcher) {
         return new PsamaIntrospectionFilter(
-            client, ctx, new ObjectMapper(), fetcher, List.of("/actuator", "/openapi", "/swagger-ui", "/logging"), "userId"
+            client, ctx, new ObjectMapper(), fetcher, List.of("/actuator", "/openapi", "/swagger-ui", "/logging")
         );
     }
 

--- a/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/filter/PsamaIntrospectionFilterTest.java
+++ b/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/filter/PsamaIntrospectionFilterTest.java
@@ -318,6 +318,24 @@ class PsamaIntrospectionFilterTest {
     }
 
     @Test
+    void v3SystemStatusIsNotAllowListed() throws Exception {
+        PsamaClient client = mock(PsamaClient.class);
+        AuditContext ctx = new AuditContext();
+        PsamaIntrospectionFilter f = filter(client, ctx, mock(QueryAuthFetcher.class));
+
+        BufferedRequestWrapper req = wrap(null, new byte[0], "/v3/system/status", "GET");
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        lenient().when(resp.getWriter()).thenReturn(new PrintWriter(new StringWriter()));
+        FilterChain chain = mock(FilterChain.class);
+        f.doFilter(req, resp, chain);
+
+        verifyNoInteractions(client);
+        verify(chain, never()).doFilter(any(), any());
+        verify(resp).setStatus(401);
+        assertThat(ctx.getMetadata()).doesNotContainEntry("username", "SYSTEM_MONITOR");
+    }
+
+    @Test
     void prefixAllowListSkipsIntrospection() throws Exception {
         PsamaClient client = mock(PsamaClient.class);
         PsamaIntrospectionFilter f = filter(client, new AuditContext(), mock(QueryAuthFetcher.class));

--- a/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/request/InboundIdentityHeaderSanitizingFilterTest.java
+++ b/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/request/InboundIdentityHeaderSanitizingFilterTest.java
@@ -59,6 +59,37 @@ class InboundIdentityHeaderSanitizingFilterTest {
     }
 
     @Test
+    void stripsSpoofableForwardingHeadersAndInternalTokenButKeepsXForwardedForAndTelemetry() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/query/sync");
+        request.addHeader("X-Real-IP", "6.6.6.6");
+        request.addHeader("Forwarded", "for=6.6.6.6");
+        request.addHeader("X-PIC-SURE-INTERNAL-TOKEN", "stolen-internal-token");
+        // X-Forwarded-For stays: the trusted front proxy appends to it, and consumers take the
+        // rightmost (trusted) entry. Session/client-type/request-source are intentional client telemetry.
+        request.addHeader("X-Forwarded-For", "6.6.6.6, 10.0.0.1");
+        request.addHeader("X-Session-Id", "session-123");
+        request.addHeader("X-Client-Type", "PYTHON_ADAPTER");
+        request.addHeader("request-source", "portal");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        AtomicReference<HttpServletRequest> captured = new AtomicReference<>();
+        filter.doFilter(request, response, (req, resp) -> captured.set((HttpServletRequest) req));
+
+        HttpServletRequest wrapped = captured.get();
+        assertThat(wrapped.getHeader("X-Real-IP")).isNull();
+        assertThat(wrapped.getHeader("Forwarded")).isNull();
+        assertThat(wrapped.getHeader("X-PIC-SURE-INTERNAL-TOKEN")).isNull();
+        assertThat(wrapped.getHeader("X-Forwarded-For")).isEqualTo("6.6.6.6, 10.0.0.1");
+        assertThat(wrapped.getHeader("X-Session-Id")).isEqualTo("session-123");
+        assertThat(wrapped.getHeader("X-Client-Type")).isEqualTo("PYTHON_ADAPTER");
+        assertThat(wrapped.getHeader("request-source")).isEqualTo("portal");
+
+        List<String> names = Collections.list(wrapped.getHeaderNames());
+        assertThat(names).doesNotContain("X-Real-IP", "Forwarded", "X-PIC-SURE-INTERNAL-TOKEN");
+        assertThat(names).contains("X-Forwarded-For", "X-Session-Id", "X-Client-Type", "request-source");
+    }
+
+    @Test
     void headerStrippingIsCaseInsensitive() throws Exception {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/query/sync");
         request.addHeader("x-user-privileges", "SYSTEM,ADMIN");

--- a/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/request/InternalEndpointGuardFilterTest.java
+++ b/services/pic-sure-gateway/src/test/java/edu/harvard/hms/dbmi/avillach/gateway/request/InternalEndpointGuardFilterTest.java
@@ -1,0 +1,56 @@
+package edu.harvard.hms.dbmi.avillach.gateway.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import jakarta.servlet.FilterChain;
+
+/**
+ * {@link InternalEndpointGuardFilter} runs before routing/auth: {@code /operations/internal/**} is service-to-service only and must never
+ * be reachable through the public gateway, even with a stolen internal token.
+ */
+class InternalEndpointGuardFilterTest {
+
+    private final InternalEndpointGuardFilter filter = new InternalEndpointGuardFilter();
+
+    @Test
+    void rejectsInternalOperationsPathsWithStructuredErrorBeforeTheChain() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/operations/internal/queries/x");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(response.getContentAsString()).contains("\"errorType\":\"not_found\"");
+        verify(chain, never()).doFilter(any(), any()); // never reaches routing
+    }
+
+    @Test
+    void rejectsDeeplyNestedInternalPathsAndTheBarePrefix() throws Exception {
+        for (String path : new String[] {"/operations/internal", "/operations/internal/", "/operations/internal/queries/abc/dispatch"}) {
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            filter.doFilter(new MockHttpServletRequest("POST", path), response, mock(FilterChain.class));
+            assertThat(response.getStatus()).as(path).isEqualTo(404);
+        }
+    }
+
+    @Test
+    void passesOtherOperationsPathsThrough() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/operations/configuration");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(any(), any());
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+}

--- a/services/pic-sure-hpds-query-service/Dockerfile
+++ b/services/pic-sure-hpds-query-service/Dockerfile
@@ -2,4 +2,7 @@ FROM amazoncorretto:25
 WORKDIR /app
 COPY target/pic-sure-hpds-query-service-*.jar /app/app.jar
 EXPOSE 8080
+
+# run unprivileged: the image only reads the root-owned jar, so a bare numeric non-root UID suffices (satisfies runAsNonRoot)
+USER 1000:1000
 ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} -jar /app/app.jar"]

--- a/services/pic-sure-hpds-query-service/src/main/java/edu/harvard/hms/dbmi/avillach/query/aggregate/AggregateService.java
+++ b/services/pic-sure-hpds-query-service/src/main/java/edu/harvard/hms/dbmi/avillach/query/aggregate/AggregateService.java
@@ -165,8 +165,7 @@ public class AggregateService {
         Map<String, String> crossCounts = objectMapper.readValue(crossCountJson, new TypeReference<>() {});
         int generatedVariance = obfuscation.generateVarianceWithCrossCounts(crossCounts);
 
-        if (obfuscation.canShowContinuousCrossCounts(crossCounts)) {
-            // NOTE: despite the name, this signals SUPPRESSION -- ported verbatim from ObfuscationService/the WAR.
+        if (obfuscation.shouldSuppressContinuousCrossCounts(crossCounts)) {
             return null;
         }
 

--- a/services/pic-sure-hpds-query-service/src/main/java/edu/harvard/hms/dbmi/avillach/query/aggregate/ObfuscationService.java
+++ b/services/pic-sure-hpds-query-service/src/main/java/edu/harvard/hms/dbmi/avillach/query/aggregate/ObfuscationService.java
@@ -136,11 +136,26 @@ public class ObfuscationService {
         return generateRequestVariance(crossCountsString.toString());
     }
 
-    /** Suppress continuous when the study-consents cross-count is below threshold or zero. */
-    public boolean canShowContinuousCrossCounts(Map<String, String> crossCounts) {
-        String lessThanThresholdStr = "< " + this.threshold;
-        String v = crossCounts.get(STUDIES_CONSENTS_KEY);
-        return v.contains(lessThanThresholdStr) || v.equals("0");
+    /**
+     * Suppress continuous when the study-consents cross-count is below threshold or zero. The WAR ran this check on an already-obfuscated
+     * map, so only the display forms "&lt; threshold" and "0" could appear; here the caller passes the RAW backend cross-count, so raw
+     * numerics (e.g. "5") must be compared numerically or a below-threshold cohort's distribution leaks. Missing or unparseable counts fail
+     * closed (suppress).
+     */
+    public boolean shouldSuppressContinuousCrossCounts(Map<String, String> crossCounts) {
+        String v = crossCounts == null ? null : crossCounts.get(STUDIES_CONSENTS_KEY);
+        if (v == null) {
+            return true;
+        }
+        if (v.contains("< " + this.threshold)) {
+            return true;
+        }
+        try {
+            return Integer.parseInt(v.trim()) < this.threshold;
+        } catch (NumberFormatException nfe) {
+            logger.warn("Study-consents cross-count was not a number ({}); suppressing continuous response", v);
+            return true;
+        }
     }
 
     /** CATEGORICAL case: bucket via the formatter, then obfuscate. Null inputs short-circuit to null. */

--- a/services/pic-sure-hpds-query-service/src/main/java/edu/harvard/hms/dbmi/avillach/query/config/AggregateHttpClientConfig.java
+++ b/services/pic-sure-hpds-query-service/src/main/java/edu/harvard/hms/dbmi/avillach/query/config/AggregateHttpClientConfig.java
@@ -1,14 +1,7 @@
 package edu.harvard.hms.dbmi.avillach.query.config;
 
-import java.util.concurrent.TimeUnit;
-
-import org.apache.hc.client5.http.config.ConnectionConfig;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 /**
@@ -17,22 +10,15 @@ import org.springframework.web.client.RestClient;
  * the open HPDS backend and the visualization service. It has NO base URL and NO default Authorization header: absolute per-request URLs
  * and the {@code Authorization: Bearer <HPDS_OPEN_TOKEN>} header are supplied per-call by {@code AggregateBackendClient}. The
  * {@link AggregateProperties} bean itself is already registered by {@code AggregateConfig} (Unit 5a) via
- * {@code @EnableConfigurationProperties} -- this class only adds the HTTP client bean.
+ * {@code @EnableConfigurationProperties} -- this class only adds the HTTP client bean. Pool/timeout assembly is shared via
+ * {@link PooledRestClients}.
  */
 @Configuration
 public class AggregateHttpClientConfig {
 
     @Bean("aggregateRestClient")
     RestClient aggregateRestClient(AggregateProperties props) {
-        PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
-        cm.setMaxTotal(100); // matches the WAR's PoolingHttpClientConnectionManager
-        cm.setDefaultMaxPerRoute(20);
-        cm.setDefaultConnectionConfig(
-            ConnectionConfig.custom().setConnectTimeout(props.getConnectTimeoutSec(), TimeUnit.SECONDS)
-                .setSocketTimeout(props.getReadTimeoutSec(), TimeUnit.SECONDS).build()
-        );
-        CloseableHttpClient httpClient = HttpClients.custom().setConnectionManager(cm).build();
-        HttpComponentsClientHttpRequestFactory rf = new HttpComponentsClientHttpRequestFactory(httpClient);
-        return RestClient.builder().requestFactory(rf).build(); // no base URL -- absolute per call
+        // no base URL -- absolute per call
+        return PooledRestClients.pooledBuilder(100, 20, props.getConnectTimeoutSec(), props.getReadTimeoutSec()).build();
     }
 }

--- a/services/pic-sure-hpds-query-service/src/main/java/edu/harvard/hms/dbmi/avillach/query/config/HpdsClientConfig.java
+++ b/services/pic-sure-hpds-query-service/src/main/java/edu/harvard/hms/dbmi/avillach/query/config/HpdsClientConfig.java
@@ -1,15 +1,8 @@
 package edu.harvard.hms.dbmi.avillach.query.config;
 
-import java.util.concurrent.TimeUnit;
-
-import org.apache.hc.client5.http.config.ConnectionConfig;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 /**
@@ -17,7 +10,7 @@ import org.springframework.web.client.RestClient;
  * {@code PoolingHttpClientConnectionManager}) for talking to HPDS. It has NO base URL and NO default Authorization header:
  * {@link edu.harvard.hms.dbmi.avillach.query.hpds.HpdsBackendSelector} resolves the target backend's absolute base + service token, and the
  * per-backend token is applied per-call on the injecting endpoints (a later task) so that non-injecting search/values calls stay
- * token-free.
+ * token-free. Pool/timeout assembly is shared via {@link PooledRestClients}.
  */
 @Configuration
 @EnableConfigurationProperties(HpdsProperties.class)
@@ -25,15 +18,6 @@ public class HpdsClientConfig {
 
     @Bean
     RestClient hpdsClient(HpdsProperties props) {
-        PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
-        cm.setMaxTotal(100);
-        cm.setDefaultMaxPerRoute(20);
-        cm.setDefaultConnectionConfig(
-            ConnectionConfig.custom().setConnectTimeout(props.getConnectTimeoutSec(), TimeUnit.SECONDS)
-                .setSocketTimeout(props.getReadTimeoutSec(), TimeUnit.SECONDS).build()
-        );
-        CloseableHttpClient httpClient = HttpClients.custom().setConnectionManager(cm).build();
-        HttpComponentsClientHttpRequestFactory rf = new HttpComponentsClientHttpRequestFactory(httpClient);
-        return RestClient.builder().requestFactory(rf).build();
+        return PooledRestClients.pooledBuilder(100, 20, props.getConnectTimeoutSec(), props.getReadTimeoutSec()).build();
     }
 }

--- a/services/pic-sure-hpds-query-service/src/main/java/edu/harvard/hms/dbmi/avillach/query/config/OperationsClientConfig.java
+++ b/services/pic-sure-hpds-query-service/src/main/java/edu/harvard/hms/dbmi/avillach/query/config/OperationsClientConfig.java
@@ -1,16 +1,9 @@
 package edu.harvard.hms.dbmi.avillach.query.config;
 
-import java.util.concurrent.TimeUnit;
-
-import org.apache.hc.client5.http.config.ConnectionConfig;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 import edu.harvard.hms.dbmi.avillach.query.operations.OperationsClient;
@@ -19,7 +12,7 @@ import edu.harvard.hms.dbmi.avillach.query.operations.OperationsClient;
  * The pooled {@link RestClient} backing {@link OperationsClient}. Unlike {@link HpdsClientConfig}'s HPDS client (which serves two backends
  * with different tokens and therefore carries no default Authorization header), this client talks to exactly one target --
  * operations-service -- so its base URL and the {@code X-PIC-SURE-INTERNAL-TOKEN} shared secret are set once as defaults and apply to every
- * call.
+ * call. Pool/timeout assembly is shared via {@link PooledRestClients}.
  */
 @Configuration
 @EnableConfigurationProperties(OperationsProperties.class)
@@ -27,17 +20,8 @@ public class OperationsClientConfig {
 
     @Bean
     RestClient operationsRestClient(OperationsProperties props) {
-        PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
-        cm.setMaxTotal(50);
-        cm.setDefaultMaxPerRoute(20);
-        cm.setDefaultConnectionConfig(
-            ConnectionConfig.custom().setConnectTimeout(props.getConnectTimeoutSec(), TimeUnit.SECONDS)
-                .setSocketTimeout(props.getReadTimeoutSec(), TimeUnit.SECONDS).build()
-        );
-        CloseableHttpClient httpClient = HttpClients.custom().setConnectionManager(cm).build();
-        HttpComponentsClientHttpRequestFactory rf = new HttpComponentsClientHttpRequestFactory(httpClient);
-        return RestClient.builder().baseUrl(props.getBaseUrl()).defaultHeader("X-PIC-SURE-INTERNAL-TOKEN", props.getInternalToken())
-            .requestFactory(rf).build();
+        return PooledRestClients.pooledBuilder(50, 20, props.getConnectTimeoutSec(), props.getReadTimeoutSec()).baseUrl(props.getBaseUrl())
+            .defaultHeader("X-PIC-SURE-INTERNAL-TOKEN", props.getInternalToken()).build();
     }
 
     @Bean

--- a/services/pic-sure-hpds-query-service/src/main/java/edu/harvard/hms/dbmi/avillach/query/config/PooledRestClients.java
+++ b/services/pic-sure-hpds-query-service/src/main/java/edu/harvard/hms/dbmi/avillach/query/config/PooledRestClients.java
@@ -1,0 +1,42 @@
+package edu.harvard.hms.dbmi.avillach.query.config;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Shared assembly for this module's pooled {@link RestClient}s (Apache HttpComponents 5). {@link HpdsClientConfig},
+ * {@link AggregateHttpClientConfig} and {@link OperationsClientConfig} previously each duplicated the same
+ * {@code PoolingHttpClientConnectionManager} + {@code ConnectionConfig} + request-factory wiring; only pool sizing, timeouts and per-client
+ * defaults (base URL, default headers) differ, so the common part lives here and each config applies its own defaults to the returned
+ * builder.
+ *
+ * <p>Future work: this builder is a candidate for {@code pic-sure-spring-commons} so other services (e.g. the gateway) can share it, but
+ * that is a cross-module API decision deliberately not taken here.
+ */
+final class PooledRestClients {
+
+    private PooledRestClients() {}
+
+    /**
+     * Returns a {@link RestClient.Builder} backed by a dedicated Apache HC5 connection pool with the given sizing and timeouts. No base URL
+     * and no default headers are set -- callers add those when the client has a single fixed target.
+     */
+    static RestClient.Builder pooledBuilder(int maxTotal, int maxPerRoute, int connectTimeoutSec, int readTimeoutSec) {
+        PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
+        cm.setMaxTotal(maxTotal);
+        cm.setDefaultMaxPerRoute(maxPerRoute);
+        cm.setDefaultConnectionConfig(
+            ConnectionConfig.custom().setConnectTimeout(connectTimeoutSec, TimeUnit.SECONDS)
+                .setSocketTimeout(readTimeoutSec, TimeUnit.SECONDS).build()
+        );
+        CloseableHttpClient httpClient = HttpClients.custom().setConnectionManager(cm).build();
+        HttpComponentsClientHttpRequestFactory rf = new HttpComponentsClientHttpRequestFactory(httpClient);
+        return RestClient.builder().requestFactory(rf);
+    }
+}

--- a/services/pic-sure-hpds-query-service/src/main/java/edu/harvard/hms/dbmi/avillach/query/operations/StoredQuery.java
+++ b/services/pic-sure-hpds-query-service/src/main/java/edu/harvard/hms/dbmi/avillach/query/operations/StoredQuery.java
@@ -8,5 +8,12 @@ import java.util.UUID;
  * {@code edu.harvard.dbmi.avillach.domain.PicSureStatus} enum NAME (or {@code null} if unset). {@code metadata} is base64-encoded bytes (or
  * {@code null} if unset).
  */
-public record StoredQuery(UUID picsureId, String query, String resourceResultId, String status, String version, String metadata) {
+public record StoredQuery(
+    UUID picsureId, String query, String resourceResultId, String status, String version, String metadata, Long startTime, Long readyTime
+) {
+
+    /** Convenience for callers that don't carry timing ({@code startTime}/{@code readyTime} are server-owned epoch millis). */
+    public StoredQuery(UUID picsureId, String query, String resourceResultId, String status, String version, String metadata) {
+        this(picsureId, query, resourceResultId, status, version, metadata, null, null);
+    }
 }

--- a/services/pic-sure-hpds-query-service/src/main/java/edu/harvard/hms/dbmi/avillach/query/query/QueryService.java
+++ b/services/pic-sure-hpds-query-service/src/main/java/edu/harvard/hms/dbmi/avillach/query/query/QueryService.java
@@ -143,14 +143,22 @@ public class QueryService {
         }
     }
 
-    /** null query → null blob; else the serialized full QueryRequest (including resourceCredentials -- stripped only at dispatch time). */
+    /**
+     * null query → null blob; else the serialized QueryRequest with {@code resourceCredentials} removed. Credentials are only ever needed
+     * for the live HPDS call (which uses the in-memory request); nothing reads them back from operations-service (dispatch re-strips as
+     * defense in depth), so they must never reach the persistence store or the /metadata queryJson echo.
+     */
     private String serializeQuery(QueryRequest req) {
         if (req.getQuery() == null) {
             return null;
         }
         try {
-            return MAPPER.writeValueAsString(req);
-        } catch (JsonProcessingException e) {
+            JsonNode node = MAPPER.valueToTree(req);
+            if (node instanceof ObjectNode obj) {
+                obj.remove("resourceCredentials");
+            }
+            return MAPPER.writeValueAsString(node);
+        } catch (IllegalArgumentException | JsonProcessingException e) {
             throw new PicsureException(HttpStatus.BAD_REQUEST, "bad_request", "Incorrectly formatted request");
         }
     }

--- a/services/pic-sure-hpds-query-service/src/test/java/edu/harvard/hms/dbmi/avillach/query/aggregate/AggregateServiceTest.java
+++ b/services/pic-sure-hpds-query-service/src/test/java/edu/harvard/hms/dbmi/avillach/query/aggregate/AggregateServiceTest.java
@@ -166,6 +166,20 @@ class AggregateServiceTest {
     }
 
     @Test
+    void continuousCrossCountSuppressedWhenStudyConsentsIsRawBelowThresholdCount() {
+        // regression: the consents lookup returns the RAW backend body; a raw "5" (below threshold, nonzero) must suppress the
+        // whole continuous response, not just floor the individual bins
+        AggregateBackendClient backend = mock(AggregateBackendClient.class);
+        when(backend.search(any())).thenReturn(consentsSearch());
+        when(backend.querySync(any(), eq(AggregateVariant.V1))).thenReturn(ResponseEntity.ok("{\"\\\\age\\\\\":{\"5\":1}}"))
+            .thenReturn(ResponseEntity.ok("{\"\\\\_studies_consents\\\\\":\"5\"}"));
+        AggregateService svc = service(backend, new AggregateProperties());
+
+        ResponseEntity<String> out = svc.querySync(sync("CONTINUOUS_CROSS_COUNT"), AggregateVariant.V1);
+        assertThat(out.getBody()).isNull();
+    }
+
+    @Test
     void continuousCrossCountObfuscatesRawWhenNoVisualizationConfigured() {
         AggregateBackendClient backend = mock(AggregateBackendClient.class);
         when(backend.search(any())).thenReturn(consentsSearch());

--- a/services/pic-sure-hpds-query-service/src/test/java/edu/harvard/hms/dbmi/avillach/query/aggregate/ObfuscationServiceTest.java
+++ b/services/pic-sure-hpds-query-service/src/test/java/edu/harvard/hms/dbmi/avillach/query/aggregate/ObfuscationServiceTest.java
@@ -67,9 +67,26 @@ class ObfuscationServiceTest {
     @Test
     void continuousSuppressedWhenStudyConsentsBelowThresholdOrZero() {
         ObfuscationService s = svc("fixed");
-        assertThat(s.canShowContinuousCrossCounts(Map.of("\\_studies_consents\\", "< 10"))).isTrue();
-        assertThat(s.canShowContinuousCrossCounts(Map.of("\\_studies_consents\\", "0"))).isTrue();
-        assertThat(s.canShowContinuousCrossCounts(Map.of("\\_studies_consents\\", "500"))).isFalse();
+        assertThat(s.shouldSuppressContinuousCrossCounts(Map.of("\\_studies_consents\\", "< 10"))).isTrue();
+        assertThat(s.shouldSuppressContinuousCrossCounts(Map.of("\\_studies_consents\\", "0"))).isTrue();
+        assertThat(s.shouldSuppressContinuousCrossCounts(Map.of("\\_studies_consents\\", "500"))).isFalse();
+    }
+
+    @Test
+    void continuousSuppressedForRawBelowThresholdCounts() {
+        // the caller passes the RAW backend cross-count, so plain numerics 1..threshold-1 must suppress too
+        ObfuscationService s = svc("fixed");
+        assertThat(s.shouldSuppressContinuousCrossCounts(Map.of("\\_studies_consents\\", "5"))).isTrue();
+        assertThat(s.shouldSuppressContinuousCrossCounts(Map.of("\\_studies_consents\\", "9"))).isTrue();
+        assertThat(s.shouldSuppressContinuousCrossCounts(Map.of("\\_studies_consents\\", "10"))).isFalse();
+    }
+
+    @Test
+    void continuousSuppressionFailsClosedOnMissingOrUnparseableCount() {
+        ObfuscationService s = svc("fixed");
+        assertThat(s.shouldSuppressContinuousCrossCounts(Map.of())).isTrue();
+        assertThat(s.shouldSuppressContinuousCrossCounts(null)).isTrue();
+        assertThat(s.shouldSuppressContinuousCrossCounts(Map.of("\\_studies_consents\\", "not-a-number"))).isTrue();
     }
 
     @Test

--- a/services/pic-sure-hpds-query-service/src/test/java/edu/harvard/hms/dbmi/avillach/query/query/QueryServiceTest.java
+++ b/services/pic-sure-hpds-query-service/src/test/java/edu/harvard/hms/dbmi/avillach/query/query/QueryServiceTest.java
@@ -106,6 +106,22 @@ class QueryServiceTest {
     }
 
     @Test
+    void createNeverPersistsResourceCredentials() {
+        // SECURITY: credentials ride the in-memory request to HPDS only; the payload sent to operations-service for storage must not
+        // carry them (they would otherwise sit at rest and echo back through /metadata queryJson).
+        UUID picsureId = UUID.randomUUID();
+        QueryRequest request = req();
+        request.setResourceCredentials(Map.of("BEARER_TOKEN", "secret"));
+        when(hpds.query(any(HpdsTarget.class), any())).thenReturn(hpdsStatus("rr-1"));
+        when(operationsClient.save(any())).thenReturn(picsureId);
+
+        service.query("auth", request);
+
+        verify(operationsClient)
+            .save(argThat((SaveQueryRequest r) -> !r.query().contains("resourceCredentials") && !r.query().contains("secret")));
+    }
+
+    @Test
     void createEchoesResourceUuidFromRequest() {
         UUID picsureId = UUID.randomUUID();
         QueryRequest request = req();

--- a/services/pic-sure-operations-service/Dockerfile
+++ b/services/pic-sure-operations-service/Dockerfile
@@ -2,4 +2,7 @@ FROM amazoncorretto:25
 WORKDIR /app
 COPY target/pic-sure-operations-service-*.jar /app/app.jar
 EXPOSE 8080
+
+# run unprivileged: the image only reads the root-owned jar, so a bare numeric non-root UID suffices (satisfies runAsNonRoot)
+USER 1000:1000
 ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} -jar /app/app.jar"]

--- a/services/pic-sure-operations-service/src/main/java/edu/harvard/hms/dbmi/avillach/operations/configuration/ConfigurationService.java
+++ b/services/pic-sure-operations-service/src/main/java/edu/harvard/hms/dbmi/avillach/operations/configuration/ConfigurationService.java
@@ -5,11 +5,11 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import edu.harvard.hms.dbmi.avillach.commons.error.PicsureException;
+import edu.harvard.hms.dbmi.avillach.operations.error.PicsureExceptions;
 
 /**
  * Ports the legacy WildFly {@code ConfigurationService}. Preserved behaviors: (1) UUID-or-name lookup ({@link #getByIdentifier(String)}) --
@@ -107,13 +107,12 @@ public class ConfigurationService {
         return repo.findByName(identifier).stream().findFirst();
     }
 
+    /** Delegates to the shared {@link PicsureExceptions} factories; only the entity-specific message text lives here. */
     private static PicsureException notFound(String identifier) {
-        return new PicsureException(HttpStatus.NOT_FOUND, "not_found", "Configuration " + identifier + " not found");
+        return PicsureExceptions.notFound("Configuration", identifier);
     }
 
     private static PicsureException conflict(String name, String kind) {
-        return new PicsureException(
-            HttpStatus.CONFLICT, "conflict", "A configuration with name '" + name + "' and kind '" + kind + "' already exists"
-        );
+        return PicsureExceptions.conflict("A configuration with name '" + name + "' and kind '" + kind + "' already exists");
     }
 }

--- a/services/pic-sure-operations-service/src/main/java/edu/harvard/hms/dbmi/avillach/operations/dataset/NamedDatasetController.java
+++ b/services/pic-sure-operations-service/src/main/java/edu/harvard/hms/dbmi/avillach/operations/dataset/NamedDatasetController.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import edu.harvard.hms.dbmi.avillach.commons.error.PicsureException;
 import edu.harvard.hms.dbmi.avillach.commons.identity.GatewayUser;
 import jakarta.validation.Valid;
 
@@ -23,8 +22,9 @@ import jakarta.validation.Valid;
  * are slash-less on purpose: the frontend calls the slash-less form, and Spring 6 -- unlike the legacy JAX-RS runtime, which matched both
  * -- serves EXACTLY the declared form (a trailing-slash mapping 404s the slash-less request). Authorization is enforced in two layers:
  * {@code WebSecurityConfig} requires an authenticated caller for all of {@code /dataset/**} (the gateway must have supplied
- * {@code X-User-Id}); this controller then email-scopes every operation via {@link NamedDatasetService}, whose repository lookups are keyed
- * on the caller's email ({@code GatewayUser#getEmail()}), never {@code userId}.
+ * {@code X-User-Id}); {@link NamedDatasetService} then email-scopes every operation, requiring and keying on the caller's email
+ * ({@code GatewayUser#getEmail()}), never {@code userId}. This controller is a thin HTTP adapter -- identity validation lives in the
+ * service.
  *
  * <p>DELETE is net-new relative to the legacy {@code NamedDatasetRS} (which had no delete endpoint) -- added here per the migration plan.
  */
@@ -40,40 +40,28 @@ public class NamedDatasetController {
 
     @GetMapping("")
     public List<NamedDatasetDto> list(GatewayUser user) {
-        return service.listForUser(requireEmail(user));
+        return service.listForUser(user);
     }
 
     @PostMapping("")
     public ResponseEntity<NamedDatasetDto> create(GatewayUser user, @Valid @RequestBody NamedDatasetRequestDto req) {
-        NamedDatasetDto created = service.create(requireEmail(user), req);
+        NamedDatasetDto created = service.create(user, req);
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 
     @GetMapping("/{id}")
     public NamedDatasetDto get(GatewayUser user, @PathVariable("id") UUID id) {
-        return service.getForUser(requireEmail(user), id);
+        return service.getForUser(user, id);
     }
 
     @PutMapping("/{id}")
     public NamedDatasetDto update(GatewayUser user, @PathVariable("id") UUID id, @Valid @RequestBody NamedDatasetRequestDto req) {
-        return service.update(requireEmail(user), id, req);
+        return service.update(user, id, req);
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(GatewayUser user, @PathVariable("id") UUID id) {
-        service.delete(requireEmail(user), id);
+        service.delete(user, id);
         return ResponseEntity.noContent().build();
-    }
-
-    /**
-     * Returns the caller's email owner key. {@code WebSecurityConfig} already rejects unauthenticated requests to {@code /dataset/**}
-     * before this method runs, so this is a defensive guard against a gateway that authenticated the caller (sent {@code X-User-Id}) but
-     * omitted {@code X-User-Email} -- not the primary auth gate.
-     */
-    private String requireEmail(GatewayUser user) {
-        if (user == null || user.getEmail() == null || user.getEmail().isBlank()) {
-            throw new PicsureException(HttpStatus.UNAUTHORIZED, "unauthorized", "User identity (email) not present in request");
-        }
-        return user.getEmail();
     }
 }

--- a/services/pic-sure-operations-service/src/main/java/edu/harvard/hms/dbmi/avillach/operations/dataset/NamedDatasetService.java
+++ b/services/pic-sure-operations-service/src/main/java/edu/harvard/hms/dbmi/avillach/operations/dataset/NamedDatasetService.java
@@ -4,20 +4,22 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import edu.harvard.hms.dbmi.avillach.commons.error.PicsureException;
+import edu.harvard.hms.dbmi.avillach.commons.identity.GatewayUser;
+import edu.harvard.hms.dbmi.avillach.operations.error.PicsureExceptions;
 import edu.harvard.hms.dbmi.avillach.operations.query.Query;
 import edu.harvard.hms.dbmi.avillach.operations.query.QueryRepository;
 
 /**
  * Ports the legacy WildFly {@code NamedDatasetService}. User-scoping is pushed into SQL via {@code NamedDatasetRepository}'s
- * {@code findByUser}/{@code findByUuidAndUser}, replacing the WAR's in-Java owner check; the owner key is the caller's EMAIL. Because the
- * lookup is scoped at the SQL layer, a caller reading/mutating another user's dataset gets exactly the same 404 as a genuinely-missing uuid
- * -- there is no separate 403 branch, and existence is never leaked to a non-owning caller (same posture as {@code ConfigurationService}'s
- * not-found handling).
+ * {@code findByUser}/{@code findByUuidAndUser}, replacing the WAR's in-Java owner check; the owner key is the caller's EMAIL, derived here
+ * from the {@link GatewayUser} via {@link #requireEmail} (the identity-completeness check lives in this service, not the controller).
+ * Because the lookup is scoped at the SQL layer, a caller reading/mutating another user's dataset gets exactly the same 404 as a
+ * genuinely-missing uuid -- there is no separate 403 branch, and existence is never leaked to a non-owning caller (same posture as
+ * {@code ConfigurationService}'s not-found handling).
  *
  * <p>{@code archived} is not a list filter -- {@code findByUser} returns archived and non-archived rows alike; there is no soft-delete.
  *
@@ -43,42 +45,55 @@ public class NamedDatasetService {
     }
 
     @Transactional(readOnly = true)
-    public List<NamedDatasetDto> listForUser(String user) {
-        return repo.findByUser(user).stream().map(mapper::toDto).toList();
+    public List<NamedDatasetDto> listForUser(GatewayUser user) {
+        return repo.findByUser(requireEmail(user)).stream().map(mapper::toDto).toList();
     }
 
     @Transactional(readOnly = true)
-    public NamedDatasetDto getForUser(String user, UUID id) {
-        NamedDataset e = repo.findByUuidAndUser(id, user).orElseThrow(() -> notFound(id));
+    public NamedDatasetDto getForUser(GatewayUser user, UUID id) {
+        NamedDataset e = repo.findByUuidAndUser(id, requireEmail(user)).orElseThrow(() -> notFound(id));
         return mapper.toDto(e);
     }
 
     @Transactional
-    public NamedDatasetDto create(String user, NamedDatasetRequestDto req) {
+    public NamedDatasetDto create(GatewayUser user, NamedDatasetRequestDto req) {
+        String email = requireEmail(user);
         Query query = resolveQuery(req.queryId());
-        NamedDataset saved = saveOrConflict(mapper.toEntity(user, query, req), req.queryId(), user);
+        NamedDataset saved = saveOrConflict(mapper.toEntity(email, query, req), req.queryId(), email);
         return mapper.toDto(saved);
     }
 
     @Transactional
-    public NamedDatasetDto update(String user, UUID id, NamedDatasetRequestDto req) {
-        NamedDataset existing = repo.findByUuidAndUser(id, user).orElseThrow(() -> notFound(id));
+    public NamedDatasetDto update(GatewayUser user, UUID id, NamedDatasetRequestDto req) {
+        String email = requireEmail(user);
+        NamedDataset existing = repo.findByUuidAndUser(id, email).orElseThrow(() -> notFound(id));
         if (existing.getQuery() == null || !existing.getQuery().getUuid().equals(req.queryId())) {
             existing.setQuery(resolveQuery(req.queryId()));
         }
         existing.setName(req.name()).setArchived(req.archived()).setMetadata(req.metadata());
-        return mapper.toDto(saveOrConflict(existing, req.queryId(), user));
+        return mapper.toDto(saveOrConflict(existing, req.queryId(), email));
     }
 
     @Transactional
-    public void delete(String user, UUID id) {
-        NamedDataset existing = repo.findByUuidAndUser(id, user).orElseThrow(() -> notFound(id));
+    public void delete(GatewayUser user, UUID id) {
+        NamedDataset existing = repo.findByUuidAndUser(id, requireEmail(user)).orElseThrow(() -> notFound(id));
         repo.delete(existing);
     }
 
+    /**
+     * Returns the caller's email owner key. {@code WebSecurityConfig} already rejects unauthenticated requests to {@code /dataset/**}
+     * before any controller method runs, so this is a defensive guard against a gateway that authenticated the caller (sent
+     * {@code X-User-Id}) but omitted {@code X-User-Email} -- not the primary auth gate.
+     */
+    private static String requireEmail(GatewayUser user) {
+        if (user == null || user.getEmail() == null || user.getEmail().isBlank()) {
+            throw PicsureExceptions.unauthorized("User identity (email) not present in request");
+        }
+        return user.getEmail();
+    }
+
     private Query resolveQuery(UUID queryId) {
-        return queryRepo.findById(queryId)
-            .orElseThrow(() -> new PicsureException(HttpStatus.NOT_FOUND, "not_found", "Query " + queryId + " not found"));
+        return queryRepo.findById(queryId).orElseThrow(() -> PicsureExceptions.notFound("Query", queryId));
     }
 
     /**
@@ -90,17 +105,11 @@ public class NamedDatasetService {
         try {
             return repo.saveAndFlush(entity);
         } catch (DataIntegrityViolationException e) {
-            throw conflict(queryId, user);
+            throw PicsureExceptions.conflict("A NamedDataset for query " + queryId + " and user '" + user + "' already exists");
         }
     }
 
     private static PicsureException notFound(UUID id) {
-        return new PicsureException(HttpStatus.NOT_FOUND, "not_found", "NamedDataset " + id + " not found");
-    }
-
-    private static PicsureException conflict(UUID queryId, String user) {
-        return new PicsureException(
-            HttpStatus.CONFLICT, "conflict", "A NamedDataset for query " + queryId + " and user '" + user + "' already exists"
-        );
+        return PicsureExceptions.notFound("NamedDataset", id);
     }
 }

--- a/services/pic-sure-operations-service/src/main/java/edu/harvard/hms/dbmi/avillach/operations/error/PicsureExceptions.java
+++ b/services/pic-sure-operations-service/src/main/java/edu/harvard/hms/dbmi/avillach/operations/error/PicsureExceptions.java
@@ -1,0 +1,30 @@
+package edu.harvard.hms.dbmi.avillach.operations.error;
+
+import org.springframework.http.HttpStatus;
+
+import edu.harvard.hms.dbmi.avillach.commons.error.PicsureException;
+
+/**
+ * Shared factories for the {@link PicsureException} shapes this service raises, so each service class does not re-declare its own
+ * status/error-type wiring ({@code ConfigurationService} and {@code NamedDatasetService} previously each carried private copies).
+ * Entity-specific message text stays at the call site; only the status + machine-readable error type + common message template live here.
+ */
+public final class PicsureExceptions {
+
+    private PicsureExceptions() {}
+
+    /** 404 with the common "{@code <Entity> <identifier> not found}" message shape used across this service. */
+    public static PicsureException notFound(String entity, Object identifier) {
+        return new PicsureException(HttpStatus.NOT_FOUND, "not_found", entity + " " + identifier + " not found");
+    }
+
+    /** 409 with a caller-supplied message (conflict messages are entity-specific and do not share a template). */
+    public static PicsureException conflict(String message) {
+        return new PicsureException(HttpStatus.CONFLICT, "conflict", message);
+    }
+
+    /** 401 with a caller-supplied message. */
+    public static PicsureException unauthorized(String message) {
+        return new PicsureException(HttpStatus.UNAUTHORIZED, "unauthorized", message);
+    }
+}

--- a/services/pic-sure-operations-service/src/main/java/edu/harvard/hms/dbmi/avillach/operations/query/QueryPersistenceService.java
+++ b/services/pic-sure-operations-service/src/main/java/edu/harvard/hms/dbmi/avillach/operations/query/QueryPersistenceService.java
@@ -1,5 +1,6 @@
 package edu.harvard.hms.dbmi.avillach.operations.query;
 
+import java.sql.Date;
 import java.util.Base64;
 import java.util.UUID;
 
@@ -46,6 +47,7 @@ public class QueryPersistenceService {
         entity.setStatus(parseStatus(req.status()));
         entity.setVersion(req.version());
         entity.setMetadata(decodeMetadata(req.metadata()));
+        entity.setStartTime(new Date(System.currentTimeMillis())); // server-owned, like the legacy WAR's create path
         return repo.save(entity).getUuid();
     }
 
@@ -58,7 +60,11 @@ public class QueryPersistenceService {
     public void update(UUID picsureId, UpdateQueryRequest req) {
         Query entity = load(picsureId);
         if (req.status() != null) {
-            entity.setStatus(parseStatus(req.status()));
+            PicSureStatus newStatus = parseStatus(req.status());
+            if (newStatus == PicSureStatus.AVAILABLE && entity.getReadyTime() == null) {
+                entity.setReadyTime(new Date(System.currentTimeMillis())); // first AVAILABLE transition, like the legacy WAR
+            }
+            entity.setStatus(newStatus);
         }
         if (req.resourceResultId() != null) {
             entity.setResourceResultId(req.resourceResultId());
@@ -100,8 +106,13 @@ public class QueryPersistenceService {
     private static StoredQuery toDto(Query entity) {
         return new StoredQuery(
             entity.getUuid(), stripResourceCredentials(entity.getQuery()), entity.getResourceResultId(),
-            entity.getStatus() == null ? null : entity.getStatus().name(), entity.getVersion(), encodeMetadata(entity.getMetadata())
+            entity.getStatus() == null ? null : entity.getStatus().name(), entity.getVersion(), encodeMetadata(entity.getMetadata()),
+            toEpochMillis(entity.getStartTime()), toEpochMillis(entity.getReadyTime())
         );
+    }
+
+    private static Long toEpochMillis(Date date) {
+        return date == null ? null : date.getTime();
     }
 
     /**

--- a/services/pic-sure-operations-service/src/main/java/edu/harvard/hms/dbmi/avillach/operations/query/QueryPersistenceService.java
+++ b/services/pic-sure-operations-service/src/main/java/edu/harvard/hms/dbmi/avillach/operations/query/QueryPersistenceService.java
@@ -41,7 +41,7 @@ public class QueryPersistenceService {
     @Transactional
     public UUID save(SaveQueryRequest req) {
         Query entity = new Query();
-        entity.setQuery(req.query());
+        entity.setQuery(stripResourceCredentials(req.query()));
         entity.setResourceResultId(req.resourceResultId());
         entity.setStatus(parseStatus(req.status()));
         entity.setVersion(req.version());
@@ -99,9 +99,30 @@ public class QueryPersistenceService {
 
     private static StoredQuery toDto(Query entity) {
         return new StoredQuery(
-            entity.getUuid(), entity.getQuery(), entity.getResourceResultId(),
+            entity.getUuid(), stripResourceCredentials(entity.getQuery()), entity.getResourceResultId(),
             entity.getStatus() == null ? null : entity.getStatus().name(), entity.getVersion(), encodeMetadata(entity.getMetadata())
         );
+    }
+
+    /**
+     * SECURITY: {@code resourceCredentials} must never be persisted (writers now strip before sending) nor returned to any internal reader
+     * -- this covers rows stored before writers stripped. Bodies without the field pass through byte-identical; malformed JSON passes
+     * through unchanged (it cannot carry a parseable credentials field, and dispatch already nulls it).
+     */
+    private static String stripResourceCredentials(String json) {
+        if (json == null || json.isBlank()) {
+            return json;
+        }
+        try {
+            JsonNode node = MAPPER.readTree(json);
+            if (node instanceof ObjectNode obj && obj.has("resourceCredentials")) {
+                obj.remove("resourceCredentials");
+                return MAPPER.writeValueAsString(node);
+            }
+            return json;
+        } catch (JsonProcessingException e) {
+            return json;
+        }
     }
 
     private static PicSureStatus parseStatus(String status) {

--- a/services/pic-sure-operations-service/src/main/java/edu/harvard/hms/dbmi/avillach/operations/query/StoredQuery.java
+++ b/services/pic-sure-operations-service/src/main/java/edu/harvard/hms/dbmi/avillach/operations/query/StoredQuery.java
@@ -7,8 +7,13 @@ import java.util.UUID;
  * plumbing. {@code status} is the {@link edu.harvard.dbmi.avillach.domain.PicSureStatus} enum NAME (or {@code null} if unset).
  * {@code metadata} is base64-encoded bytes (or {@code null} if unset) -- callers that need the raw JSON therein decode it themselves.
  *
+ * <p>{@code startTime}/{@code readyTime} are epoch millis (or {@code null} if unset), server-owned: stamped on save and on the first
+ * transition to {@code AVAILABLE} respectively (precision follows the legacy DATE columns).
+ *
  * <p>Deliberately distinct from the gateway-only dispatch payload ({@code {queryJson: "..."}}), which excludes everything here except the
  * (auth-mutated) query body -- see {@code InternalQueryController#dispatch}.
  */
-public record StoredQuery(UUID picsureId, String query, String resourceResultId, String status, String version, String metadata) {
+public record StoredQuery(
+    UUID picsureId, String query, String resourceResultId, String status, String version, String metadata, Long startTime, Long readyTime
+) {
 }

--- a/services/pic-sure-operations-service/src/test/java/edu/harvard/hms/dbmi/avillach/operations/dataset/NamedDatasetControllerTest.java
+++ b/services/pic-sure-operations-service/src/test/java/edu/harvard/hms/dbmi/avillach/operations/dataset/NamedDatasetControllerTest.java
@@ -53,6 +53,13 @@ class NamedDatasetControllerTest {
     }
 
     @Test
+    void listWithUserIdButNoEmailIsUnauthorized() throws Exception {
+        // Passes the WebSecurityConfig gate (X-User-Id present) but trips the email guard in NamedDatasetService.
+        mockMvc.perform(get("/dataset/named").header(GatewayUserResolver.HEADER_USER_ID, "auth0|alice"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
     void listReturnsOnlyCallersDatasets() throws Exception {
         Query aliceQuery = queryRepo.save(new Query());
         Query bobQuery = queryRepo.save(new Query());

--- a/services/pic-sure-operations-service/src/test/java/edu/harvard/hms/dbmi/avillach/operations/dataset/NamedDatasetServiceTest.java
+++ b/services/pic-sure-operations-service/src/test/java/edu/harvard/hms/dbmi/avillach/operations/dataset/NamedDatasetServiceTest.java
@@ -5,10 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
@@ -16,6 +18,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 
 import edu.harvard.hms.dbmi.avillach.commons.error.PicsureException;
+import edu.harvard.hms.dbmi.avillach.commons.identity.GatewayUser;
 import edu.harvard.hms.dbmi.avillach.operations.query.Query;
 import edu.harvard.hms.dbmi.avillach.operations.query.QueryRepository;
 
@@ -31,6 +34,9 @@ import edu.harvard.hms.dbmi.avillach.operations.query.QueryRepository;
  */
 class NamedDatasetServiceTest {
 
+    /** Gateway-resolved identity for the canonical caller; the service keys everything on {@code getEmail()}. */
+    static final GatewayUser ALICE = new GatewayUser("auth0|alice", "auth0|alice", "alice@example.com", null, Set.of());
+
     NamedDatasetRepository repo = mock(NamedDatasetRepository.class);
     QueryRepository queryRepo = mock(QueryRepository.class);
     NamedDatasetMapper mapper = new NamedDatasetMapper();
@@ -44,7 +50,7 @@ class NamedDatasetServiceTest {
         e.setUuid(UUID.randomUUID());
         when(repo.findByUser("alice@example.com")).thenReturn(List.of(e));
 
-        List<NamedDatasetDto> result = service.listForUser("alice@example.com");
+        List<NamedDatasetDto> result = service.listForUser(ALICE);
 
         assertThat(result).hasSize(1).extracting(NamedDatasetDto::name).containsExactly("d1");
     }
@@ -54,7 +60,7 @@ class NamedDatasetServiceTest {
         UUID id = UUID.randomUUID();
         when(repo.findByUuidAndUser(id, "alice@example.com")).thenReturn(Optional.empty());
 
-        PicsureException ex = assertThrows(PicsureException.class, () -> service.getForUser("alice@example.com", id));
+        PicsureException ex = assertThrows(PicsureException.class, () -> service.getForUser(ALICE, id));
 
         assertThat(ex.getStatus()).isEqualTo(HttpStatus.NOT_FOUND);
     }
@@ -66,7 +72,7 @@ class NamedDatasetServiceTest {
         e.setUuid(id);
         when(repo.findByUuidAndUser(id, "alice@example.com")).thenReturn(Optional.of(e));
 
-        NamedDatasetDto dto = service.getForUser("alice@example.com", id);
+        NamedDatasetDto dto = service.getForUser(ALICE, id);
 
         assertThat(dto.name()).isEqualTo("d1");
     }
@@ -84,7 +90,7 @@ class NamedDatasetServiceTest {
         });
 
         NamedDatasetRequestDto req = new NamedDatasetRequestDto(queryId, "d2", false, null);
-        NamedDatasetDto dto = service.create("alice@example.com", req);
+        NamedDatasetDto dto = service.create(ALICE, req);
 
         assertThat(dto.name()).isEqualTo("d2");
         assertThat(dto.query().uuid()).isEqualTo(queryId);
@@ -99,7 +105,7 @@ class NamedDatasetServiceTest {
         when(repo.saveAndFlush(any())).thenThrow(new DataIntegrityViolationException("unique_queryId_user"));
 
         NamedDatasetRequestDto req = new NamedDatasetRequestDto(queryId, "dup", false, null);
-        PicsureException ex = assertThrows(PicsureException.class, () -> service.create("alice@example.com", req));
+        PicsureException ex = assertThrows(PicsureException.class, () -> service.create(ALICE, req));
 
         assertThat(ex.getStatus()).isEqualTo(HttpStatus.CONFLICT);
     }
@@ -110,7 +116,7 @@ class NamedDatasetServiceTest {
         when(queryRepo.findById(queryId)).thenReturn(Optional.empty());
         NamedDatasetRequestDto req = new NamedDatasetRequestDto(queryId, "d3", false, null);
 
-        PicsureException ex = assertThrows(PicsureException.class, () -> service.create("alice@example.com", req));
+        PicsureException ex = assertThrows(PicsureException.class, () -> service.create(ALICE, req));
 
         assertThat(ex.getStatus()).isEqualTo(HttpStatus.NOT_FOUND);
     }
@@ -121,7 +127,7 @@ class NamedDatasetServiceTest {
         when(repo.findByUuidAndUser(id, "alice@example.com")).thenReturn(Optional.empty());
         NamedDatasetRequestDto req = new NamedDatasetRequestDto(UUID.randomUUID(), "renamed", false, null);
 
-        PicsureException ex = assertThrows(PicsureException.class, () -> service.update("alice@example.com", id, req));
+        PicsureException ex = assertThrows(PicsureException.class, () -> service.update(ALICE, id, req));
 
         assertThat(ex.getStatus()).isEqualTo(HttpStatus.NOT_FOUND);
     }
@@ -138,7 +144,7 @@ class NamedDatasetServiceTest {
         when(repo.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
 
         NamedDatasetRequestDto req = new NamedDatasetRequestDto(queryId, "renamed", true, null);
-        NamedDatasetDto dto = service.update("alice@example.com", id, req);
+        NamedDatasetDto dto = service.update(ALICE, id, req);
 
         assertThat(dto.name()).isEqualTo("renamed");
         assertThat(dto.archived()).isTrue();
@@ -160,7 +166,7 @@ class NamedDatasetServiceTest {
         when(repo.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
 
         NamedDatasetRequestDto req = new NamedDatasetRequestDto(newQueryId, "d1", false, null);
-        NamedDatasetDto dto = service.update("alice@example.com", id, req);
+        NamedDatasetDto dto = service.update(ALICE, id, req);
 
         assertThat(dto.query().uuid()).isEqualTo(newQueryId);
     }
@@ -181,7 +187,7 @@ class NamedDatasetServiceTest {
         when(repo.saveAndFlush(any())).thenThrow(new DataIntegrityViolationException("unique_queryId_user"));
 
         NamedDatasetRequestDto req = new NamedDatasetRequestDto(newQueryId, "d1", false, null);
-        PicsureException ex = assertThrows(PicsureException.class, () -> service.update("alice@example.com", id, req));
+        PicsureException ex = assertThrows(PicsureException.class, () -> service.update(ALICE, id, req));
 
         assertThat(ex.getStatus()).isEqualTo(HttpStatus.CONFLICT);
     }
@@ -191,7 +197,7 @@ class NamedDatasetServiceTest {
         UUID id = UUID.randomUUID();
         when(repo.findByUuidAndUser(id, "alice@example.com")).thenReturn(Optional.empty());
 
-        PicsureException ex = assertThrows(PicsureException.class, () -> service.delete("alice@example.com", id));
+        PicsureException ex = assertThrows(PicsureException.class, () -> service.delete(ALICE, id));
 
         assertThat(ex.getStatus()).isEqualTo(HttpStatus.NOT_FOUND);
     }
@@ -203,8 +209,35 @@ class NamedDatasetServiceTest {
         existing.setUuid(id);
         when(repo.findByUuidAndUser(id, "alice@example.com")).thenReturn(Optional.of(existing));
 
-        service.delete("alice@example.com", id);
+        service.delete(ALICE, id);
 
         verify(repo).delete(existing);
+    }
+
+    // Identity-completeness guard (moved here from the controller): a gateway-authenticated caller without an email owner key is
+    // rejected with 401 before any repository access.
+
+    @Test
+    void nullUserIsUnauthorized() {
+        PicsureException ex = assertThrows(PicsureException.class, () -> service.listForUser(null));
+        assertThat(ex.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        verifyNoInteractions(repo);
+    }
+
+    @Test
+    void userWithoutEmailIsUnauthorized() {
+        GatewayUser noEmail = new GatewayUser("auth0|alice", "auth0|alice", null, null, Set.of());
+        PicsureException ex = assertThrows(PicsureException.class, () -> service.getForUser(noEmail, UUID.randomUUID()));
+        assertThat(ex.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        verifyNoInteractions(repo);
+    }
+
+    @Test
+    void userWithBlankEmailIsUnauthorizedOnCreate() {
+        GatewayUser blankEmail = new GatewayUser("auth0|alice", "auth0|alice", "   ", null, Set.of());
+        NamedDatasetRequestDto req = new NamedDatasetRequestDto(UUID.randomUUID(), "d1", false, null);
+        PicsureException ex = assertThrows(PicsureException.class, () -> service.create(blankEmail, req));
+        assertThat(ex.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        verifyNoInteractions(repo, queryRepo);
     }
 }

--- a/services/pic-sure-operations-service/src/test/java/edu/harvard/hms/dbmi/avillach/operations/query/InternalQueryControllerTest.java
+++ b/services/pic-sure-operations-service/src/test/java/edu/harvard/hms/dbmi/avillach/operations/query/InternalQueryControllerTest.java
@@ -116,6 +116,20 @@ class InternalQueryControllerTest {
     }
 
     @Test
+    void getStripsResourceCredentialsLikeDispatchDoes() throws Exception {
+        // the full GET must not be a credential side door around dispatch's stripping
+        Query saved = new Query();
+        saved.setQuery("{\"resourceUUID\":\"r\",\"resourceCredentials\":{\"BEARER_TOKEN\":\"secret\"},\"query\":\"q\"}");
+        saved = queryRepo.save(saved);
+
+        mockMvc.perform(get("/internal/queries/{picsureId}", saved.getUuid()).header(InternalTokenFilter.HEADER, validToken))
+            .andExpect(status().isOk()).andExpect(
+                result -> org.assertj.core.api.Assertions.assertThat(result.getResponse().getContentAsString()).doesNotContain("secret")
+                    .doesNotContain("resourceCredentials")
+            );
+    }
+
+    @Test
     void dispatchReturnsQueryJsonWithResourceCredentialsStripped() throws Exception {
         Query saved = new Query();
         saved.setQuery("{\"resourceUUID\":\"r\",\"resourceCredentials\":{\"BEARER_TOKEN\":\"secret\"},\"query\":\"q\"}");

--- a/services/pic-sure-operations-service/src/test/java/edu/harvard/hms/dbmi/avillach/operations/query/QueryPersistenceServiceTest.java
+++ b/services/pic-sure-operations-service/src/test/java/edu/harvard/hms/dbmi/avillach/operations/query/QueryPersistenceServiceTest.java
@@ -86,6 +86,32 @@ class QueryPersistenceServiceTest {
     }
 
     @Test
+    void saveStripsResourceCredentialsBeforePersisting() {
+        UUID picsureId = service.save(
+            new SaveQueryRequest(
+                "{\"resourceUUID\":\"r\",\"resourceCredentials\":{\"BEARER_TOKEN\":\"secret\"},\"query\":\"q\"}", null, "QUEUED", null, null
+            )
+        );
+        entityManager.flush();
+        entityManager.clear();
+
+        Query entity = repo.findById(picsureId).orElseThrow();
+        assertThat(entity.getQuery()).doesNotContain("resourceCredentials").doesNotContain("secret").contains("\"query\":\"q\"");
+    }
+
+    @Test
+    void getStripsResourceCredentialsFromRowsStoredBeforeWritersStripped() {
+        Query legacy = new Query();
+        legacy.setQuery("{\"resourceUUID\":\"r\",\"resourceCredentials\":{\"BEARER_TOKEN\":\"secret\"},\"query\":\"q\"}");
+        UUID picsureId = repo.save(legacy).getUuid();
+        entityManager.flush();
+        entityManager.clear();
+
+        StoredQuery stored = service.get(picsureId);
+        assertThat(stored.query()).doesNotContain("resourceCredentials").doesNotContain("secret").contains("\"query\":\"q\"");
+    }
+
+    @Test
     void dispatchStripsResourceCredentialsAndReturnsAString() {
         UUID picsureId = service.save(
             new SaveQueryRequest(

--- a/services/pic-sure-operations-service/src/test/java/edu/harvard/hms/dbmi/avillach/operations/query/QueryPersistenceServiceTest.java
+++ b/services/pic-sure-operations-service/src/test/java/edu/harvard/hms/dbmi/avillach/operations/query/QueryPersistenceServiceTest.java
@@ -86,6 +86,47 @@ class QueryPersistenceServiceTest {
     }
 
     @Test
+    void saveStampsStartTimeAndFirstAvailableTransitionStampsReadyTime() {
+        UUID picsureId = service.save(new SaveQueryRequest("{}", null, "QUEUED", null, null));
+        entityManager.flush();
+        entityManager.clear();
+
+        StoredQuery afterSave = service.get(picsureId);
+        assertThat(afterSave.startTime()).isNotNull();
+        assertThat(afterSave.readyTime()).isNull();
+
+        service.update(picsureId, new UpdateQueryRequest("AVAILABLE", null, null));
+        entityManager.flush();
+        entityManager.clear();
+
+        StoredQuery ready = service.get(picsureId);
+        assertThat(ready.startTime()).isEqualTo(afterSave.startTime());
+        assertThat(ready.readyTime()).isNotNull();
+
+        // a later status update must not move the original readyTime
+        service.update(picsureId, new UpdateQueryRequest("AVAILABLE", "rr-later", null));
+        entityManager.flush();
+        entityManager.clear();
+        assertThat(service.get(picsureId).readyTime()).isEqualTo(ready.readyTime());
+    }
+
+    @Test
+    void timingFieldsOnMigratedRowsRoundTripThroughGet() {
+        // rows migrated from the legacy schema already carry timing; the internal API must return it
+        Query legacy = new Query();
+        legacy.setQuery("{}");
+        legacy.setStartTime(java.sql.Date.valueOf("2024-01-02"));
+        legacy.setReadyTime(java.sql.Date.valueOf("2024-01-03"));
+        UUID picsureId = repo.save(legacy).getUuid();
+        entityManager.flush();
+        entityManager.clear();
+
+        StoredQuery stored = service.get(picsureId);
+        assertThat(stored.startTime()).isEqualTo(java.sql.Date.valueOf("2024-01-02").getTime());
+        assertThat(stored.readyTime()).isEqualTo(java.sql.Date.valueOf("2024-01-03").getTime());
+    }
+
+    @Test
     void saveStripsResourceCredentialsBeforePersisting() {
         UUID picsureId = service.save(
             new SaveQueryRequest(


### PR DESCRIPTION
## Summary

Rebuilt `api_rewrite_feedback_changes` directly on `pic_sure_api_mono_repo` and re-evaluated every feedback change against the current monorepo implementation.

The resulting PR contains 20 focused commits across 54 files. Changes that are already present, no longer apply, or conflict with the current architecture were not replayed.

## Retained or adapted feedback

| Commit | Change |
|---|---|
| 55f5203b | Continuous cross-count suppression compares raw counts numerically and fails closed |
| d9db92ac | Never persist or return `resourceCredentials` |
| 8a316a15 | Stamp and expose query `startTime` / `readyTime` |
| b7b248bc | Run the three service containers as non-root |
| 288499a3 | Make `GatewayApplication.main` public |
| bd87d4b5 | Return structured 502 errors for open-access PSAMA transport failures |
| 56b719cf | Remove dead `userIdClaim` configuration |
| cd0263d6 | Require authentication for unsupported `/v3/system/status` |
| 765d9599 | Sanitize identity/internal headers, audit the trusted XFF hop, and guard internal endpoints |
| 155f29db | Expose audit metadata as an unmodifiable view |
| 4645ab9f | Bound logging-client in-flight sends and apply backpressure |
| 029343e2 | Fail fast on invalid logging-client configuration |
| c60e4b21 | Sanitize and bound session IDs |
| 8703e0e1 | Clarify query-ID semantics and null-harden phenotypic clauses |
| e4424517 | Move email validation into the service and share operations exceptions |
| c607e8ac | Consolidate pooled REST-client construction |
| 58257f18 | Add QueryTranslator regression coverage |
| ead13b1f | Collapse any-record-of groups to maximal prefixes |
| fc4bfd01 | Correct QueryTranslator documentation for maximal-prefix behavior |
| f95cb233 | Align the root README with the current reactor |

## Feedback changes not replayed

- Uploader buffering exemption: the uploader path is being removed and the target no longer needs this exception.
- AIO auth-dispatch default: the required default is already present in the target configuration.
- `{backend}` to `{instance}` path-variable rename: URL behavior is unchanged, while the current auth/open architecture deliberately models these destinations as backends.

## Items verified with no change needed

- Constant-time token comparison already exists in both relevant paths.
- Blank actuator tokens deliberately fail closed, and `AuditRouteTable` already validates its configuration.
- Authorization is used only as the outbound logging-service authentication header; it is not copied into audit payloads or log lines.

## Verification

- Full 26-module reactor: `mvn test` under JDK 25 — **BUILD SUCCESS**
- Docker-backed dictionary and dump tests included
- Focused regression suites for continuous counts, credentials/timing, gateway security, logging, operations, query, and model changes all pass
- `git diff --check` passes
- Branch is a direct descendant of `pic_sure_api_mono_repo`
