### PR TITLE
ALS-12138: Add partitioning tests, refactor code

### DIFF
--- a/services/pic-sure-hpds/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/MissingConsentsException.java
+++ b/services/pic-sure-hpds/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/MissingConsentsException.java
@@ -1,0 +1,7 @@
+package edu.harvard.hms.dbmi.avillach.hpds.processing;
+
+public class MissingConsentsException extends RuntimeException {
+    public MissingConsentsException(String message) {
+        super(message);
+    }
+}

--- a/services/pic-sure-hpds/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PartitionedPhenotypicObservationStore.java
+++ b/services/pic-sure-hpds/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PartitionedPhenotypicObservationStore.java
@@ -136,7 +136,13 @@ public class PartitionedPhenotypicObservationStore {
             }
             return phenotypicPartitions.values().stream();
         } else {
-            return userRequestContext.getUserConsents().stream().map(phenotypicPartitions::get).filter(Objects::nonNull);
+            return userRequestContext.getUserConsents().stream().map(consent -> {
+                PhenotypicObservationStore phenotypicObservationStore = phenotypicPartitions.get(consent);
+                if (phenotypicObservationStore == null) {
+                    log.debug("No partition found for consent {}", consent);
+                }
+                return phenotypicObservationStore;
+            }).filter(Objects::nonNull);
         }
     }
 

--- a/services/pic-sure-hpds/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PartitionedPhenotypicObservationStore.java
+++ b/services/pic-sure-hpds/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PartitionedPhenotypicObservationStore.java
@@ -1,11 +1,9 @@
 package edu.harvard.hms.dbmi.avillach.hpds.processing.v3;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.ColumnMeta;
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.PhenoCube;
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.SummaryColumnMeta;
+import edu.harvard.hms.dbmi.avillach.hpds.processing.MissingConsentsException;
 import edu.harvard.hms.dbmi.avillach.hpds.processing.PhenotypeMetaStore;
 import edu.harvard.hms.dbmi.avillach.hpds.processing.util.UserRequestContext;
 import org.jspecify.annotations.NonNull;
@@ -20,8 +18,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
-import java.util.concurrent.ExecutionException;
-import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -36,11 +33,15 @@ public class PartitionedPhenotypicObservationStore {
 
     private final Map<String, SummaryColumnMeta> allPartitionMetaStore;
 
+    private final boolean requireAuthorizationFilter;
+
     @Autowired
     public PartitionedPhenotypicObservationStore(
-        UserRequestContext userRequestContext, @Value("${HPDS_DATA_DIRECTORY:/opt/local/hpds/}") String hpdsDataDirectory
+        UserRequestContext userRequestContext, @Value("${HPDS_DATA_DIRECTORY:/opt/local/hpds/}") String hpdsDataDirectory,
+        @Value("${hpds.requireAuthorizationFilter:true}") boolean requireAuthorizationFilter
     ) {
         this.userRequestContext = userRequestContext;
+        this.requireAuthorizationFilter = requireAuthorizationFilter;
 
         try (Stream<Path> stream = Files.list(Path.of(hpdsDataDirectory))) {
             List<Path> subdirectories = stream.filter(Files::isDirectory)
@@ -64,60 +65,23 @@ public class PartitionedPhenotypicObservationStore {
     }
 
     public Set<Integer> getKeysForRange(String conceptPath, Double min, Double max) {
-        // todo: disallow this by default
-        if (userRequestContext.getUserConsents().isEmpty()) {
-            Set<Integer> patientIds = phenotypicPartitions.values().stream()
-                .flatMap(phenotypicObservationStore -> phenotypicObservationStore.getKeysForRange(conceptPath, min, max).stream())
-                .collect(Collectors.toSet());
-            return patientIds;
-        } else {
-            Set<Integer> patientIds = userRequestContext.getUserConsents().stream().map(phenotypicPartitions::get)
-                .flatMap(phenotypicObservationStore -> phenotypicObservationStore.getKeysForRange(conceptPath, min, max).stream())
-                .collect(Collectors.toSet());
-            return patientIds;
-        }
+        return aggregateForPartition(phenotypicObservationStore -> phenotypicObservationStore.getKeysForRange(conceptPath, min, max))
+            .collect(Collectors.toSet());
     }
 
     public Set<Integer> getKeysForValues(String conceptPath, Collection<String> values) {
-        // todo: disallow this by default
-        if (userRequestContext.getUserConsents().isEmpty()) {
-            Set<Integer> patientIds = phenotypicPartitions.values().stream()
-                .flatMap(phenotypicObservationStore -> phenotypicObservationStore.getKeysForValues(conceptPath, values).stream())
-                .collect(Collectors.toSet());
-            return patientIds;
-        } else {
-            Set<Integer> patientIds = userRequestContext.getUserConsents().stream().map(phenotypicPartitions::get)
-                .flatMap(phenotypicObservationStore -> phenotypicObservationStore.getKeysForValues(conceptPath, values).stream())
-                .collect(Collectors.toSet());
-            return patientIds;
-        }
+        return aggregateForPartition((phenotypicObservationStore -> phenotypicObservationStore.getKeysForValues(conceptPath, values)))
+            .collect(Collectors.toSet());
     }
 
     public List<Integer> getAllKeys(String conceptPath) {
-        // todo: disallow this by default
-        if (userRequestContext.getUserConsents().isEmpty()) {
-            List<Integer> patientIds = phenotypicPartitions.values().stream()
-                .flatMap(phenotypicObservationStore -> phenotypicObservationStore.getAllKeys(conceptPath).stream())
-                .collect(Collectors.toList());
-            return patientIds;
-        } else {
-            List<Integer> patientIds = userRequestContext.getUserConsents().stream().map(phenotypicPartitions::get)
-                .flatMap(phenotypicObservationStore -> phenotypicObservationStore.getAllKeys(conceptPath).stream())
-                .collect(Collectors.toList());
-            return patientIds;
-        }
+        return aggregateForPartition(phenotypicObservationStore -> phenotypicObservationStore.getAllKeys(conceptPath))
+            .collect(Collectors.toList());
     }
 
     public Optional<PhenoCube<?>> getCube(String path) {
-        Set<PhenoCube<?>> phenoCubes;
-        // todo: disallow this by default
-        if (userRequestContext.getUserConsents().isEmpty()) {
-            phenoCubes = phenotypicPartitions.values().stream()
-                .flatMap(phenotypicObservationStore -> phenotypicObservationStore.getCube(path).stream()).collect(Collectors.toSet());
-        } else {
-            phenoCubes = userRequestContext.getUserConsents().stream().map(phenotypicPartitions::get)
-                .flatMap(phenotypicObservationStore -> phenotypicObservationStore.getCube(path).stream()).collect(Collectors.toSet());
-        }
+        Set<PhenoCube<?>> phenoCubes = getPartitionsForUser()
+            .flatMap(phenotypicObservationStore -> phenotypicObservationStore.getCube(path).stream()).collect(Collectors.toSet());
         PhenoCube<?> result = phenoCubes.stream().reduce((phenoCube, phenoCube2) -> {
             if (phenoCube.vType.equals(String.class)) {
                 return ((PhenoCube<String>) phenoCube).merge((PhenoCube<String>) phenoCube2);
@@ -133,16 +97,7 @@ public class PartitionedPhenotypicObservationStore {
     }
 
     public Set<Integer> getPatientIds() {
-        // todo: disallow this by default
-        if (userRequestContext.getUserConsents().isEmpty()) {
-            Set<Integer> patientIds = phenotypicPartitions.values().stream()
-                .flatMap(phenotypicObservationStore -> phenotypicObservationStore.getPatientIds().stream()).collect(Collectors.toSet());
-            return patientIds;
-        } else {
-            Set<Integer> patientIds = userRequestContext.getUserConsents().stream().map(phenotypicPartitions::get)
-                .flatMap(phenotypicObservationStore -> phenotypicObservationStore.getPatientIds().stream()).collect(Collectors.toSet());
-            return patientIds;
-        }
+        return aggregateForPartition(PhenotypicObservationStore::getPatientIds).collect(Collectors.toSet());
     }
 
     @Cacheable("PartitionedPhenotypicObservationStore.getMetaStore")
@@ -166,6 +121,23 @@ public class PartitionedPhenotypicObservationStore {
             }
         }
         return Map.copyOf(mergedColumnMeta);
+    }
+
+    private <T> Stream<T> aggregateForPartition(Function<PhenotypicObservationStore, Collection<T>> partitionFunction) {
+        return getPartitionsForUser().map(partitionFunction).flatMap(Collection::stream);
+    }
+
+    private @NonNull Stream<PhenotypicObservationStore> getPartitionsForUser() {
+        if (userRequestContext.getUserConsents().isEmpty()) {
+            if (requireAuthorizationFilter) {
+                throw new MissingConsentsException(
+                    "User consents must be specified. To allow users access to all data set hpds.requireAuthorizationFilter=false"
+                );
+            }
+            return phenotypicPartitions.values().stream();
+        } else {
+            return userRequestContext.getUserConsents().stream().map(phenotypicPartitions::get).filter(Objects::nonNull);
+        }
     }
 
 

--- a/services/pic-sure-hpds/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/PartitionedPhenotypicObservationStoreIntegrationTest.java
+++ b/services/pic-sure-hpds/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/PartitionedPhenotypicObservationStoreIntegrationTest.java
@@ -1,0 +1,115 @@
+package edu.harvard.hms.dbmi.avillach.hpds.test;
+
+import edu.harvard.hms.dbmi.avillach.hpds.processing.MissingConsentsException;
+import edu.harvard.hms.dbmi.avillach.hpds.processing.util.UserRequestContext;
+import edu.harvard.hms.dbmi.avillach.hpds.processing.v3.PartitionedPhenotypicObservationStore;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+@EnableAutoConfiguration
+@SpringBootTest(
+    classes = edu.harvard.hms.dbmi.avillach.hpds.service.HpdsApplication.class, properties = {"hpds.requireAuthorizationFilter=true"}
+)
+@ActiveProfiles("integration-test")
+@AutoConfigureMockMvc
+class PartitionedPhenotypicObservationStoreIntegrationTest {
+
+    @MockitoBean
+    private UserRequestContext userRequestContext;
+
+    @Autowired
+    private PartitionedPhenotypicObservationStore partitionedPhenotypicObservationStore;
+
+    @Test
+    public void getKeysForRange_noConsents_throwException() {
+        when(userRequestContext.getUserConsents()).thenReturn(List.of());
+
+        assertThrows(MissingConsentsException.class, () -> {
+            partitionedPhenotypicObservationStore.getKeysForRange("/a/concept/path/", 0.0, 10.0);
+        });
+    }
+
+    @Test
+    public void getKeysForValues_noConsents_throwException() {
+        when(userRequestContext.getUserConsents()).thenReturn(List.of());
+
+        assertThrows(MissingConsentsException.class, () -> {
+            partitionedPhenotypicObservationStore.getKeysForValues("/a/concept/path/", Set.of("value"));
+        });
+    }
+
+    @Test
+    public void getAllKeys_noConsents_throwException() {
+        when(userRequestContext.getUserConsents()).thenReturn(List.of());
+
+        assertThrows(MissingConsentsException.class, () -> {
+            partitionedPhenotypicObservationStore.getAllKeys("/a/concept/path/");
+        });
+    }
+
+    @Test
+    public void getCube_noConsents_throwException() {
+        when(userRequestContext.getUserConsents()).thenReturn(List.of());
+
+        assertThrows(MissingConsentsException.class, () -> {
+            partitionedPhenotypicObservationStore.getCube("/a/concept/path/");
+        });
+    }
+
+    @Test
+    public void getPatientIds_noConsents_throwException() {
+        when(userRequestContext.getUserConsents()).thenReturn(List.of());
+
+        assertThrows(MissingConsentsException.class, () -> {
+            partitionedPhenotypicObservationStore.getPatientIds();
+        });
+    }
+
+
+
+    @Test
+    public void getKeysForRange_hasConsents_doNotThrow() {
+        when(userRequestContext.getUserConsents()).thenReturn(List.of("partition1"));
+        partitionedPhenotypicObservationStore.getKeysForRange("\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", 0.0, 10.0);
+    }
+
+    @Test
+    public void getKeysForValues_hasConsents_doNotThrow() {
+        when(userRequestContext.getUserConsents()).thenReturn(List.of("partition1"));
+        partitionedPhenotypicObservationStore.getKeysForValues("\\open_access-1000Genomes\\data\\SEX\\", Set.of("male"));
+    }
+
+    @Test
+    public void getAllKeys_hasConsents_doNotThrow() {
+        when(userRequestContext.getUserConsents()).thenReturn(List.of("partition1"));
+        partitionedPhenotypicObservationStore.getAllKeys("\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\");
+    }
+
+    @Test
+    public void getCube_hasConsents_doNotThrow() {
+        when(userRequestContext.getUserConsents()).thenReturn(List.of("partition1"));
+        partitionedPhenotypicObservationStore.getCube("\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\");
+    }
+
+    @Test
+    public void getPatientIds_hasConsents_doNotThrow() {
+        when(userRequestContext.getUserConsents()).thenReturn(List.of("partition1"));
+
+        Set<Integer> patientIds = partitionedPhenotypicObservationStore.getPatientIds();
+        assertTrue(patientIds.size() > 0);
+    }
+}

--- a/services/pic-sure-hpds/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/PartitionedPhenotypicObservationStoreIntegrationTest.java
+++ b/services/pic-sure-hpds/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/PartitionedPhenotypicObservationStoreIntegrationTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 @EnableAutoConfiguration
+// this test is specifically testing when authorization filters are required, which is not the default for integration tests
 @SpringBootTest(
     classes = edu.harvard.hms.dbmi.avillach.hpds.service.HpdsApplication.class, properties = {"hpds.requireAuthorizationFilter=true"}
 )

--- a/services/pic-sure-hpds/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/QueryExecutorIntegrationTest.java
+++ b/services/pic-sure-hpds/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/QueryExecutorIntegrationTest.java
@@ -18,11 +18,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 @EnableAutoConfiguration
@@ -61,6 +61,20 @@ public class QueryExecutorIntegrationTest {
     }
 
     @Test
+    public void getPatientSubsetForQuery_validEmptyQuerySomePartitions() {
+        Query query = new Query(
+            List.of(), List.of(), null, List.of(new GenomicFilter("Gene_with_variant", List.of("LOC102723996"), null, null)),
+            ResultType.COUNT, null, null
+        );
+
+        when(userRequestContext.getUserConsents()).thenReturn(List.of("partition2", "partition3"));
+
+        Set<Integer> idList = queryExecutor.getPatientSubsetForQuery(query);
+        assertEquals(3, idList.size());
+        assertEquals(Set.of(198024, 198206, 198476), new HashSet<>(idList));
+    }
+
+    @Test
     public void getPatientSubsetForQuery_validGeneWithMultipleVariantQuery() {
         Query query = new Query(
             List.of(), List.of(), null,
@@ -70,6 +84,21 @@ public class QueryExecutorIntegrationTest {
 
         Set<Integer> idList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(22, idList.size());
+    }
+
+    @Test
+    public void getPatientSubsetForQuery_validGeneWithMultipleVariantQuerySomePartitions() {
+        Query query = new Query(
+            List.of(), List.of(), null,
+            List.of(new GenomicFilter("Gene_with_variant", List.of("LOC102723996", "LOC101928576"), null, null)), ResultType.COUNT, null,
+            null
+        );
+        when(userRequestContext.getUserConsents()).thenReturn(List.of("partition2", "partition3"));
+
+        Set<Integer> idList = queryExecutor.getPatientSubsetForQuery(query);
+
+        assertEquals(4, idList.size());
+        assertEquals(Set.of(198024, 198206, 198717, 198476), new HashSet<>(idList));
     }
 
     @Test
@@ -84,7 +113,23 @@ public class QueryExecutorIntegrationTest {
         assertEquals(4, idList.size());
     }
 
+    @Test
+    public void getPatientSubsetForQuery_validGeneWithVariantQueryAndNumericQuerySomePartitions() {
+        Query query = new Query(
+            List.of(), List.of(),
+            new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 35.0, 45.0, null),
+            List.of(new GenomicFilter("Gene_with_variant", List.of("LOC102723996"), null, null)), ResultType.COUNT, null, null
+        );
 
+
+        when(userRequestContext.getUserConsents()).thenReturn(List.of("partition2", "partition3"));
+        Set<Integer> idList = queryExecutor.getPatientSubsetForQuery(query);
+        assertEquals(0, idList.size());
+
+        when(userRequestContext.getUserConsents()).thenReturn(List.of("partition4"));
+        idList = queryExecutor.getPatientSubsetForQuery(query);
+        assertEquals(4, idList.size());
+    }
 
     @Test
     public void getPatientSubsetForQuery_validNumericPhenotypicQuery() {
@@ -96,6 +141,43 @@ public class QueryExecutorIntegrationTest {
 
         Set<Integer> idList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(562, idList.size());
+    }
+
+    @Test
+    public void getPatientSubsetForQuery_validNumericPhenotypicQuerySomePartitions() {
+        Query query = new Query(
+            List.of(), List.of(),
+            new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 35.0, 45.0, null),
+            null, ResultType.COUNT, null, null
+        );
+
+        when(userRequestContext.getUserConsents()).thenReturn(List.of("partition2", "partition3"));
+        Set<Integer> idList = queryExecutor.getPatientSubsetForQuery(query);
+        assertEquals(151, idList.size());
+        idList.forEach(id -> assertTrue(id >= 198000 && id < 200000));
+
+        when(userRequestContext.getUserConsents()).thenReturn(List.of("partition1", "partition4"));
+        idList = queryExecutor.getPatientSubsetForQuery(query);
+        assertEquals(411, idList.size());
+        idList.forEach(id -> assertTrue(id < 198000 || id >= 200000));
+    }
+
+    @Test
+    public void getPatientSubsetForQuery_validNumericPhenotypicQueryInvalidPartitions() {
+        Query query = new Query(
+            List.of(), List.of(),
+            new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 35.0, 45.0, null),
+            null, ResultType.COUNT, null, null
+        );
+
+        when(userRequestContext.getUserConsents()).thenReturn(List.of("partition2", "partition3452345", "partition3"));
+        Set<Integer> idList = queryExecutor.getPatientSubsetForQuery(query);
+        assertEquals(151, idList.size());
+        idList.forEach(id -> assertTrue(id >= 198000 && id < 200000));
+
+        when(userRequestContext.getUserConsents()).thenReturn(List.of("partition3452345"));
+        idList = queryExecutor.getPatientSubsetForQuery(query);
+        assertEquals(0, idList.size());
     }
 
     @Test
@@ -111,6 +193,24 @@ public class QueryExecutorIntegrationTest {
     }
 
     @Test
+    public void getPatientSubsetForQuery_validCategoricalPhenotypicQuerySomePartitions() {
+        Query query = new Query(
+            List.of(), List.of(),
+            new PhenotypicFilter(
+                PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\POPULATION NAME\\", Set.of("Finnish"), null, null, null
+            ), null, ResultType.COUNT, null, null
+        );
+
+        // note: all of the patients in this population are in partition 4
+        when(userRequestContext.getUserConsents()).thenReturn(List.of("partition2", "partition3"));
+        Set<Integer> idList = queryExecutor.getPatientSubsetForQuery(query);
+        assertEquals(0, idList.size());
+        when(userRequestContext.getUserConsents()).thenReturn(List.of("partition4"));
+        idList = queryExecutor.getPatientSubsetForQuery(query);
+        assertEquals(102, idList.size());
+    }
+
+    @Test
     public void getPatientSubsetForQuery_nonExistentCategoricalPhenotypicQuery() {
         Query query = new Query(
             List.of(), List.of(),
@@ -118,6 +218,21 @@ public class QueryExecutorIntegrationTest {
                 PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\NOTAREAL_CONCEPT\\", Set.of("Finnish"), null, null, null
             ), null, ResultType.COUNT, null, null
         );
+        Set<Integer> idList = queryExecutor.getPatientSubsetForQuery(query);
+        assertEquals(0, idList.size());
+    }
+
+
+    @Test
+    public void getPatientSubsetForQuery_nonExistentCategoricalPhenotypicQuerySomePartitions() {
+        Query query = new Query(
+            List.of(), List.of(),
+            new PhenotypicFilter(
+                PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\NOTAREAL_CONCEPT\\", Set.of("Finnish"), null, null, null
+            ), null, ResultType.COUNT, null, null
+        );
+
+        when(userRequestContext.getUserConsents()).thenReturn(List.of("partition2", "partition3"));
         Set<Integer> idList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(0, idList.size());
     }
@@ -152,6 +267,25 @@ public class QueryExecutorIntegrationTest {
         Set<Integer> bothIdList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(255, bothIdList.size());
         assertEquals(Sets.union(finnishIdList, columbianIdList), bothIdList);
+    }
+
+    @Test
+    public void getPatientSubsetForQuery_validMultipleValueCategoricalPhenotypicQuerySomePartitions() {
+        Query query = new Query(
+            List.of(), List.of(),
+            new PhenotypicFilter(
+                PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\POPULATION NAME\\", Set.of("Finnish", "Colombian"), null,
+                null, null
+            ), null, ResultType.COUNT, null, null
+        );
+
+        when(userRequestContext.getUserConsents()).thenReturn(List.of("partition2", "partition3"));
+        Set<Integer> bothIdList = queryExecutor.getPatientSubsetForQuery(query);
+        assertEquals(0, bothIdList.size());
+
+        when(userRequestContext.getUserConsents()).thenReturn(List.of("partition4"));
+        bothIdList = queryExecutor.getPatientSubsetForQuery(query);
+        assertEquals(255, bothIdList.size());
     }
 
     @Test
@@ -198,6 +332,29 @@ public class QueryExecutorIntegrationTest {
     }
 
     @Test
+    public void getPatientSubsetForQuery_validMultiplePhenotypicQuerySomePartitions() {
+        when(userRequestContext.getUserConsents()).thenReturn(List.of("partition2", "partition3"));
+
+        PhenotypicFilter ageFilter =
+                new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 35.0, 45.0, null);
+        Query query = new Query(List.of(), List.of(), ageFilter, null, ResultType.COUNT, null, null);
+        Set<Integer> ageIdList = queryExecutor.getPatientSubsetForQuery(query);
+        assertEquals(151, ageIdList.size());
+
+        PhenotypicFilter maleFilter =
+                new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SEX\\", Set.of("male"), null, null, null);
+        query = new Query(List.of(), List.of(), maleFilter, null, ResultType.COUNT, null, null);
+        Set<Integer> sexIdList = queryExecutor.getPatientSubsetForQuery(query);
+        assertEquals(1150, sexIdList.size());
+
+        PhenotypicSubquery phenotypicSubquery = new PhenotypicSubquery(null, List.of(ageFilter, maleFilter), Operator.AND);
+        query = new Query(List.of(), List.of(), phenotypicSubquery, null, ResultType.COUNT, null, null);
+        Set<Integer> bothIdList = queryExecutor.getPatientSubsetForQuery(query);
+        assertEquals(68, bothIdList.size());
+        assertEquals(Sets.intersection(ageIdList, sexIdList), bothIdList);
+    }
+
+    @Test
     public void getPatientSubsetForQuery_validMultipleNumericPhenotypicQuery() {
         PhenotypicFilter ageFilter =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 35.0, 45.0, null);
@@ -225,6 +382,23 @@ public class QueryExecutorIntegrationTest {
         );
 
         Set<Integer> idList = queryExecutor.getPatientSubsetForQuery(query);
+        assertEquals(7, idList.size());
+    }
+
+    @Test
+    public void getPatientSubsetForQuery_validRequiredVariantSomePartitions() {
+        Query query = new Query(
+            List.of(), List.of(), null, List.of(new GenomicFilter("chr21,5032061,A,G,LOC102723996,missense_variant", null, null, null)),
+            ResultType.COUNT, null, null
+        );
+
+
+        when(userRequestContext.getUserConsents()).thenReturn(List.of("partition2", "partition3"));
+        Set<Integer> idList = queryExecutor.getPatientSubsetForQuery(query);
+        assertEquals(0, idList.size());
+
+        when(userRequestContext.getUserConsents()).thenReturn(List.of("partition2", "partition4"));
+        idList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(7, idList.size());
     }
 
@@ -333,6 +507,22 @@ public class QueryExecutorIntegrationTest {
 
         Collection<String> variantList = queryExecutor.getVariantList(query);
         assertEquals(4, variantList.size());
+    }
+
+    @Test
+    public void getVariantList_validGeneWithVariantQuerySomePartitions() {
+        Query query = new Query(
+            List.of(), List.of(), null, List.of(new GenomicFilter("Gene_with_variant", List.of("LOC102723996"), null, null)),
+            ResultType.COUNT, null, null
+        );
+
+
+        when(userRequestContext.getUserConsents()).thenReturn(List.of("partition2"));
+
+        Set<Integer> patientSubsetForQuery = queryExecutor.getPatientSubsetForQuery(query);
+
+        Collection<String> variantList = queryExecutor.getVariantList(query);
+        assertEquals(3, variantList.size());
     }
 
     @Test


### PR DESCRIPTION
Refactored boilerplate code into a generic function to handle partitioning with consents. Added comprehensive integration tests for partitioning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable authorization filtering for partition-based data access.
  - Requests with valid consent partitions now retrieve data only from authorized partitions.
  - Requests without required consents now return a clear missing-consent error when enforcement is enabled.
  - Supported access includes keys, cubes, patient identifiers, and query results across genomic and phenotypic data.

- **Tests**
  - Added coverage for authorized, unauthorized, invalid, and partially populated partition scenarios across supported query types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->