### PR TITLE
ALS-12638: Update user consent passing

### DIFF
--- a/libs/pic-sure-commons/pic-sure-hpds-model/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/translation/QueryTranslator.java
+++ b/libs/pic-sure-commons/pic-sure-hpds-model/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/translation/QueryTranslator.java
@@ -32,7 +32,7 @@ public class QueryTranslator {
 
     public static Query translate(edu.harvard.hms.dbmi.avillach.hpds.data.query.Query v1) throws UntranslatableQueryException {
         return new Query(
-            buildSelect(v1), List.of(), buildPhenotypicClause(v1), buildGenomicFilters(v1), v1.getExpectedResultType(),
+            buildSelect(v1), List.of(), Set.of(), buildPhenotypicClause(v1), buildGenomicFilters(v1), v1.getExpectedResultType(),
             parseUuid(v1.getPicSureId()), parseUuid(v1.getId())
         );
     }

--- a/libs/pic-sure-commons/pic-sure-hpds-model/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/v3/Query.java
+++ b/libs/pic-sure-commons/pic-sure-hpds-model/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/v3/Query.java
@@ -5,15 +5,18 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 public record Query(
     @Schema(
         description = "A list of concept paths to select. Ignored for expectedResultType that do not return fields, such as COUNT"
     ) List<String> select,
+    @Deprecated
     @Schema(
-        description = "A list of filters specifically applied for authorization purposes"
+        description = "A list of filters specifically applied for authorization purposes", deprecated = true
     ) List<AuthorizationFilter> authorizationFilters,
+    Set<UserConsent> userConsents,
     @Schema(description = "An object specifying phenotypic filters") PhenotypicClause phenotypicClause,
     @Schema(description = "A list of genomic filters") List<GenomicFilter> genomicFilters,
     @Schema(description = "An object specifying the result type") ResultType expectedResultType,
@@ -26,6 +29,7 @@ public record Query(
         return select == null ? List.of() : select;
     }
 
+    @Deprecated
     @Override
     public List<AuthorizationFilter> authorizationFilters() {
         return authorizationFilters == null ? List.of() : authorizationFilters;
@@ -33,9 +37,15 @@ public record Query(
 
     public Query setAuthorizationFilters(List<AuthorizationFilter> authorizationFilters) {
         return new Query(
-            this.select, authorizationFilters == null ? List.of() : authorizationFilters, this.phenotypicClause, this.genomicFilters,
+            this.select, authorizationFilters == null ? List.of() : authorizationFilters, this.userConsents, this.phenotypicClause, this.genomicFilters,
             this.expectedResultType, this.picsureId, this.id
         );
+    }
+
+
+    @Override
+    public Set<UserConsent> userConsents() {
+        return userConsents == null ? Set.of() : userConsents;
     }
 
 
@@ -73,6 +83,6 @@ public record Query(
         if (id != null) {
             return this;
         }
-        return new Query(select, authorizationFilters, phenotypicClause, genomicFilters, expectedResultType, picsureId, UUID.randomUUID());
+        return new Query(select, authorizationFilters, userConsents, phenotypicClause, genomicFilters, expectedResultType, picsureId, UUID.randomUUID());
     }
 }

--- a/libs/pic-sure-commons/pic-sure-hpds-model/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/v3/Query.java
+++ b/libs/pic-sure-commons/pic-sure-hpds-model/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/v3/Query.java
@@ -48,6 +48,13 @@ public record Query(
         return userConsents == null ? Set.of() : userConsents;
     }
 
+    public Query setUserConsents(Set<UserConsent> userConsents) {
+        return new Query(
+                this.select, this.authorizationFilters, userConsents != null ? userConsents : Set.of(), this.phenotypicClause, this.genomicFilters,
+                this.expectedResultType, this.picsureId, this.id
+        );
+    }
+
 
     @Override
     public List<GenomicFilter> genomicFilters() {

--- a/libs/pic-sure-commons/pic-sure-hpds-model/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/v3/UserConsent.java
+++ b/libs/pic-sure-commons/pic-sure-hpds-model/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/v3/UserConsent.java
@@ -1,0 +1,4 @@
+package edu.harvard.hms.dbmi.avillach.hpds.data.query.v3;
+
+public record UserConsent(String value) {
+}

--- a/libs/pic-sure-commons/pic-sure-hpds-model/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/v3/QueryTest.java
+++ b/libs/pic-sure-commons/pic-sure-hpds-model/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/v3/QueryTest.java
@@ -29,7 +29,7 @@ public class QueryTest {
 
         PhenotypicSubquery phenotypicQuery =
             new PhenotypicSubquery(null, List.of(phenotypicSubquery, phenotypicSubquery2, phenotypicFilter), Operator.OR);
-        Query query = new Query(List.of("PATIENT_ID"), authorizationFilters, phenotypicQuery, List.of(), ResultType.COUNT, null, null);
+        Query query = new Query(List.of("PATIENT_ID"), authorizationFilters, Set.of(), phenotypicQuery, List.of(), ResultType.COUNT, null, null);
 
         String serialized = objectMapper.writeValueAsString(query);
         System.out.println(serialized);
@@ -43,7 +43,7 @@ public class QueryTest {
     public void jacksonSerialization_validNullValues() throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
 
-        Query query = new Query(null, null, null, null, null, null, null);
+        Query query = new Query(null, null, null, null, null, null, null, null);
 
         String serialized = objectMapper.writeValueAsString(query);
         System.out.println(serialized);
@@ -72,7 +72,7 @@ public class QueryTest {
 
         PhenotypicSubquery phenotypicQuery =
             new PhenotypicSubquery(null, List.of(phenotypicSubquery, phenotypicSubquery2, phenotypicFilter), null);
-        Query query = new Query(List.of("PATIENT_ID"), authorizationFilters, phenotypicQuery, List.of(), ResultType.COUNT, null, null);
+        Query query = new Query(List.of("PATIENT_ID"), authorizationFilters, Set.of(), phenotypicQuery, List.of(), ResultType.COUNT, null, null);
 
         String serialized = objectMapper.writeValueAsString(query);
         System.out.println(serialized);
@@ -84,7 +84,7 @@ public class QueryTest {
 
     @Test
     public void generateId_nullId_createNewId() {
-        Query query = new Query(List.of("PATIENT_ID"), List.of(), null, List.of(), ResultType.COUNT, null, null);
+        Query query = new Query(List.of("PATIENT_ID"), List.of(), Set.of(), null, List.of(), ResultType.COUNT, null, null);
 
         query = query.generateId();
         assertNotNull(query.id());
@@ -93,7 +93,7 @@ public class QueryTest {
     @Test
     public void generateId_idExists_doNotReplaceId() {
         UUID uuid = UUID.randomUUID();
-        Query query = new Query(List.of("PATIENT_ID"), List.of(), null, List.of(), ResultType.COUNT, null, uuid);
+        Query query = new Query(List.of("PATIENT_ID"), List.of(), Set.of(), null, List.of(), ResultType.COUNT, null, uuid);
 
         query = query.generateId();
         assertEquals(uuid, query.id());

--- a/services/pic-sure-auth-microapp/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/entity/UserConsents.java
+++ b/services/pic-sure-auth-microapp/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/entity/UserConsents.java
@@ -19,7 +19,7 @@ public class UserConsents extends BaseEntity {
 
 
     @Convert(converter = ConsentsJsonConverter.class)
-    private Map<String, Set<String>> consents;
+    private Set<String> consents;
 
     public UUID getUserId() {
         return userId;
@@ -30,11 +30,11 @@ public class UserConsents extends BaseEntity {
         return this;
     }
 
-    public Map<String, Set<String>> getConsents() {
+    public Set<String> getConsents() {
         return consents;
     }
 
-    public UserConsents setConsents(Map<String, Set<String>> consents) {
+    public UserConsents setConsents(Set<String> consents) {
         this.consents = consents;
         return this;
     }

--- a/services/pic-sure-auth-microapp/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/UserService.java
+++ b/services/pic-sure-auth-microapp/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/UserService.java
@@ -822,7 +822,7 @@ public class UserService {
     }
 
     public User updateUserConsents(User user, Set<String> userConsentStrings) {
-        Map<String, Set<String>> consents = new BdcConsentsBuilder(fenceMappingUtility.getFENCEMapping(), userConsentStrings).createConsents();
+        Set<String> consents = new BdcConsentsBuilder(fenceMappingUtility.getFENCEMapping(), userConsentStrings).createConsents();
         UserConsents userConsents = userConsentsRepository.findByUserId(user.getUuid());
         if (userConsents == null) {
             logger.info("Creating user consents");

--- a/services/pic-sure-auth-microapp/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/BdcConsentBasedAccessRuleEvaluator.java
+++ b/services/pic-sure-auth-microapp/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/BdcConsentBasedAccessRuleEvaluator.java
@@ -5,6 +5,7 @@ import edu.harvard.hms.dbmi.avillach.auth.entity.UserConsents;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.AuthorizationFilter;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.PhenotypicFilter;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.Query;
+import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.UserConsent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -26,7 +27,7 @@ public class BdcConsentBasedAccessRuleEvaluator implements ConsentBasedAccessRul
 
     @Override
     public boolean evaluateAccessRule(Query query, AccessRule accessRule, UserConsents consents) {
-        Set<String> userStudies = consents.getConsents().values().stream().flatMap(Collection::stream)
+        Set<String> userStudies = consents.getConsents().stream()
             .map(consent -> consent.split("\\.")[0]).collect(Collectors.toSet());
 
         for (PhenotypicFilter phenotypicFilter : query.allFilters()) {
@@ -35,15 +36,6 @@ public class BdcConsentBasedAccessRuleEvaluator implements ConsentBasedAccessRul
 
         for (String conceptPath : query.select()) {
             if (!isConceptPathAuthorized(conceptPath, consents, userStudies)) return false;
-        }
-
-        if (!query.genomicFilters().isEmpty()) {
-            if (!consents.getConsents().containsKey(GENOMIC_AUTHORIZATION_FILTER)) {
-                log.debug(
-                    "Genomic filters must contain the following authorization concepts: " + String.join(", ", GENOMIC_AUTHORIZATION_FILTER)
-                );
-                return false;
-            }
         }
 
         return true;
@@ -58,11 +50,7 @@ public class BdcConsentBasedAccessRuleEvaluator implements ConsentBasedAccessRul
             return true;
         }
         if (filterConsent.equals("DCC Harmonized data set")) {
-            Set<String> harmonizedConsents = consents.getConsents().getOrDefault(HARMONIZED_AUTHORIZATION_FILTER, Set.of());
-            if (harmonizedConsents.isEmpty()) {
-                log.debug("User must have at least one consent in " + HARMONIZED_AUTHORIZATION_FILTER + " to use filter " + conceptPath);
-                return false;
-            }
+            return true;
         } else if (!userStudies.contains(filterConsent)) {
             log.debug("User does not have study: " + filterConsent + " to access " + conceptPath);
             return false;
@@ -72,22 +60,6 @@ public class BdcConsentBasedAccessRuleEvaluator implements ConsentBasedAccessRul
 
     @Override
     public Query setAuthorizationFiltersForQuery(UserConsents userConsents, Query query) {
-        List<AuthorizationFilter> authorizationFilter = userConsents.getConsents().entrySet().stream().filter(entry -> {
-            if (entry.getKey().equals(GENOMIC_AUTHORIZATION_FILTER) && query.genomicFilters().isEmpty()) {
-                return false;
-            }
-            if (entry.getKey().equals(HARMONIZED_AUTHORIZATION_FILTER)) {
-                long harmonizedFilterCount =
-                    query.allFilters().stream().filter(filter -> filter.conceptPath().startsWith("\\DCC Harmonized data set\\")).count();
-                // leave these consents if there are any filters on harmonized concept paths
-                return harmonizedFilterCount > 0;
-            }
-            return true;
-        }).map(entry -> new AuthorizationFilter(entry.getKey(), entry.getValue())).toList();
-
-        log.debug("Adding authorization filters to query:");
-        authorizationFilter.stream().map(Objects::toString).forEach(log::debug);
-
-        return query.setAuthorizationFilters(authorizationFilter);
+        return query.setUserConsents(userConsents.getConsents().stream().map(UserConsent::new).collect(Collectors.toSet()));
     }
 }

--- a/services/pic-sure-auth-microapp/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/BdcConsentsBuilder.java
+++ b/services/pic-sure-auth-microapp/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/BdcConsentsBuilder.java
@@ -32,9 +32,8 @@ public class BdcConsentsBuilder {
         this.userConsentStrings = userConsentStrings;
     }
 
-    public Map<String, Set<String>> createConsents() {
-        Map<String, Set<String>> result = new HashMap<>();
-        result.put(CONSENTS_KEY, new HashSet<>());
+    public Set<String> createConsents() {
+        Set<String> result = new HashSet<>();
 
         userConsentStrings.forEach(consent -> {
             StudyMetaData studyMetaData = fenceMappingByConsent.get(consent);
@@ -43,35 +42,17 @@ public class BdcConsentsBuilder {
                 return;
             }
             // all user consents go in the consents list
-            result.computeIfAbsent(CONSENTS_KEY, _ -> new HashSet<>()).add(consent);
-
-            if (studyMetaData.getIsHarmonized()) {
-                Set<String> harmonizedConsents = result.getOrDefault(HARMONIZED_CONSENTS_KEY, new HashSet<>());
-                harmonizedConsents.add(consent);
-                result.put(HARMONIZED_CONSENTS_KEY, harmonizedConsents);
-            }
-
-            if (studyMetaData.getDataType() != null && studyMetaData.getDataType().contains(GENOMIC_DATA_TYPE_VALUE)) {
-                Set<String> topmedConsents = result.getOrDefault(TOPMED_CONSENTS_KEY, new HashSet<>());
-                topmedConsents.add(consent);
-                result.put(TOPMED_CONSENTS_KEY, topmedConsents);
-            }
+            result.add(consent);
         });
 
         // Add all public studies to the consents list
         fenceMappingByConsent.forEach((key, value) -> {
             if (PUBLIC_STUDY_TYPE.equalsIgnoreCase(value.getStudyType())) {
-                result.computeIfAbsent(CONSENTS_KEY, _ -> new HashSet<>()).add(key);
-
-                if (value.getDataType() != null && value.getDataType().contains(GENOMIC_DATA_TYPE_VALUE)) {
-                    Set<String> topmedConsents = result.getOrDefault(TOPMED_CONSENTS_KEY, new HashSet<>());
-                    topmedConsents.add(key);
-                    result.put(TOPMED_CONSENTS_KEY, topmedConsents);
-                }
+                result.add(key);
             }
         });
 
-        if (result.get(CONSENTS_KEY).isEmpty()) {
+        if (result.isEmpty()) {
             throw new IllegalStateException("No studies available for user");
         }
 

--- a/services/pic-sure-auth-microapp/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/UserServiceTest.java
+++ b/services/pic-sure-auth-microapp/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/UserServiceTest.java
@@ -19,15 +19,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockitoAnnotations;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.security.SecureRandom;
 import java.util.*;
@@ -39,23 +38,23 @@ import static org.mockito.Mockito.*;
 @ContextConfiguration(classes = {JWTUtil.class, UserService.class})
 public class UserServiceTest {
 
-    @MockBean
+    @MockitoBean
     private SecurityContext securityContext;
-    @MockBean
+    @MockitoBean
     private BasicMailService basicMailService;
-    @MockBean
+    @MockitoBean
     private TOSService tosService;
-    @MockBean
+    @MockitoBean
     private UserRepository userRepository;
-    @MockBean
+    @MockitoBean
     private ConnectionRepository connectionRepository;
-    @MockBean
+    @MockitoBean
     private ApplicationRepository applicationRepository;
-    @MockBean
+    @MockitoBean
     private RoleService roleService;
-    @MockBean
+    @MockitoBean
     private JWTUtil mockJwtUtil;
-    @MockBean
+    @MockitoBean
     private LoggingClient loggingClient;
     private JWTUtil jwtUtil;
 
@@ -63,9 +62,9 @@ public class UserServiceTest {
     private final long longTermTokenExpirationTime = 2592000000L;
 
     private UserService userService;
-    @MockBean
+    @MockitoBean
     private UserConsentsRepository userConsentsRepository;
-    @MockBean
+    @MockitoBean
     private FenceMappingUtility fenceMappingUtility;
 
     @BeforeEach
@@ -586,21 +585,21 @@ public class UserServiceTest {
 
         ArgumentCaptor<UserConsents> userConsentsCaptor = ArgumentCaptor.forClass(UserConsents.class);
         verify(userConsentsRepository).save(userConsentsCaptor.capture());
-        assertEquals(Map.of("\\_consents\\", Set.of("phs1234.c1")), userConsentsCaptor.getValue().getConsents());
+        assertEquals(Set.of("phs1234.c1"), userConsentsCaptor.getValue().getConsents());
     }
 
 
     @Test
     public void updateUserConsents_existingUser() {
         when(fenceMappingUtility.getFENCEMapping()).thenReturn(Map.of("phs1234.c1", new StudyMetaData().setHarmonized(false).setDataType("P")));
-        when(userConsentsRepository.findByUserId(any(UUID.class))).thenReturn(new UserConsents().setConsents(Map.of("_consents", Set.of("phs345.c2"))));
+        when(userConsentsRepository.findByUserId(any(UUID.class))).thenReturn(new UserConsents().setConsents(Set.of("phs345.c2")));
         User user = createTestUser();
 
         userService.updateUserConsents(user, Set.of("phs1234.c1"));
 
         ArgumentCaptor<UserConsents> userConsentsCaptor = ArgumentCaptor.forClass(UserConsents.class);
         verify(userConsentsRepository).save(userConsentsCaptor.capture());
-        assertEquals(Map.of("\\_consents\\", Set.of("phs1234.c1")), userConsentsCaptor.getValue().getConsents());
+        assertEquals(Set.of("phs1234.c1"), userConsentsCaptor.getValue().getConsents());
     }
 
     private UserClaims buildTestUserClaims(User user) {

--- a/services/pic-sure-auth-microapp/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/BdcConsentBasedAccessRuleEvaluatorTest.java
+++ b/services/pic-sure-auth-microapp/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/BdcConsentBasedAccessRuleEvaluatorTest.java
@@ -24,7 +24,7 @@ class BdcConsentBasedAccessRuleEvaluatorTest {
 
     @Test
     public void evaluateAccessRule_validPhenotypicFilters_accept() {
-        UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2")));
+        UserConsents userConsents = new UserConsents().setConsents(Set.of("phs123.c1", "phs456.c2"));
         Query query = new Query(
             List.of(), List.of(), Set.of(),
             new PhenotypicSubquery(
@@ -43,7 +43,7 @@ class BdcConsentBasedAccessRuleEvaluatorTest {
 
     @Test
     public void evaluateAccessRule_phenotypicFiltersOneWrongConsent_reject() {
-        UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2")));
+        UserConsents userConsents = new UserConsents().setConsents(Set.of("phs123.c1", "phs456.c2"));
         Query query = new Query(
                 List.of(), List.of(), Set.of(),
                 new PhenotypicSubquery(
@@ -62,7 +62,7 @@ class BdcConsentBasedAccessRuleEvaluatorTest {
 
     @Test
     public void evaluateAccessRule_nestedInvalidPhenotypicFiltersConsent_reject() {
-        UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2")));
+        UserConsents userConsents = new UserConsents().setConsents(Set.of("phs123.c1", "phs456.c2"));
         Query query = new Query(
                 List.of(), List.of(), Set.of(),
                 new PhenotypicSubquery(
@@ -82,7 +82,7 @@ class BdcConsentBasedAccessRuleEvaluatorTest {
 
     @Test
     public void evaluateAccessRule_userNoConsents_reject() {
-        UserConsents userConsents = new UserConsents().setConsents(Map.of());
+        UserConsents userConsents = new UserConsents().setConsents(Set.of());
         Query query = new Query(
             List.of(), List.of(), Set.of(),
             new PhenotypicSubquery(
@@ -101,8 +101,8 @@ class BdcConsentBasedAccessRuleEvaluatorTest {
 
     @Test
     public void evaluateAccessRule_genomicFiltersValidTopmedConsents_accept() {
-        Map<String, Set<String>> consents =
-            Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2"), "\\_topmed_consents\\", Set.of("phs123.c1", "phs456.c2"));
+        Set<String> consents =
+            Set.of("phs123.c1", "phs456.c2");
         UserConsents userConsents = new UserConsents().setConsents(consents);
         Query query = new Query(
             List.of(), List.of(), Set.of(),
@@ -122,28 +122,8 @@ class BdcConsentBasedAccessRuleEvaluatorTest {
 
 
     @Test
-    public void evaluateAccessRule_genomicFiltersNoTopmedConsents_reject() {
-        UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2")));
-        Query query = new Query(
-            List.of(), List.of(), Set.of(),
-            new PhenotypicSubquery(
-                null,
-                List.of(
-                    new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\phs123\\data\\age\\", null, 30.0, 40.0, null),
-                    new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\phs456\\data\\age\\", null, 30.0, 40.0, null),
-                    new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\phs123\\data\\sex\\", Set.of("male", "female"), null, null, null)
-                ), Operator.AND
-            ), List.of(new GenomicFilter("Gene_with_variant", List.of("CDH8"), null, null)), ResultType.COUNT, null, null
-        );
-
-        boolean result = bdcConsentBasedAccessRuleEvaluator.evaluateAccessRule(query, null, userConsents);
-        assertFalse(result);
-    }
-
-
-    @Test
     public void evaluateAccessRule_validHarmonizedPhenotypicFilters_accept() {
-        UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2"), "\\_harmonized_consent\\", Set.of("phs789.c1", "phs789.c2")));
+        UserConsents userConsents = new UserConsents().setConsents(Set.of("phs123.c1", "phs456.c2", "phs789.c1", "phs789.c2"));
         Query query = new Query(
                 List.of(), List.of(), Set.of(),
                 new PhenotypicSubquery(
@@ -161,27 +141,8 @@ class BdcConsentBasedAccessRuleEvaluatorTest {
     }
 
     @Test
-    public void evaluateAccessRule_invalidNestedHarmonizedPhenotypicFilters_reject() {
-        UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2")));
-        Query query = new Query(
-                List.of(), List.of(), Set.of(),
-                new PhenotypicSubquery(
-                        null,
-                        List.of(
-                                new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\phs123\\data\\age\\", null, 30.0, 40.0, null),
-                                new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\phs456\\data\\age\\", null, 30.0, 40.0, null),
-                                new PhenotypicSubquery(false, List.of(new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\DCC Harmonized data set\\data\\sex\\", Set.of("male", "female"), null, null, null)), Operator.AND)
-                        ), Operator.AND
-                ), null, ResultType.COUNT, null, null
-        );
-
-        boolean result = bdcConsentBasedAccessRuleEvaluator.evaluateAccessRule(query, null, userConsents);
-        assertFalse(result);
-    }
-
-    @Test
     public void evaluateAccessRule_harmonizedPhenotypicFiltersEmptyUserConsent_reject() {
-        UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2"), "\\_harmonized_consent\\", Set.of()));
+        UserConsents userConsents = new UserConsents().setConsents(Set.of("phs123.c1", "phs456.c2"));
         Query query = new Query(
                 List.of(), List.of(), Set.of(),
                 new PhenotypicSubquery(
@@ -195,31 +156,12 @@ class BdcConsentBasedAccessRuleEvaluatorTest {
         );
 
         boolean result = bdcConsentBasedAccessRuleEvaluator.evaluateAccessRule(query, null, userConsents);
-        assertFalse(result);
-    }
-
-    @Test
-    public void setAuthorizationFiltersForQuery_normalConsents_addOnlyConsents() {
-        UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2"), "\\_harmonized_consent\\", Set.of("phs789.c1", "phs789.c2")));
-        Query query = new Query(
-                List.of(), List.of(), Set.of(),
-                new PhenotypicSubquery(
-                        null,
-                        List.of(
-                                new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\phs123\\data\\age\\", null, 30.0, 40.0, null),
-                                new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\phs456\\data\\age\\", null, 30.0, 40.0, null)
-                        ), Operator.AND
-                ), null, ResultType.COUNT, null, null
-        );
-
-        Query queryWithConsents = bdcConsentBasedAccessRuleEvaluator.setAuthorizationFiltersForQuery(userConsents, query);
-        assertEquals(1, queryWithConsents.authorizationFilters().size());
-        assertEquals(new AuthorizationFilter("\\_consents\\", Set.of("phs123.c1", "phs456.c2")), queryWithConsents.authorizationFilters().get(0));
+        assertTrue(result);
     }
 
     @Test
     public void evaluateAccessRule_filterIncludesTopmedAndParentStudyId_accept() {
-        UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2")));
+        UserConsents userConsents = new UserConsents().setConsents(Set.of("phs123.c1", "phs456.c2"));
         Query query = new Query(
                 List.of(), List.of(), Set.of(),
                 new PhenotypicSubquery(
@@ -239,7 +181,7 @@ class BdcConsentBasedAccessRuleEvaluatorTest {
 
     @Test
     public void evaluateAccessRule_selectIncludesTopmedAndParentStudyId_accept() {
-        UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2")));
+        UserConsents userConsents = new UserConsents().setConsents(Set.of("phs123.c1", "phs456.c2"));
         Query query = new Query(
                 List.of("\\_Topmed Study Accession with Subject ID\\", "\\_Parent Study Accession with Subject ID\\", "\\_consents\\", "\\_harmonized_consent\\", "\\_topmed_consents\\"), List.of(),
                 Set.of(),

--- a/services/pic-sure-auth-microapp/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/BdcConsentBasedAccessRuleEvaluatorTest.java
+++ b/services/pic-sure-auth-microapp/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/BdcConsentBasedAccessRuleEvaluatorTest.java
@@ -26,7 +26,7 @@ class BdcConsentBasedAccessRuleEvaluatorTest {
     public void evaluateAccessRule_validPhenotypicFilters_accept() {
         UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2")));
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicSubquery(
                 null,
                 List.of(
@@ -45,7 +45,7 @@ class BdcConsentBasedAccessRuleEvaluatorTest {
     public void evaluateAccessRule_phenotypicFiltersOneWrongConsent_reject() {
         UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2")));
         Query query = new Query(
-                List.of(), List.of(),
+                List.of(), List.of(), Set.of(),
                 new PhenotypicSubquery(
                         null,
                         List.of(
@@ -64,7 +64,7 @@ class BdcConsentBasedAccessRuleEvaluatorTest {
     public void evaluateAccessRule_nestedInvalidPhenotypicFiltersConsent_reject() {
         UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2")));
         Query query = new Query(
-                List.of(), List.of(),
+                List.of(), List.of(), Set.of(),
                 new PhenotypicSubquery(
                         null,
                         List.of(
@@ -84,7 +84,7 @@ class BdcConsentBasedAccessRuleEvaluatorTest {
     public void evaluateAccessRule_userNoConsents_reject() {
         UserConsents userConsents = new UserConsents().setConsents(Map.of());
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicSubquery(
                 null,
                 List.of(
@@ -105,7 +105,7 @@ class BdcConsentBasedAccessRuleEvaluatorTest {
             Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2"), "\\_topmed_consents\\", Set.of("phs123.c1", "phs456.c2"));
         UserConsents userConsents = new UserConsents().setConsents(consents);
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicSubquery(
                 null,
                 List.of(
@@ -125,7 +125,7 @@ class BdcConsentBasedAccessRuleEvaluatorTest {
     public void evaluateAccessRule_genomicFiltersNoTopmedConsents_reject() {
         UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2")));
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicSubquery(
                 null,
                 List.of(
@@ -145,7 +145,7 @@ class BdcConsentBasedAccessRuleEvaluatorTest {
     public void evaluateAccessRule_validHarmonizedPhenotypicFilters_accept() {
         UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2"), "\\_harmonized_consent\\", Set.of("phs789.c1", "phs789.c2")));
         Query query = new Query(
-                List.of(), List.of(),
+                List.of(), List.of(), Set.of(),
                 new PhenotypicSubquery(
                         null,
                         List.of(
@@ -164,7 +164,7 @@ class BdcConsentBasedAccessRuleEvaluatorTest {
     public void evaluateAccessRule_invalidNestedHarmonizedPhenotypicFilters_reject() {
         UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2")));
         Query query = new Query(
-                List.of(), List.of(),
+                List.of(), List.of(), Set.of(),
                 new PhenotypicSubquery(
                         null,
                         List.of(
@@ -183,7 +183,7 @@ class BdcConsentBasedAccessRuleEvaluatorTest {
     public void evaluateAccessRule_harmonizedPhenotypicFiltersEmptyUserConsent_reject() {
         UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2"), "\\_harmonized_consent\\", Set.of()));
         Query query = new Query(
-                List.of(), List.of(),
+                List.of(), List.of(), Set.of(),
                 new PhenotypicSubquery(
                         null,
                         List.of(
@@ -202,7 +202,7 @@ class BdcConsentBasedAccessRuleEvaluatorTest {
     public void setAuthorizationFiltersForQuery_normalConsents_addOnlyConsents() {
         UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2"), "\\_harmonized_consent\\", Set.of("phs789.c1", "phs789.c2")));
         Query query = new Query(
-                List.of(), List.of(),
+                List.of(), List.of(), Set.of(),
                 new PhenotypicSubquery(
                         null,
                         List.of(
@@ -221,7 +221,7 @@ class BdcConsentBasedAccessRuleEvaluatorTest {
     public void evaluateAccessRule_filterIncludesTopmedAndParentStudyId_accept() {
         UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2")));
         Query query = new Query(
-                List.of(), List.of(),
+                List.of(), List.of(), Set.of(),
                 new PhenotypicSubquery(
                         null,
                         List.of(
@@ -242,6 +242,7 @@ class BdcConsentBasedAccessRuleEvaluatorTest {
         UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2")));
         Query query = new Query(
                 List.of("\\_Topmed Study Accession with Subject ID\\", "\\_Parent Study Accession with Subject ID\\", "\\_consents\\", "\\_harmonized_consent\\", "\\_topmed_consents\\"), List.of(),
+                Set.of(),
                 new PhenotypicSubquery(
                         null,
                         List.of(

--- a/services/pic-sure-auth-microapp/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/BdcConsentsBuilderTest.java
+++ b/services/pic-sure-auth-microapp/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/BdcConsentsBuilderTest.java
@@ -27,9 +27,8 @@ public class BdcConsentsBuilderTest {
     @Test
     public void createConsents_noConsents_addPublic() {
         Set<String> userStudies = Set.of();
-        Map<String, Set<String>> consents = new BdcConsentsBuilder(DEFAULT_FENCE_MAPPING, userStudies).createConsents();
-        assertEquals(Set.of(BdcConsentsBuilder.CONSENTS_KEY), consents.keySet());
-        assertEquals(consents.get(BdcConsentsBuilder.CONSENTS_KEY), Set.of("open_access-1000Genomes", "tutorial-biolincc_framingham"));
+        Set<String> consents = new BdcConsentsBuilder(DEFAULT_FENCE_MAPPING, userStudies).createConsents();
+        assertEquals(consents, Set.of("open_access-1000Genomes", "tutorial-biolincc_framingham"));
     }
 
     @Test
@@ -45,31 +44,28 @@ public class BdcConsentsBuilderTest {
     @Test
     public void createConsents_oneNormalConsent() {
         Set<String> userStudies = Set.of("phs123.c1");
-        Map<String, Set<String>> consents = new BdcConsentsBuilder(DEFAULT_FENCE_MAPPING, userStudies).createConsents();
-        assertEquals(Set.of(BdcConsentsBuilder.CONSENTS_KEY), consents.keySet());
+        Set<String> consents = new BdcConsentsBuilder(DEFAULT_FENCE_MAPPING, userStudies).createConsents();
         assertEquals(
-            Set.of("phs123.c1", "open_access-1000Genomes", "tutorial-biolincc_framingham"), consents.get(BdcConsentsBuilder.CONSENTS_KEY)
+            Set.of("phs123.c1", "open_access-1000Genomes", "tutorial-biolincc_framingham"), consents
         );
     }
 
     @Test
     public void createConsents_multipleNormalConsent() {
         Set<String> userStudies = Set.of("phs123.c1","phs123.c2");
-        Map<String, Set<String>> consents = new BdcConsentsBuilder(DEFAULT_FENCE_MAPPING, userStudies).createConsents();
-        assertEquals(Set.of(BdcConsentsBuilder.CONSENTS_KEY), consents.keySet());
+        Set<String> consents = new BdcConsentsBuilder(DEFAULT_FENCE_MAPPING, userStudies).createConsents();
         assertEquals(
             Set.of("phs123.c1", "phs123.c2", "open_access-1000Genomes", "tutorial-biolincc_framingham"),
-            consents.get(BdcConsentsBuilder.CONSENTS_KEY)
+            consents
         );
     }
 
     @Test
     public void createConsents_oneNormalConsentOneMissingConsent_ignoreMissingConsent() {
         Set<String> userStudies = Set.of("phs123.c1","phs321.c1");
-        Map<String, Set<String>> consents = new BdcConsentsBuilder(DEFAULT_FENCE_MAPPING, userStudies).createConsents();
-        assertEquals(Set.of(BdcConsentsBuilder.CONSENTS_KEY), consents.keySet());
+        Set<String> consents = new BdcConsentsBuilder(DEFAULT_FENCE_MAPPING, userStudies).createConsents();
         assertEquals(
-            Set.of("phs123.c1", "open_access-1000Genomes", "tutorial-biolincc_framingham"), consents.get(BdcConsentsBuilder.CONSENTS_KEY)
+            Set.of("phs123.c1", "open_access-1000Genomes", "tutorial-biolincc_framingham"), consents
         );
     }
 
@@ -77,82 +73,62 @@ public class BdcConsentsBuilderTest {
     @Test
     public void createConsents_harmonizedConsentsOnly() {
         Set<String> userStudies = Set.of("phs456.c1","phs456.c2");
-        Map<String, Set<String>> consents = new BdcConsentsBuilder(DEFAULT_FENCE_MAPPING, userStudies).createConsents();
-        assertEquals(Set.of(BdcConsentsBuilder.CONSENTS_KEY, BdcConsentsBuilder.HARMONIZED_CONSENTS_KEY), consents.keySet());
+        Set<String> consents = new BdcConsentsBuilder(DEFAULT_FENCE_MAPPING, userStudies).createConsents();
         assertEquals(
             Set.of("phs456.c1", "phs456.c2", "open_access-1000Genomes", "tutorial-biolincc_framingham"),
-            consents.get(BdcConsentsBuilder.CONSENTS_KEY)
+            consents
         );
-        assertEquals(Set.of("phs456.c1", "phs456.c2"), consents.get(BdcConsentsBuilder.HARMONIZED_CONSENTS_KEY));
     }
 
     @Test
     public void createConsents_multipleNormalAndHarmonizedConsents() {
         Set<String> userStudies = Set.of("phs123.c1","phs123.c2","phs456.c1");
-        Map<String, Set<String>> consents = new BdcConsentsBuilder(DEFAULT_FENCE_MAPPING, userStudies).createConsents();
-        assertEquals(Set.of(BdcConsentsBuilder.CONSENTS_KEY, BdcConsentsBuilder.HARMONIZED_CONSENTS_KEY), consents.keySet());
+        Set<String> consents = new BdcConsentsBuilder(DEFAULT_FENCE_MAPPING, userStudies).createConsents();
         assertEquals(
             Set.of("phs123.c1", "phs123.c2", "phs456.c1", "open_access-1000Genomes", "tutorial-biolincc_framingham"),
-            consents.get(BdcConsentsBuilder.CONSENTS_KEY)
+            consents
         );
-        assertEquals(Set.of("phs456.c1"), consents.get(BdcConsentsBuilder.HARMONIZED_CONSENTS_KEY));
     }
 
 
     @Test
     public void createConsents_genomicConsentsOnly() {
         Set<String> userStudies = Set.of("phs789.c1","phs789.c2");
-        Map<String, Set<String>> consents = new BdcConsentsBuilder(DEFAULT_FENCE_MAPPING, userStudies).createConsents();
-        assertEquals(Set.of(BdcConsentsBuilder.CONSENTS_KEY, BdcConsentsBuilder.TOPMED_CONSENTS_KEY), consents.keySet());
+        Set<String> consents = new BdcConsentsBuilder(DEFAULT_FENCE_MAPPING, userStudies).createConsents();
         assertEquals(
             Set.of("phs789.c1", "phs789.c2", "open_access-1000Genomes", "tutorial-biolincc_framingham"),
-            consents.get(BdcConsentsBuilder.CONSENTS_KEY)
+            consents
         );
-        assertEquals(Set.of("phs789.c1", "phs789.c2"), consents.get(BdcConsentsBuilder.TOPMED_CONSENTS_KEY));
     }
 
     @Test
     public void createConsents_multipleNormalAndGenomicConsents() {
         Set<String> userStudies = Set.of("phs123.c1","phs123.c2","phs789.c1");
-        Map<String, Set<String>> consents = new BdcConsentsBuilder(DEFAULT_FENCE_MAPPING, userStudies).createConsents();
-        assertEquals(Set.of(BdcConsentsBuilder.CONSENTS_KEY, BdcConsentsBuilder.TOPMED_CONSENTS_KEY), consents.keySet());
+        Set<String> consents = new BdcConsentsBuilder(DEFAULT_FENCE_MAPPING, userStudies).createConsents();
         assertEquals(
             Set.of("phs123.c1", "phs123.c2", "phs789.c1", "open_access-1000Genomes", "tutorial-biolincc_framingham"),
-            consents.get(BdcConsentsBuilder.CONSENTS_KEY)
+            consents
         );
-        assertEquals(Set.of("phs789.c1"), consents.get(BdcConsentsBuilder.TOPMED_CONSENTS_KEY));
     }
 
     @Test
     public void createConsents_harmonizedGenomicConsentsOnly() {
         Set<String> userStudies = Set.of("phs999.c1","phs999.c2");
-        Map<String, Set<String>> consents = new BdcConsentsBuilder(DEFAULT_FENCE_MAPPING, userStudies).createConsents();
-        assertEquals(
-            Set.of(BdcConsentsBuilder.CONSENTS_KEY, BdcConsentsBuilder.TOPMED_CONSENTS_KEY, BdcConsentsBuilder.HARMONIZED_CONSENTS_KEY),
-            consents.keySet()
-        );
+        Set<String> consents = new BdcConsentsBuilder(DEFAULT_FENCE_MAPPING, userStudies).createConsents();
         assertEquals(
             Set.of("phs999.c1", "phs999.c2", "open_access-1000Genomes", "tutorial-biolincc_framingham"),
-            consents.get(BdcConsentsBuilder.CONSENTS_KEY)
+            consents
         );
-        assertEquals(Set.of("phs999.c1", "phs999.c2"), consents.get(BdcConsentsBuilder.TOPMED_CONSENTS_KEY));
-        assertEquals(Set.of("phs999.c1", "phs999.c2"), consents.get(BdcConsentsBuilder.HARMONIZED_CONSENTS_KEY));
     }
 
     @Test
     public void createConsents_multipleNormalAndHarmonizedGenomicConsents() {
         Set<String> userStudies = Set.of("phs123.c1","phs123.c2","phs999.c1");
-        Map<String, Set<String>> consents = new BdcConsentsBuilder(DEFAULT_FENCE_MAPPING, userStudies).createConsents();
-        assertEquals(
-            Set.of(BdcConsentsBuilder.CONSENTS_KEY, BdcConsentsBuilder.TOPMED_CONSENTS_KEY, BdcConsentsBuilder.HARMONIZED_CONSENTS_KEY),
-            consents.keySet()
-        );
+        Set<String> consents = new BdcConsentsBuilder(DEFAULT_FENCE_MAPPING, userStudies).createConsents();
         assertEquals(
             Set.of("phs123.c1", "phs123.c2", "phs999.c1", "open_access-1000Genomes", "tutorial-biolincc_framingham"),
-            consents.get(BdcConsentsBuilder.CONSENTS_KEY)
+            consents
         );
-        assertEquals(Set.of("phs999.c1"), consents.get(BdcConsentsBuilder.TOPMED_CONSENTS_KEY));
-        assertEquals(Set.of("phs999.c1"), consents.get(BdcConsentsBuilder.HARMONIZED_CONSENTS_KEY));
     }
 
     @Test
@@ -161,9 +137,7 @@ public class BdcConsentsBuilderTest {
         studyMetaData.put("open_access-1000Genomes",
                 new StudyMetaData().setHarmonized(false).setDataType("P/G").setStudyType("public"));
         Set<String> userStudies = Set.of();
-        Map<String, Set<String>> consents = new BdcConsentsBuilder(studyMetaData, userStudies).createConsents();
-        assertEquals(Set.of(BdcConsentsBuilder.CONSENTS_KEY, BdcConsentsBuilder.TOPMED_CONSENTS_KEY), consents.keySet());
-        assertEquals(consents.get(BdcConsentsBuilder.CONSENTS_KEY), Set.of("open_access-1000Genomes", "tutorial-biolincc_framingham"));
-        assertEquals(consents.get(BdcConsentsBuilder.TOPMED_CONSENTS_KEY), Set.of("open_access-1000Genomes"));
+        Set<String> consents = new BdcConsentsBuilder(studyMetaData, userStudies).createConsents();
+        assertEquals(consents, Set.of("open_access-1000Genomes", "tutorial-biolincc_framingham"));
     }
 }

--- a/services/pic-sure-hpds/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/CountV3Processor.java
+++ b/services/pic-sure-hpds/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/CountV3Processor.java
@@ -92,7 +92,7 @@ public class CountV3Processor implements HpdsV3Processor {
         query.select().parallelStream().forEach((String concept) -> {
             try {
                 Query safeCopy = new Query(
-                    List.of(), List.of(), new PhenotypicFilter(PhenotypicFilterType.REQUIRED, concept, null, null, null, null), List.of(),
+                    List.of(), List.of(), Set.of(), new PhenotypicFilter(PhenotypicFilterType.REQUIRED, concept, null, null, null, null), List.of(),
                     null, null, null
                 );
                 int matchingPatients = Sets.intersection(queryExecutor.getPatientSubsetForQuery(safeCopy), baseQueryPatientSet).size();

--- a/services/pic-sure-hpds/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/CountV3ProcessorTest.java
+++ b/services/pic-sure-hpds/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/CountV3ProcessorTest.java
@@ -52,14 +52,14 @@ class CountV3ProcessorTest {
         String conceptPath1 = "\\_studies_consents\\phs001194\\HMB\\";
         String conceptPath2 = "\\_studies_consents\\phs000007\\HMB-IRB-MDS\\";
 
-        Query fullQuery = new Query(List.of(conceptPath1, conceptPath2), List.of(), null, List.of(), ResultType.CROSS_COUNT, null, null);
+        Query fullQuery = new Query(List.of(conceptPath1, conceptPath2), List.of(), Set.of(), null, List.of(), ResultType.CROSS_COUNT, null, null);
 
         Query queryConcept1 = new Query(
-            List.of(), List.of(), new PhenotypicFilter(PhenotypicFilterType.REQUIRED, conceptPath1, null, null, null, null), List.of(),
+            List.of(), List.of(), Set.of(), new PhenotypicFilter(PhenotypicFilterType.REQUIRED, conceptPath1, null, null, null, null), List.of(),
             null, null, null
         );
         Query queryConcept2 = new Query(
-            List.of(), List.of(), new PhenotypicFilter(PhenotypicFilterType.REQUIRED, conceptPath2, null, null, null, null), List.of(),
+            List.of(), List.of(), Set.of(), new PhenotypicFilter(PhenotypicFilterType.REQUIRED, conceptPath2, null, null, null, null), List.of(),
             null, null, null
         );
 
@@ -84,14 +84,14 @@ class CountV3ProcessorTest {
         String conceptPath1 = "\\_studies_consents\\phs001194\\HMB\\";
         String conceptPath2 = "\\_studies_consents\\phs000007\\HMB-IRB-MDS\\";
 
-        Query fullQuery = new Query(List.of(conceptPath1, conceptPath2), List.of(), null, List.of(), ResultType.CROSS_COUNT, null, null);
+        Query fullQuery = new Query(List.of(conceptPath1, conceptPath2), List.of(), Set.of(), null, List.of(), ResultType.CROSS_COUNT, null, null);
 
         Query queryConcept1 = new Query(
-            List.of(), List.of(), new PhenotypicFilter(PhenotypicFilterType.REQUIRED, conceptPath1, null, null, null, null), List.of(),
+            List.of(), List.of(), Set.of(), new PhenotypicFilter(PhenotypicFilterType.REQUIRED, conceptPath1, null, null, null, null), List.of(),
             null, null, null
         );
         Query queryConcept2 = new Query(
-            List.of(), List.of(), new PhenotypicFilter(PhenotypicFilterType.REQUIRED, conceptPath2, null, null, null, null), List.of(),
+            List.of(), List.of(), Set.of(), new PhenotypicFilter(PhenotypicFilterType.REQUIRED, conceptPath2, null, null, null, null), List.of(),
             null, null, null
         );
 
@@ -117,14 +117,14 @@ class CountV3ProcessorTest {
         String conceptPath1 = "\\_studies_consents\\phs001194\\HMB\\";
         String conceptPath2 = "\\_studies_consents\\phs000007\\HMB-IRB-MDS\\";
 
-        Query fullQuery = new Query(List.of(conceptPath1, conceptPath2), List.of(), null, List.of(), ResultType.CROSS_COUNT, null, null);
+        Query fullQuery = new Query(List.of(conceptPath1, conceptPath2), List.of(), Set.of(), null, List.of(), ResultType.CROSS_COUNT, null, null);
 
         Query queryConcept1 = new Query(
-            List.of(), List.of(), new PhenotypicFilter(PhenotypicFilterType.REQUIRED, conceptPath1, null, null, null, null), List.of(),
+            List.of(), List.of(), Set.of(), new PhenotypicFilter(PhenotypicFilterType.REQUIRED, conceptPath1, null, null, null, null), List.of(),
             null, null, null
         );
         Query queryConcept2 = new Query(
-            List.of(), List.of(), new PhenotypicFilter(PhenotypicFilterType.REQUIRED, conceptPath2, null, null, null, null), List.of(),
+            List.of(), List.of(), Set.of(), new PhenotypicFilter(PhenotypicFilterType.REQUIRED, conceptPath2, null, null, null, null), List.of(),
             null, null, null
         );
 
@@ -146,7 +146,7 @@ class CountV3ProcessorTest {
     public void runContinuousCrossCounts_requiredNumericConcept_returnsObservedValues() {
         String conceptPath = "\\demographics\\AGE\\";
         PhenotypicFilter required = new PhenotypicFilter(PhenotypicFilterType.REQUIRED, conceptPath, null, null, null, null);
-        Query query = new Query(List.of(), List.of(), required, List.of(), ResultType.CONTINUOUS_CROSS_COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), required, List.of(), ResultType.CONTINUOUS_CROSS_COUNT, null, null);
 
         PhenoCube<Double> cube = new PhenoCube<>(conceptPath, Double.class);
         cube.setSortedByKey(new KeyAndValue[] {new KeyAndValue<>(1, 18.0), new KeyAndValue<>(2, 19.0), new KeyAndValue<>(3, 19.0)});
@@ -168,7 +168,7 @@ class CountV3ProcessorTest {
         PhenotypicFilter maleFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, sexPath, Set.of("male"), null, null, null);
         PhenotypicFilter femaleFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, sexPath, Set.of("female"), null, null, null);
         PhenotypicSubquery subquery = new PhenotypicSubquery(null, List.of(maleFilter, femaleFilter), Operator.OR);
-        Query query = new Query(List.of(), List.of(), subquery, List.of(), ResultType.CATEGORICAL_CROSS_COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), subquery, List.of(), ResultType.CATEGORICAL_CROSS_COUNT, null, null);
 
         TreeMap<String, TreeSet<Integer>> categoryMap = new TreeMap<>();
         categoryMap.put("male", new TreeSet<>(Set.of(1, 2, 3)));
@@ -192,7 +192,7 @@ class CountV3ProcessorTest {
     public void runCategoryCrossCounts_requiredFilterPartialBaseSet_countsEachPatientOnce() {
         String sexPath = "\\demographics\\SEX\\";
         PhenotypicFilter requiredSex = new PhenotypicFilter(PhenotypicFilterType.REQUIRED, sexPath, null, null, null, null);
-        Query query = new Query(List.of(), List.of(), requiredSex, List.of(), ResultType.CATEGORICAL_CROSS_COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), requiredSex, List.of(), ResultType.CATEGORICAL_CROSS_COUNT, null, null);
 
         TreeMap<String, TreeSet<Integer>> categoryMap = new TreeMap<>();
         categoryMap.put("male", new TreeSet<>(Set.of(1, 2, 3)));
@@ -220,7 +220,7 @@ class CountV3ProcessorTest {
         // range is OR'd with a filter on another concept. The age distribution must include 40 because patient 2 is in the cohort; the
         // filter range only constrains the cohort, not which values are displayed.
         PhenotypicFilter youngFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, agePath, null, 10.0, 20.0, null);
-        Query query = new Query(List.of(), List.of(), youngFilter, List.of(), ResultType.CONTINUOUS_CROSS_COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), youngFilter, List.of(), ResultType.CONTINUOUS_CROSS_COUNT, null, null);
 
         PhenoCube<Double> cube = new PhenoCube<>(agePath, Double.class);
         cube.setSortedByKey(new KeyAndValue[] {new KeyAndValue<>(1, 15.0), new KeyAndValue<>(2, 40.0), new KeyAndValue<>(3, 65.0)});

--- a/services/pic-sure-hpds/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PhenotypicQueryExecutorTest.java
+++ b/services/pic-sure-hpds/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PhenotypicQueryExecutorTest.java
@@ -33,7 +33,7 @@ class PhenotypicQueryExecutorTest {
 
     @Test
     public void getPatientSet_noFilters_returnAllPatients() {
-        Query query = new Query(List.of(), List.of(), null, null, ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), null, null, ResultType.COUNT, null, null);
 
         Set<Integer> patientIds = Set.of(10, 100, 1000);
         when(phenotypicObservationStore.getPatientIds()).thenReturn(new TreeSet<>(patientIds));
@@ -46,7 +46,7 @@ class PhenotypicQueryExecutorTest {
     public void getPatientSet_validNumericFilter_returnPatients() throws ExecutionException {
         String conceptPath = "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\";
         Query query = new Query(
-            List.of(), List.of(), new PhenotypicFilter(PhenotypicFilterType.FILTER, conceptPath, null, 35.0, 45.0, null), null,
+            List.of(), List.of(), Set.of(), new PhenotypicFilter(PhenotypicFilterType.FILTER, conceptPath, null, 35.0, 45.0, null), null,
             ResultType.COUNT, null, null
         );
 
@@ -61,7 +61,7 @@ class PhenotypicQueryExecutorTest {
     public void getPatientSet_validCategoricalFilter_returnPatients() throws ExecutionException {
         String conceptPath = "\\open_access-1000Genomes\\data\\POPULATION NAME\\";
         Query query = new Query(
-            List.of(), List.of(), new PhenotypicFilter(PhenotypicFilterType.FILTER, conceptPath, Set.of("Finnish"), null, null, null), null,
+            List.of(), List.of(), Set.of(), new PhenotypicFilter(PhenotypicFilterType.FILTER, conceptPath, Set.of("Finnish"), null, null, null), null,
             ResultType.COUNT, null, null
         );
 
@@ -76,7 +76,7 @@ class PhenotypicQueryExecutorTest {
     public void getPatientSet_nonExistentCategoricalFilter_returnNoPatients() {
         String conceptPath = "\\open_access-1000Genomes\\data\\NOT_A_CONCEPT_PATH\\";
         Query query = new Query(
-            List.of(), List.of(), new PhenotypicFilter(PhenotypicFilterType.FILTER, conceptPath, Set.of("Finnish"), null, null, null), null,
+            List.of(), List.of(), Set.of(), new PhenotypicFilter(PhenotypicFilterType.FILTER, conceptPath, Set.of("Finnish"), null, null, null), null,
             ResultType.COUNT, null, null
         );
 
@@ -90,7 +90,7 @@ class PhenotypicQueryExecutorTest {
     public void getPatientSet_nonExistentNumericFilter_returnNoPatients() {
         String conceptPath = "\\open_access-1000Genomes\\data\\NOT_A_CONCEPT_PATH\\";
         Query query = new Query(
-            List.of(), List.of(), new PhenotypicFilter(PhenotypicFilterType.FILTER, conceptPath, null, 42.0, null, null), null,
+            List.of(), List.of(), Set.of(), new PhenotypicFilter(PhenotypicFilterType.FILTER, conceptPath, null, 42.0, null, null), null,
             ResultType.COUNT, null, null
         );
 
@@ -118,7 +118,7 @@ class PhenotypicQueryExecutorTest {
         PhenotypicClause phenotypicSubquery2 = new PhenotypicSubquery(null, List.of(categoricalFilter2, numericFilter2), Operator.AND);
         PhenotypicClause topSubquery = new PhenotypicSubquery(null, List.of(phenotypicSubquery1, phenotypicSubquery2), Operator.OR);
 
-        Query query = new Query(List.of(), List.of(), topSubquery, List.of(), ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), topSubquery, List.of(), ResultType.COUNT, null, null);
 
         Set<Integer> catFilter1Ids = Set.of(3, 5, 8, 13, 21);
         Set<Integer> numFilter1Ids = Set.of(2, 3, 5, 8, 13);
@@ -140,7 +140,7 @@ class PhenotypicQueryExecutorTest {
     public void getPatientSet_validCategoricalFilterMultipleValues_returnPatients() throws ExecutionException {
         String conceptPath = "\\open_access-1000Genomes\\data\\POPULATION NAME\\";
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicFilter(PhenotypicFilterType.FILTER, conceptPath, Set.of("Finnish", "Zapotec"), null, null, null), null,
             ResultType.COUNT, null, null
         );
@@ -158,7 +158,7 @@ class PhenotypicQueryExecutorTest {
         String numericConceptPath = "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\";
         String nonMatchingConceptPath = "\\synthea\\data\\SYNTHETIC_AGE\\";
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicFilter(PhenotypicFilterType.ANY_RECORD_OF, "\\open_access-1000Genomes\\", null, null, null, null), null,
             ResultType.COUNT, null, null
         );
@@ -186,7 +186,7 @@ class PhenotypicQueryExecutorTest {
     public void getPatientSet_anyRecordOfFilterNoMatches_returnNoPatients() {
         String nonMatchingConceptPath = "\\synthea\\data\\SYNTHETIC_AGE\\";
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicFilter(PhenotypicFilterType.ANY_RECORD_OF, "\\open_access-1000Genomes\\", null, null, null, null), null,
             ResultType.COUNT, null, null
         );
@@ -207,7 +207,7 @@ class PhenotypicQueryExecutorTest {
     public void getPatientSet_validRequiredFilter_returnPatients() throws ExecutionException {
         String conceptPath = "\\open_access-1000Genomes\\data\\POPULATION NAME\\";
         Query query = new Query(
-            List.of(), List.of(), new PhenotypicFilter(PhenotypicFilterType.REQUIRED, conceptPath, null, null, null, null), null,
+            List.of(), List.of(), Set.of(), new PhenotypicFilter(PhenotypicFilterType.REQUIRED, conceptPath, null, null, null, null), null,
             ResultType.COUNT, null, null
         );
 
@@ -222,7 +222,7 @@ class PhenotypicQueryExecutorTest {
     public void getPatientSet_notFoundRequiredFilter_returnNoPatients() {
         String conceptPath = "\\open_access-1000Genomes\\data\\POPULATION NAME\\";
         Query query = new Query(
-            List.of(), List.of(), new PhenotypicFilter(PhenotypicFilterType.REQUIRED, conceptPath, null, null, null, null), null,
+            List.of(), List.of(), Set.of(), new PhenotypicFilter(PhenotypicFilterType.REQUIRED, conceptPath, null, null, null, null), null,
             ResultType.COUNT, null, null
         );
 

--- a/services/pic-sure-hpds/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/QueryValidatorTest.java
+++ b/services/pic-sure-hpds/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/QueryValidatorTest.java
@@ -44,7 +44,7 @@ class QueryValidatorTest {
 
     @Test
     public void validate_emptyQuery_isValid() {
-        Query query = new Query(List.of(), List.of(), null, List.of(), ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), null, List.of(), ResultType.COUNT, null, null);
         queryValidator.validate(query);
     }
 
@@ -52,7 +52,7 @@ class QueryValidatorTest {
     public void validate_validPhenotypicFilter_isValid() {
         PhenotypicFilter phenotypicFilter =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\study123\\demographics\\sex\\", Set.of("male"), null, null, null);
-        Query query = new Query(List.of(), List.of(), phenotypicFilter, List.of(), ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), phenotypicFilter, List.of(), ResultType.COUNT, null, null);
         queryValidator.validate(query);
         verify(phenotypicFilterValidator, times(1)).validate(phenotypicFilter, metaStore);
     }
@@ -65,7 +65,7 @@ class QueryValidatorTest {
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\study123\\demographics\\age\\", null, 42.0, null, null);
         PhenotypicClause phenotypicSubquery1 = new PhenotypicSubquery(null, List.of(phenotypicFilter, phenotypicFilter2), Operator.AND);
         PhenotypicClause phenotypicSubquery2 = new PhenotypicSubquery(null, List.of(phenotypicSubquery1, phenotypicSubquery1), Operator.OR);
-        Query query = new Query(List.of(), List.of(), phenotypicSubquery2, List.of(), ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), phenotypicSubquery2, List.of(), ResultType.COUNT, null, null);
         queryValidator.validate(query);
         verify(phenotypicFilterValidator, times(2)).validate(phenotypicFilter, metaStore);
         verify(phenotypicFilterValidator, times(2)).validate(phenotypicFilter2, metaStore);
@@ -75,7 +75,7 @@ class QueryValidatorTest {
     public void validate_invalidFilter_throwsException() {
         PhenotypicFilter phenotypicFilter =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\study123\\demographics\\age\\", Set.of("male"), null, null, null);
-        Query query = new Query(List.of(), List.of(), phenotypicFilter, List.of(), ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), phenotypicFilter, List.of(), ResultType.COUNT, null, null);
         doThrow(IllegalArgumentException.class).when(phenotypicFilterValidator).validate(phenotypicFilter, metaStore);
         assertThrows(IllegalArgumentException.class, () -> queryValidator.validate(query));
     }
@@ -88,7 +88,7 @@ class QueryValidatorTest {
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\study123\\demographics\\age\\", null, 42.0, null, null);
         PhenotypicClause phenotypicSubquery1 = new PhenotypicSubquery(null, List.of(phenotypicFilter, phenotypicFilter2), Operator.AND);
         PhenotypicClause phenotypicSubquery2 = new PhenotypicSubquery(null, List.of(phenotypicSubquery1, phenotypicSubquery1), Operator.OR);
-        Query query = new Query(List.of(), List.of(), phenotypicSubquery2, List.of(), ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), phenotypicSubquery2, List.of(), ResultType.COUNT, null, null);
         doThrow(IllegalArgumentException.class).when(phenotypicFilterValidator).validate(phenotypicFilter, metaStore);
         assertThrows(IllegalArgumentException.class, () -> queryValidator.validate(query));
     }
@@ -98,7 +98,7 @@ class QueryValidatorTest {
         PhenotypicFilter phenotypicFilter =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\study123\\demographics\\sex\\", Set.of("male"), null, null, null);
         Query query = new Query(
-            List.of(), List.of(new AuthorizationFilter("\\_consent\\", Set.of("studyABC"))), phenotypicFilter, List.of(), ResultType.COUNT,
+            List.of(), List.of(new AuthorizationFilter("\\_consent\\", Set.of("studyABC"))), Set.of(), phenotypicFilter, List.of(), ResultType.COUNT,
             null, null
         );
 
@@ -110,7 +110,7 @@ class QueryValidatorTest {
     public void validate_requireAuthorizationFilter_throwsException() {
         PhenotypicFilter phenotypicFilter =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\study123\\demographics\\sex\\", Set.of("male"), null, null, null);
-        Query query = new Query(List.of(), List.of(), phenotypicFilter, List.of(), ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), phenotypicFilter, List.of(), ResultType.COUNT, null, null);
 
         queryValidator = new QueryValidator(phenotypicQueryExecutor, phenotypicFilterValidator, true);
         assertThrows(IllegalArgumentException.class, () -> queryValidator.validate(query));

--- a/services/pic-sure-hpds/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/service/filesharing/FileSharingServiceTest.java
+++ b/services/pic-sure-hpds/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/service/filesharing/FileSharingServiceTest.java
@@ -18,6 +18,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -53,7 +54,7 @@ public class FileSharingServiceTest {
         UUID picsureId = UUID.randomUUID();
         UUID uuid = UUID.randomUUID();
         Query query = new Query(
-            List.of("\\open_access-1000Genomes\\data\\SUPERPOPULATION NAME\\"), List.of(), null, null, ResultType.DATAFRAME_TIMESERIES,
+            List.of("\\open_access-1000Genomes\\data\\SUPERPOPULATION NAME\\"), List.of(), Set.of(), null, null, ResultType.DATAFRAME_TIMESERIES,
             picsureId, uuid
         );
         AsyncResult result = new AsyncResult(query, variantListProcessor, resultWriter);
@@ -72,7 +73,7 @@ public class FileSharingServiceTest {
         UUID picsureId = UUID.randomUUID();
         UUID uuid = UUID.randomUUID();
         Query query = new Query(
-            List.of("\\open_access-1000Genomes\\data\\SUPERPOPULATION NAME\\"), List.of(), null, null, ResultType.DATAFRAME_TIMESERIES,
+            List.of("\\open_access-1000Genomes\\data\\SUPERPOPULATION NAME\\"), List.of(), Set.of(), null, null, ResultType.DATAFRAME_TIMESERIES,
             picsureId, uuid
         );
         AsyncResult result = new AsyncResult(query, variantListProcessor, resultWriter);
@@ -90,7 +91,7 @@ public class FileSharingServiceTest {
         UUID picsureId = UUID.randomUUID();
         UUID uuid = UUID.randomUUID();
         Query query = new Query(
-            List.of("\\open_access-1000Genomes\\data\\SUPERPOPULATION NAME\\"), List.of(), null, null, ResultType.DATAFRAME_TIMESERIES,
+            List.of("\\open_access-1000Genomes\\data\\SUPERPOPULATION NAME\\"), List.of(), Set.of(), null, null, ResultType.DATAFRAME_TIMESERIES,
             picsureId, uuid
         );
         String vcf = "lol lets put the whole vcf in a string";
@@ -107,7 +108,7 @@ public class FileSharingServiceTest {
         UUID picsureId = UUID.randomUUID();
         UUID uuid = UUID.randomUUID();
         Query query = new Query(
-            List.of("\\open_access-1000Genomes\\data\\SUPERPOPULATION NAME\\"), List.of(), null, null, ResultType.PATIENTS, picsureId, uuid
+            List.of("\\open_access-1000Genomes\\data\\SUPERPOPULATION NAME\\"), List.of(), Set.of(), null, null, ResultType.PATIENTS, picsureId, uuid
         );
 
         AsyncResult result = new AsyncResult(query, patientProcessor, resultWriter);

--- a/services/pic-sure-hpds/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/service/v3/QueryServiceTest.java
+++ b/services/pic-sure-hpds/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/service/v3/QueryServiceTest.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -52,7 +53,7 @@ class QueryServiceTest {
     @Test
     public void dataframeMulti() throws IOException, InterruptedException {
         Query query = new Query(
-            List.of("\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\"), List.of(),
+            List.of("\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\"), List.of(), Set.of(),
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 35.0, 45.0, null),
             List.of(new GenomicFilter("Gene_with_variant", List.of("LOC102723996", "LOC101928576"), null, null)), ResultType.DATAFRAME,
             null, null
@@ -79,7 +80,7 @@ class QueryServiceTest {
     @Test
     public void runQuery_dataframeSelectInvalidConcept_doNotFail() throws IOException, InterruptedException {
         Query query = new Query(
-            List.of("\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", "\\open_access-1000Genomes\\data\\NOT_A_CONCEPT_PATH\\"), List.of(),
+            List.of("\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", "\\open_access-1000Genomes\\data\\NOT_A_CONCEPT_PATH\\"), List.of(), Set.of(),
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 35.0, 45.0, null),
             List.of(new GenomicFilter("Gene_with_variant", List.of("LOC102723996", "LOC101928576"), null, null)), ResultType.DATAFRAME,
             null, null

--- a/services/pic-sure-hpds/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/CountV3ProcessorIntegrationTest.java
+++ b/services/pic-sure-hpds/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/CountV3ProcessorIntegrationTest.java
@@ -45,7 +45,7 @@ public class CountV3ProcessorIntegrationTest {
     @Test
     public void runCategoryCrossCounts_multipleConceptsNoFilters() {
         Query query = new Query(
-            List.of("\\open_access-1000Genomes\\data\\SEX\\", "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\"), List.of(), null, null,
+            List.of("\\open_access-1000Genomes\\data\\SEX\\", "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\"), List.of(), Set.of(), null, null,
             ResultType.CROSS_COUNT, null, null
         );
 
@@ -58,7 +58,7 @@ public class CountV3ProcessorIntegrationTest {
     @Test
     public void runCategoryCrossCounts_unknownConceptNoFilters() {
         Query query = new Query(
-            List.of("\\open_access-1000Genomes\\data\\SEX\\", "\\open_access-1000Genomes\\data\\NOT_REAL_DOESNT_EXIST\\"), List.of(), null,
+            List.of("\\open_access-1000Genomes\\data\\SEX\\", "\\open_access-1000Genomes\\data\\NOT_REAL_DOESNT_EXIST\\"), List.of(), Set.of(), null,
             null, ResultType.CROSS_COUNT, null, null
         );
 
@@ -78,7 +78,7 @@ public class CountV3ProcessorIntegrationTest {
         PhenotypicSubquery phenotypicSubquery = new PhenotypicSubquery(null, List.of(sexFilter, populationFilter), Operator.AND);
 
         Query query = new Query(
-            List.of("\\open_access-1000Genomes\\data\\SEX\\", "\\open_access-1000Genomes\\data\\SYNTHETIC_HEIGHT\\"), List.of(),
+            List.of("\\open_access-1000Genomes\\data\\SEX\\", "\\open_access-1000Genomes\\data\\SYNTHETIC_HEIGHT\\"), List.of(), Set.of(),
             phenotypicSubquery, null, ResultType.CROSS_COUNT, null, null
         );
 
@@ -99,7 +99,7 @@ public class CountV3ProcessorIntegrationTest {
         PhenotypicSubquery phenotypicSubquery = new PhenotypicSubquery(null, List.of(sexFilter, populationFilter), Operator.AND);
 
         Query query = new Query(
-            List.of("\\open_access-1000Genomes\\data\\SEX\\", "\\open_access-1000Genomes\\data\\SYNTHETIC_HEIGHT\\"), List.of(),
+            List.of("\\open_access-1000Genomes\\data\\SEX\\", "\\open_access-1000Genomes\\data\\SYNTHETIC_HEIGHT\\"), List.of(), Set.of(),
             phenotypicSubquery, null, ResultType.CROSS_COUNT, null, null
         );
 
@@ -119,7 +119,7 @@ public class CountV3ProcessorIntegrationTest {
         );
 
         PhenotypicSubquery phenotypicSubquery = new PhenotypicSubquery(null, List.of(sexFilter, populationFilter), Operator.AND);
-        Query query = new Query(List.of(), List.of(), phenotypicSubquery, null, ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), phenotypicSubquery, null, ResultType.COUNT, null, null);
 
         Map<String, Map<String, Integer>> crossCounts = countProcessor.runCategoryCrossCounts(query);
         assertEquals(2, crossCounts.size());
@@ -142,7 +142,7 @@ public class CountV3ProcessorIntegrationTest {
             new PhenotypicFilter(PhenotypicFilterType.FILTER, populationPath, Set.of("Finnish"), null, null, null);
 
         PhenotypicSubquery phenotypicSubquery = new PhenotypicSubquery(null, List.of(sexFilter, populationFilter), Operator.OR);
-        Query query = new Query(List.of(), List.of(), phenotypicSubquery, null, ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), phenotypicSubquery, null, ResultType.COUNT, null, null);
 
         Map<String, Map<String, Integer>> crossCounts = countProcessor.runCategoryCrossCounts(query);
 
@@ -164,7 +164,7 @@ public class CountV3ProcessorIntegrationTest {
         PhenotypicFilter sexFilter =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SEX\\", Set.of("male"), null, null, null);
         Query query = new Query(
-            List.of(), List.of(), sexFilter, List.of(new GenomicFilter("chr21,5032061,A,G", List.of("0/1", "1/1"), null, null)),
+            List.of(), List.of(), Set.of(), sexFilter, List.of(new GenomicFilter("chr21,5032061,A,G", List.of("0/1", "1/1"), null, null)),
             ResultType.COUNT, null, null
         );
 
@@ -183,7 +183,7 @@ public class CountV3ProcessorIntegrationTest {
         PhenotypicFilter maleFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, sexPath, Set.of("male"), null, null, null);
         PhenotypicFilter femaleFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, sexPath, Set.of("female"), null, null, null);
         PhenotypicSubquery subquery = new PhenotypicSubquery(null, List.of(maleFilter, femaleFilter), Operator.OR);
-        Query query = new Query(List.of(), List.of(), subquery, null, ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), subquery, null, ResultType.COUNT, null, null);
 
         Map<String, Map<String, Integer>> crossCounts = countProcessor.runCategoryCrossCounts(query);
 
@@ -204,7 +204,7 @@ public class CountV3ProcessorIntegrationTest {
         PhenotypicFilter maleFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, sexPath, Set.of("male"), null, null, null);
         PhenotypicFilter femaleFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, sexPath, Set.of("female"), null, null, null);
         PhenotypicSubquery subquery = new PhenotypicSubquery(null, List.of(maleFilter, femaleFilter), Operator.AND);
-        Query query = new Query(List.of(), List.of(), subquery, null, ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), subquery, null, ResultType.COUNT, null, null);
 
         Map<String, Map<String, Integer>> crossCounts = countProcessor.runCategoryCrossCounts(query);
 
@@ -225,7 +225,7 @@ public class CountV3ProcessorIntegrationTest {
         PhenotypicFilter requiredSex = new PhenotypicFilter(PhenotypicFilterType.REQUIRED, sexPath, null, null, null, null);
         PhenotypicFilter maleFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, sexPath, Set.of("male"), null, null, null);
         PhenotypicSubquery subquery = new PhenotypicSubquery(null, List.of(requiredSex, maleFilter), Operator.AND);
-        Query query = new Query(List.of(), List.of(), subquery, null, ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), subquery, null, ResultType.COUNT, null, null);
 
         Map<String, Map<String, Integer>> crossCounts = countProcessor.runCategoryCrossCounts(query);
 
@@ -247,7 +247,7 @@ public class CountV3ProcessorIntegrationTest {
         PhenotypicFilter requiredPopulation = new PhenotypicFilter(PhenotypicFilterType.REQUIRED, populationPath, null, null, null, null);
 
         PhenotypicSubquery subquery = new PhenotypicSubquery(null, List.of(maleFilter, requiredPopulation), Operator.OR);
-        Query query = new Query(List.of(), List.of(), subquery, null, ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), subquery, null, ResultType.COUNT, null, null);
 
         Map<String, Map<String, Integer>> crossCounts = countProcessor.runCategoryCrossCounts(query);
 
@@ -265,7 +265,7 @@ public class CountV3ProcessorIntegrationTest {
     public void runCategoryCrossCounts_requiredContinuousConcept_isExcluded() {
         String agePath = "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\";
         PhenotypicFilter requiredAge = new PhenotypicFilter(PhenotypicFilterType.REQUIRED, agePath, null, null, null, null);
-        Query query = new Query(List.of(), List.of(), requiredAge, null, ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), requiredAge, null, ResultType.COUNT, null, null);
 
         Map<String, Map<String, Integer>> crossCounts = countProcessor.runCategoryCrossCounts(query);
 
@@ -282,7 +282,7 @@ public class CountV3ProcessorIntegrationTest {
         PhenotypicFilter youngFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, agePath, null, 31.0, 35.0, null);
         PhenotypicFilter oldFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, agePath, null, 55.0, 62.0, null);
         PhenotypicSubquery subquery = new PhenotypicSubquery(null, List.of(youngFilter, oldFilter), Operator.OR);
-        Query query = new Query(List.of(), List.of(), subquery, null, ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), subquery, null, ResultType.COUNT, null, null);
 
         Map<String, Map<Double, Integer>> crossCounts = countProcessor.runContinuousCrossCounts(query);
 
@@ -304,7 +304,7 @@ public class CountV3ProcessorIntegrationTest {
         PhenotypicFilter oldFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, agePath, null, 55.0, 62.0, null);
         PhenotypicFilter maleFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, sexPath, Set.of("male"), null, null, null);
         PhenotypicSubquery subquery = new PhenotypicSubquery(null, List.of(oldFilter, maleFilter), Operator.OR);
-        Query query = new Query(List.of(), List.of(), subquery, null, ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), subquery, null, ResultType.COUNT, null, null);
 
         Map<String, Map<Double, Integer>> crossCounts = countProcessor.runContinuousCrossCounts(query);
 

--- a/services/pic-sure-hpds/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/QueryExecutorIntegrationTest.java
+++ b/services/pic-sure-hpds/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/QueryExecutorIntegrationTest.java
@@ -49,7 +49,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_validEmptyQuery() {
         Query query = new Query(
-            List.of(), List.of(), null, List.of(new GenomicFilter("Gene_with_variant", List.of("LOC102723996"), null, null)),
+            List.of(), List.of(), Set.of(), null, List.of(new GenomicFilter("Gene_with_variant", List.of("LOC102723996"), null, null)),
             ResultType.COUNT, null, null
         );
 
@@ -63,7 +63,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_validEmptyQuerySomePartitions() {
         Query query = new Query(
-            List.of(), List.of(), null, List.of(new GenomicFilter("Gene_with_variant", List.of("LOC102723996"), null, null)),
+            List.of(), List.of(), Set.of(), null, List.of(new GenomicFilter("Gene_with_variant", List.of("LOC102723996"), null, null)),
             ResultType.COUNT, null, null
         );
 
@@ -77,7 +77,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_validGeneWithMultipleVariantQuery() {
         Query query = new Query(
-            List.of(), List.of(), null,
+            List.of(), List.of(), Set.of(), null,
             List.of(new GenomicFilter("Gene_with_variant", List.of("LOC102723996", "LOC101928576"), null, null)), ResultType.COUNT, null,
             null
         );
@@ -89,7 +89,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_validGeneWithMultipleVariantQuerySomePartitions() {
         Query query = new Query(
-            List.of(), List.of(), null,
+            List.of(), List.of(), Set.of(), null,
             List.of(new GenomicFilter("Gene_with_variant", List.of("LOC102723996", "LOC101928576"), null, null)), ResultType.COUNT, null,
             null
         );
@@ -104,7 +104,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_validGeneWithVariantQueryAndNumericQuery() {
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 35.0, 45.0, null),
             List.of(new GenomicFilter("Gene_with_variant", List.of("LOC102723996"), null, null)), ResultType.COUNT, null, null
         );
@@ -116,7 +116,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_validGeneWithVariantQueryAndNumericQuerySomePartitions() {
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 35.0, 45.0, null),
             List.of(new GenomicFilter("Gene_with_variant", List.of("LOC102723996"), null, null)), ResultType.COUNT, null, null
         );
@@ -134,7 +134,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_validNumericPhenotypicQuery() {
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 35.0, 45.0, null),
             null, ResultType.COUNT, null, null
         );
@@ -146,7 +146,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_validNumericPhenotypicQuerySomePartitions() {
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 35.0, 45.0, null),
             null, ResultType.COUNT, null, null
         );
@@ -165,7 +165,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_validNumericPhenotypicQueryInvalidPartitions() {
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 35.0, 45.0, null),
             null, ResultType.COUNT, null, null
         );
@@ -183,7 +183,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_validCategoricalPhenotypicQuery() {
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicFilter(
                 PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\POPULATION NAME\\", Set.of("Finnish"), null, null, null
             ), null, ResultType.COUNT, null, null
@@ -195,7 +195,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_validCategoricalPhenotypicQuerySomePartitions() {
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicFilter(
                 PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\POPULATION NAME\\", Set.of("Finnish"), null, null, null
             ), null, ResultType.COUNT, null, null
@@ -213,7 +213,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_nonExistentCategoricalPhenotypicQuery() {
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicFilter(
                 PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\NOTAREAL_CONCEPT\\", Set.of("Finnish"), null, null, null
             ), null, ResultType.COUNT, null, null
@@ -226,7 +226,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_nonExistentCategoricalPhenotypicQuerySomePartitions() {
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicFilter(
                 PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\NOTAREAL_CONCEPT\\", Set.of("Finnish"), null, null, null
             ), null, ResultType.COUNT, null, null
@@ -240,7 +240,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_validMultipleValueCategoricalPhenotypicQuery() {
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicFilter(
                 PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\POPULATION NAME\\", Set.of("Finnish"), null, null, null
             ), null, ResultType.COUNT, null, null
@@ -249,7 +249,7 @@ public class QueryExecutorIntegrationTest {
         assertEquals(102, finnishIdList.size());
 
         query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicFilter(
                 PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\POPULATION NAME\\", Set.of("Colombian"), null, null, null
             ), null, ResultType.COUNT, null, null
@@ -258,7 +258,7 @@ public class QueryExecutorIntegrationTest {
         assertEquals(153, columbianIdList.size());
 
         query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicFilter(
                 PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\POPULATION NAME\\", Set.of("Finnish", "Colombian"), null,
                 null, null
@@ -272,7 +272,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_validMultipleValueCategoricalPhenotypicQuerySomePartitions() {
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicFilter(
                 PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\POPULATION NAME\\", Set.of("Finnish", "Colombian"), null,
                 null, null
@@ -293,18 +293,18 @@ public class QueryExecutorIntegrationTest {
         PhenotypicFilter finnishFilter = new PhenotypicFilter(
             PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\POPULATION NAME\\", Set.of("Finnish"), null, null, null
         );
-        Query query = new Query(List.of(), List.of(), finnishFilter, null, ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), finnishFilter, null, ResultType.COUNT, null, null);
         Set<Integer> finnishIdList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(102, finnishIdList.size());
 
         PhenotypicFilter femaleFilter =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SEX\\", Set.of("female"), null, null, null);
-        query = new Query(List.of(), List.of(), femaleFilter, null, ResultType.COUNT, null, null);
+        query = new Query(List.of(), List.of(), Set.of(), femaleFilter, null, ResultType.COUNT, null, null);
         Set<Integer> femaleIdList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(2330, femaleIdList.size());
 
         PhenotypicSubquery phenotypicSubquery = new PhenotypicSubquery(null, List.of(finnishFilter, femaleFilter), Operator.AND);
-        query = new Query(List.of(), List.of(), phenotypicSubquery, null, ResultType.COUNT, null, null);
+        query = new Query(List.of(), List.of(), Set.of(), phenotypicSubquery, null, ResultType.COUNT, null, null);
         Set<Integer> bothIdList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(64, bothIdList.size());
         assertEquals(Sets.intersection(finnishIdList, femaleIdList), bothIdList);
@@ -314,18 +314,18 @@ public class QueryExecutorIntegrationTest {
     public void getPatientSubsetForQuery_validMultiplePhenotypicQuery() {
         PhenotypicFilter ageFilter =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 35.0, 45.0, null);
-        Query query = new Query(List.of(), List.of(), ageFilter, null, ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), ageFilter, null, ResultType.COUNT, null, null);
         Set<Integer> ageIdList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(562, ageIdList.size());
 
         PhenotypicFilter maleFilter =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SEX\\", Set.of("male"), null, null, null);
-        query = new Query(List.of(), List.of(), maleFilter, null, ResultType.COUNT, null, null);
+        query = new Query(List.of(), List.of(), Set.of(), maleFilter, null, ResultType.COUNT, null, null);
         Set<Integer> sexIdList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(2648, sexIdList.size());
 
         PhenotypicSubquery phenotypicSubquery = new PhenotypicSubquery(null, List.of(ageFilter, maleFilter), Operator.AND);
-        query = new Query(List.of(), List.of(), phenotypicSubquery, null, ResultType.COUNT, null, null);
+        query = new Query(List.of(), List.of(), Set.of(), phenotypicSubquery, null, ResultType.COUNT, null, null);
         Set<Integer> bothIdList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(269, bothIdList.size());
         assertEquals(Sets.intersection(ageIdList, sexIdList), bothIdList);
@@ -337,18 +337,18 @@ public class QueryExecutorIntegrationTest {
 
         PhenotypicFilter ageFilter =
                 new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 35.0, 45.0, null);
-        Query query = new Query(List.of(), List.of(), ageFilter, null, ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), ageFilter, null, ResultType.COUNT, null, null);
         Set<Integer> ageIdList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(151, ageIdList.size());
 
         PhenotypicFilter maleFilter =
                 new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SEX\\", Set.of("male"), null, null, null);
-        query = new Query(List.of(), List.of(), maleFilter, null, ResultType.COUNT, null, null);
+        query = new Query(List.of(), List.of(), Set.of(), maleFilter, null, ResultType.COUNT, null, null);
         Set<Integer> sexIdList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(1150, sexIdList.size());
 
         PhenotypicSubquery phenotypicSubquery = new PhenotypicSubquery(null, List.of(ageFilter, maleFilter), Operator.AND);
-        query = new Query(List.of(), List.of(), phenotypicSubquery, null, ResultType.COUNT, null, null);
+        query = new Query(List.of(), List.of(), Set.of(), phenotypicSubquery, null, ResultType.COUNT, null, null);
         Set<Integer> bothIdList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(68, bothIdList.size());
         assertEquals(Sets.intersection(ageIdList, sexIdList), bothIdList);
@@ -358,17 +358,17 @@ public class QueryExecutorIntegrationTest {
     public void getPatientSubsetForQuery_validMultipleNumericPhenotypicQuery() {
         PhenotypicFilter ageFilter =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 35.0, 45.0, null);
-        Query query = new Query(List.of(), List.of(), ageFilter, null, ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), ageFilter, null, ResultType.COUNT, null, null);
         Set<Integer> ageIdList = queryExecutor.getPatientSubsetForQuery(query);
 
         PhenotypicFilter heightFilter = new PhenotypicFilter(
             PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_HEIGHT\\", null, 180.0, null, null
         );
-        query = new Query(List.of(), List.of(), heightFilter, null, ResultType.COUNT, null, null);
+        query = new Query(List.of(), List.of(), Set.of(), heightFilter, null, ResultType.COUNT, null, null);
         Set<Integer> heightIdList = queryExecutor.getPatientSubsetForQuery(query);
 
         PhenotypicSubquery phenotypicSubquery = new PhenotypicSubquery(null, List.of(ageFilter, heightFilter), Operator.AND);
-        query = new Query(List.of(), List.of(), phenotypicSubquery, null, ResultType.COUNT, null, null);
+        query = new Query(List.of(), List.of(), Set.of(), phenotypicSubquery, null, ResultType.COUNT, null, null);
         Set<Integer> bothIdList = queryExecutor.getPatientSubsetForQuery(query);
 
         assertEquals(Sets.intersection(ageIdList, heightIdList), bothIdList);
@@ -377,7 +377,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_validRequiredVariant() {
         Query query = new Query(
-            List.of(), List.of(), null, List.of(new GenomicFilter("chr21,5032061,A,G,LOC102723996,missense_variant", null, null, null)),
+            List.of(), List.of(), Set.of(), null, List.of(new GenomicFilter("chr21,5032061,A,G,LOC102723996,missense_variant", null, null, null)),
             ResultType.COUNT, null, null
         );
 
@@ -388,7 +388,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_validRequiredVariantSomePartitions() {
         Query query = new Query(
-            List.of(), List.of(), null, List.of(new GenomicFilter("chr21,5032061,A,G,LOC102723996,missense_variant", null, null, null)),
+            List.of(), List.of(), Set.of(), null, List.of(new GenomicFilter("chr21,5032061,A,G,LOC102723996,missense_variant", null, null, null)),
             ResultType.COUNT, null, null
         );
 
@@ -405,7 +405,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_invalidRequiredVariant() {
         Query query = new Query(
-            List.of(), List.of(), null, List.of(new GenomicFilter("chr21,5061,A,G", null, null, null)), ResultType.COUNT, null, null
+            List.of(), List.of(), Set.of(), null, List.of(new GenomicFilter("chr21,5061,A,G", null, null, null)), ResultType.COUNT, null, null
         );
 
         Set<Integer> idList = queryExecutor.getPatientSubsetForQuery(query);
@@ -415,7 +415,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_validRequiredVariantOldFormat() {
         Query query = new Query(
-            List.of(), List.of(), null, List.of(new GenomicFilter("chr21,5032061,A,G", null, null, null)), ResultType.COUNT, null, null
+            List.of(), List.of(), Set.of(), null, List.of(new GenomicFilter("chr21,5032061,A,G", null, null, null)), ResultType.COUNT, null, null
         );
 
         Set<Integer> idList = queryExecutor.getPatientSubsetForQuery(query);
@@ -425,7 +425,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_invalidVariantSpecQuery() {
         Query query = new Query(
-            List.of(), List.of(), null, List.of(new GenomicFilter("chr21,5061,AAAA,GGGG", List.of("0/1", "1/1"), null, null)),
+            List.of(), List.of(), Set.of(), null, List.of(new GenomicFilter("chr21,5061,AAAA,GGGG", List.of("0/1", "1/1"), null, null)),
             ResultType.COUNT, null, null
         );
 
@@ -437,7 +437,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_validRequiredVariantOldFormatCategoryFilter() {
         Query query = new Query(
-            List.of(), List.of(), null, List.of(new GenomicFilter("chr21,5032061,A,G", List.of("0/1", "1/1"), null, null)),
+            List.of(), List.of(), Set.of(), null, List.of(new GenomicFilter("chr21,5032061,A,G", List.of("0/1", "1/1"), null, null)),
             ResultType.COUNT, null, null
         );
 
@@ -449,7 +449,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_validRequiredVariantOldFormatCategoryFilterHomozygous() {
         Query query = new Query(
-            List.of(), List.of(), null, List.of(new GenomicFilter("chr21,5032061,A,G", List.of("1/1"), null, null)), ResultType.COUNT, null,
+            List.of(), List.of(), Set.of(), null, List.of(new GenomicFilter("chr21,5032061,A,G", List.of("1/1"), null, null)), ResultType.COUNT, null,
             null
         );
 
@@ -460,7 +460,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_validRequiredVariantOldFormatCategoryFilterHeterozygous() {
         Query query = new Query(
-            List.of(), List.of(), null, List.of(new GenomicFilter("chr21,5032061,A,G", List.of("0/1"), null, null)), ResultType.COUNT, null,
+            List.of(), List.of(), Set.of(), null, List.of(new GenomicFilter("chr21,5032061,A,G", List.of("0/1"), null, null)), ResultType.COUNT, null,
             null
         );
 
@@ -471,7 +471,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_verifySeparateQueriesAreEquivalent() {
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 35.0, 45.0, null),
             List.of(), ResultType.COUNT, null, null
         );
@@ -479,7 +479,7 @@ public class QueryExecutorIntegrationTest {
         Set<Integer> numericIdList = queryExecutor.getPatientSubsetForQuery(query);
 
         query = new Query(
-            List.of(), List.of(), null, List.of(new GenomicFilter("chr21,5032061,A,G", List.of("0/1"), null, null)), ResultType.COUNT, null,
+            List.of(), List.of(), Set.of(), null, List.of(new GenomicFilter("chr21,5032061,A,G", List.of("0/1"), null, null)), ResultType.COUNT, null,
             null
         );
 
@@ -487,7 +487,7 @@ public class QueryExecutorIntegrationTest {
 
 
         query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 35.0, 45.0, null),
             List.of(new GenomicFilter("chr21,5032061,A,G", List.of("0/1"), null, null)), ResultType.COUNT, null, null
         );
@@ -501,7 +501,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getVariantList_validGeneWithVariantQuery() {
         Query query = new Query(
-            List.of(), List.of(), null, List.of(new GenomicFilter("Gene_with_variant", List.of("LOC102723996"), null, null)),
+            List.of(), List.of(), Set.of(), null, List.of(new GenomicFilter("Gene_with_variant", List.of("LOC102723996"), null, null)),
             ResultType.COUNT, null, null
         );
 
@@ -512,7 +512,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getVariantList_validGeneWithVariantQuerySomePartitions() {
         Query query = new Query(
-            List.of(), List.of(), null, List.of(new GenomicFilter("Gene_with_variant", List.of("LOC102723996"), null, null)),
+            List.of(), List.of(), Set.of(), null, List.of(new GenomicFilter("Gene_with_variant", List.of("LOC102723996"), null, null)),
             ResultType.COUNT, null, null
         );
 
@@ -528,7 +528,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getVariantList_invalidGeneQuery() {
         Query query = new Query(
-            List.of(), List.of(), null, List.of(new GenomicFilter("Gene_with_variant", List.of("NOTAGENE"), null, null)), ResultType.COUNT,
+            List.of(), List.of(), Set.of(), null, List.of(new GenomicFilter("Gene_with_variant", List.of("NOTAGENE"), null, null)), ResultType.COUNT,
             null, null
         );
 
@@ -539,7 +539,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getVariantList_validGeneWithMultipleVariantQuery() {
         Query query = new Query(
-            List.of(), List.of(), null,
+            List.of(), List.of(), Set.of(), null,
             List.of(new GenomicFilter("Gene_with_variant", List.of("LOC102723996", "LOC101928576"), null, null)), ResultType.COUNT, null,
             null
         );
@@ -551,7 +551,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getVariantList_validGeneWithVariantQueryAndNumericQuery() {
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 35.0, 45.0, null),
             List.of(new GenomicFilter("Gene_with_variant", List.of("LOC102723996"), null, null)), ResultType.COUNT, null, null
         );
@@ -564,7 +564,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getVariantList_validContinuousGenomicFilter() {
         Query query = new Query(
-            List.of(), List.of(), null, List.of(new GenomicFilter("Variant_frequency_in_gnomAD", null, 0.0001345F, 0.0001347f)),
+            List.of(), List.of(), Set.of(), null, List.of(new GenomicFilter("Variant_frequency_in_gnomAD", null, 0.0001345F, 0.0001347f)),
             ResultType.COUNT, null, null
         );
 
@@ -575,7 +575,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_validContinuousGenomicFilter() {
         Query query = new Query(
-            List.of(), List.of(), null, List.of(new GenomicFilter("Variant_frequency_in_gnomAD", null, 0.0001345F, 0.0001347f)),
+            List.of(), List.of(), Set.of(), null, List.of(new GenomicFilter("Variant_frequency_in_gnomAD", null, 0.0001345F, 0.0001347f)),
             ResultType.COUNT, null, null
         );
 
@@ -591,18 +591,18 @@ public class QueryExecutorIntegrationTest {
         PhenotypicFilter finnishFilter = new PhenotypicFilter(
             PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\POPULATION NAME\\", Set.of("Finnish"), null, null, null
         );
-        Query query = new Query(List.of(), List.of(), finnishFilter, null, ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), finnishFilter, null, ResultType.COUNT, null, null);
         Set<Integer> finnishIdList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(102, finnishIdList.size());
 
         PhenotypicFilter ageFilter =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 35.0, 45.0, null);
-        query = new Query(List.of(), List.of(), ageFilter, null, ResultType.COUNT, null, null);
+        query = new Query(List.of(), List.of(), Set.of(), ageFilter, null, ResultType.COUNT, null, null);
         Set<Integer> femaleIdList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(562, femaleIdList.size());
 
         PhenotypicSubquery phenotypicSubquery = new PhenotypicSubquery(null, List.of(finnishFilter, ageFilter), Operator.OR);
-        query = new Query(List.of(), List.of(), phenotypicSubquery, null, ResultType.COUNT, null, null);
+        query = new Query(List.of(), List.of(), Set.of(), phenotypicSubquery, null, ResultType.COUNT, null, null);
         Set<Integer> bothIdList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(Sets.union(finnishIdList, femaleIdList), bothIdList);
     }
@@ -612,18 +612,18 @@ public class QueryExecutorIntegrationTest {
         PhenotypicFilter yorubaFilter = new PhenotypicFilter(
             PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\POPULATION NAME\\", Set.of("Yoruba"), null, null, null
         );
-        Query query = new Query(List.of(), List.of(), yorubaFilter, null, ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), yorubaFilter, null, ResultType.COUNT, null, null);
         Set<Integer> yorubaIdList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(208, yorubaIdList.size());
 
         PhenotypicFilter ageFilter =
             new PhenotypicFilter(PhenotypicFilterType.REQUIRED, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, null, null, null);
-        query = new Query(List.of(), List.of(), ageFilter, null, ResultType.COUNT, null, null);
+        query = new Query(List.of(), List.of(), Set.of(), ageFilter, null, ResultType.COUNT, null, null);
         Set<Integer> ageIdList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(1126, ageIdList.size());
 
         PhenotypicSubquery phenotypicSubquery = new PhenotypicSubquery(null, List.of(yorubaFilter, ageFilter), Operator.AND);
-        query = new Query(List.of(), List.of(), phenotypicSubquery, null, ResultType.COUNT, null, null);
+        query = new Query(List.of(), List.of(), Set.of(), phenotypicSubquery, null, ResultType.COUNT, null, null);
         Set<Integer> bothIdList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(Sets.intersection(yorubaIdList, ageIdList), bothIdList);
     }
@@ -634,20 +634,20 @@ public class QueryExecutorIntegrationTest {
         PhenotypicFilter finnishFilter = new PhenotypicFilter(
             PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\POPULATION NAME\\", Set.of("Finnish"), null, null, null
         );
-        Query query = new Query(List.of(), List.of(), finnishFilter, null, ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), finnishFilter, null, ResultType.COUNT, null, null);
         Set<Integer> finnishIdList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(102, finnishIdList.size());
 
         PhenotypicFilter femaleFilter =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SEX\\", Set.of("female"), null, null, null);
-        query = new Query(List.of(), List.of(), femaleFilter, null, ResultType.COUNT, null, null);
+        query = new Query(List.of(), List.of(), Set.of(), femaleFilter, null, ResultType.COUNT, null, null);
         Set<Integer> femaleIdList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(2330, femaleIdList.size());
 
 
         AuthorizationFilter authorizationFilter =
             new AuthorizationFilter("\\open_access-1000Genomes\\data\\POPULATION NAME\\", Set.of("Finnish"));
-        query = new Query(List.of(), List.of(authorizationFilter), femaleFilter, null, ResultType.COUNT, null, null);
+        query = new Query(List.of(), List.of(authorizationFilter), Set.of(), femaleFilter, null, ResultType.COUNT, null, null);
         Set<Integer> bothIdList = queryExecutor.getPatientSubsetForQuery(query);
         assertEquals(64, bothIdList.size());
         assertEquals(Sets.intersection(finnishIdList, femaleIdList), bothIdList);
@@ -656,7 +656,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_validAnyRecordOfPhenotypicQuery_returnsPatients() {
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicFilter(PhenotypicFilterType.ANY_RECORD_OF, "\\open_access-1000Genomes\\", null, null, null, null), null,
             ResultType.COUNT, null, null
         );
@@ -668,7 +668,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_nonMatchingAnyRecordOfPhenotypicQuery_returnsNoPatients() {
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicFilter(PhenotypicFilterType.ANY_RECORD_OF, "\\study-does-not-exist\\demographics\\", null, null, null, null),
             null, ResultType.COUNT, null, null
         );
@@ -690,7 +690,7 @@ public class QueryExecutorIntegrationTest {
         PhenotypicSubquery phenotypicClause =
             new PhenotypicSubquery(null, List.of(anyRecordOfFilter, filterFilter, requiredFilter), Operator.AND);
         Query query = new Query(
-            List.of("\\open_access-1000Genomes\\data\\SEX\\"), List.of(authorizationFilter), phenotypicClause, null, ResultType.COUNT, null,
+            List.of("\\open_access-1000Genomes\\data\\SEX\\"), List.of(authorizationFilter), Set.of(), phenotypicClause, null, ResultType.COUNT, null,
             null
         );
 
@@ -710,7 +710,7 @@ public class QueryExecutorIntegrationTest {
 
     @Test
     public void getAllConceptPaths_emptyQuery_returnEmpty() {
-        Query query = new Query(List.of(), List.of(), null, null, ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), null, null, ResultType.COUNT, null, null);
 
         SequencedSet<String> allConceptPaths = queryExecutor.getAllConceptPaths(query);
         assertEquals(0, allConceptPaths.size());
@@ -719,7 +719,7 @@ public class QueryExecutorIntegrationTest {
     @Test
     public void getPatientSubsetForQuery_validLargeGenomicQuery() {
         Query query = new Query(
-            List.of(), List.of(),
+            List.of(), List.of(), Set.of(),
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 35.0, 45.0, null),
             List.of(
                 new GenomicFilter("Gene_with_variant", List.of("LOC102723996", "LOC101928576", "ABC1", "ABC2", "ABC3"), null, null),

--- a/services/pic-sure-hpds/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/TimeseriesProcessorIntegrationTest.java
+++ b/services/pic-sure-hpds/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/TimeseriesProcessorIntegrationTest.java
@@ -49,7 +49,7 @@ public class TimeseriesProcessorIntegrationTest {
             null
         );
         Query query = new Query(
-            List.of("\\open_access-1000Genomes\\data\\SUPERPOPULATION NAME\\"), List.of(), phenotypicClause, null,
+            List.of("\\open_access-1000Genomes\\data\\SUPERPOPULATION NAME\\"), List.of(), Set.of(), phenotypicClause, null,
             ResultType.DATAFRAME_TIMESERIES, UUID.randomUUID(), UUID.randomUUID()
         );
 
@@ -73,7 +73,7 @@ public class TimeseriesProcessorIntegrationTest {
         PhenotypicClause phenotypicClause =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SEX\\", Set.of("male"), null, null, null);
         Query query = new Query(
-            List.of("\\open_access-1000Genomes\\data\\SEX\\"), List.of(), phenotypicClause, null, ResultType.DATAFRAME_TIMESERIES,
+            List.of("\\open_access-1000Genomes\\data\\SEX\\"), List.of(), Set.of(), phenotypicClause, null, ResultType.DATAFRAME_TIMESERIES,
             UUID.randomUUID(), UUID.randomUUID()
         );
 

--- a/services/pic-sure-hpds/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/VariantListV3ProcessorIntegrationTest.java
+++ b/services/pic-sure-hpds/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/VariantListV3ProcessorIntegrationTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -43,7 +44,7 @@ public class VariantListV3ProcessorIntegrationTest {
     @Test
     public void runVcfExcerptQuery_validGeneWithVariantQuery() {
         GenomicFilter genomicFilter = new GenomicFilter("Gene_with_variant", List.of("LOC102723996"), null, null);
-        Query query = new Query(List.of(), List.of(), null, List.of(genomicFilter), ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), null, List.of(genomicFilter), ResultType.COUNT, null, null);
 
         String vcfExerpt = variantListProcessor.runVcfExcerptQuery(query, true);
         log.debug(vcfExerpt);
@@ -74,7 +75,7 @@ public class VariantListV3ProcessorIntegrationTest {
     @Test
     public void runVcfExcerptQuery_validGeneWithVariantQueryNoCall() {
         GenomicFilter genomicFilter = new GenomicFilter("Gene_with_variant", List.of("ABC1"), null, null);
-        Query query = new Query(List.of(), List.of(), null, List.of(genomicFilter), ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), null, List.of(genomicFilter), ResultType.COUNT, null, null);
 
         String vcfExerpt = variantListProcessor.runVcfExcerptQuery(query, true);
         log.debug(vcfExerpt);
@@ -108,7 +109,7 @@ public class VariantListV3ProcessorIntegrationTest {
         PhenotypicFilter phenotypicFilter =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 35.0, 45.0, null);
         GenomicFilter genomicFilter = new GenomicFilter("Gene_with_variant", List.of("LOC102723996"), null, null);
-        Query query = new Query(List.of(), List.of(), phenotypicFilter, List.of(genomicFilter), ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), phenotypicFilter, List.of(genomicFilter), ResultType.COUNT, null, null);
 
         String vcfExerpt = variantListProcessor.runVcfExcerptQuery(query, true);
         log.debug(vcfExerpt);
@@ -141,7 +142,7 @@ public class VariantListV3ProcessorIntegrationTest {
         PhenotypicFilter phenotypicFilter =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 35.0, 45.0, null);
         GenomicFilter genomicFilter = new GenomicFilter("Gene_with_variant", List.of("ABC1"), null, null);
-        Query query = new Query(List.of(), List.of(), phenotypicFilter, List.of(genomicFilter), ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), phenotypicFilter, List.of(genomicFilter), ResultType.COUNT, null, null);
 
         String vcfExerpt = variantListProcessor.runVcfExcerptQuery(query, true);
         log.debug(vcfExerpt);
@@ -175,7 +176,7 @@ public class VariantListV3ProcessorIntegrationTest {
         PhenotypicFilter phenotypicFilter =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\", null, 0.0, 1.0, null);
         GenomicFilter genomicFilter = new GenomicFilter("Gene_with_variant", List.of("LOC102723996"), null, null);
-        Query query = new Query(List.of(), List.of(), phenotypicFilter, List.of(genomicFilter), ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), phenotypicFilter, List.of(genomicFilter), ResultType.COUNT, null, null);
 
         String vcfExerpt = variantListProcessor.runVcfExcerptQuery(query, true);
         assertEquals("No Variants Found\n", vcfExerpt);
@@ -184,7 +185,7 @@ public class VariantListV3ProcessorIntegrationTest {
     @Test
     public void runVariantListQuery_validQuery_returnVariants() {
         GenomicFilter genomicFilter = new GenomicFilter("Gene_with_variant", List.of("LOC102723996"), null, null);
-        Query query = new Query(List.of(), List.of(), null, List.of(genomicFilter), ResultType.COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), null, List.of(genomicFilter), ResultType.COUNT, null, null);
 
         String variantList = variantListProcessor.runVariantListQuery(query);
         assertEquals(

--- a/services/pic-sure-visualization-service/src/main/java/edu/harvard/dbmi/avillach/visualization/service/QueryDecomposer.java
+++ b/services/pic-sure-visualization-service/src/main/java/edu/harvard/dbmi/avillach/visualization/service/QueryDecomposer.java
@@ -47,7 +47,7 @@ public class QueryDecomposer {
 
         if (!categoricalPaths.isEmpty()) {
             Query categoricalQuery = new Query(
-                new ArrayList<>(categoricalPaths), query.authorizationFilters(), query.phenotypicClause(), query.genomicFilters(),
+                new ArrayList<>(categoricalPaths), query.authorizationFilters(), query.userConsents(), query.phenotypicClause(), query.genomicFilters(),
                 ResultType.CATEGORICAL_CROSS_COUNT, query.picsureId(), null
             );
             subQueries.add(new SubQueryDescriptor(categoricalQuery, ResultType.CATEGORICAL_CROSS_COUNT, DistributionType.CATEGORICAL));
@@ -55,7 +55,7 @@ public class QueryDecomposer {
 
         if (!numericPaths.isEmpty()) {
             Query numericQuery = new Query(
-                new ArrayList<>(numericPaths), query.authorizationFilters(), query.phenotypicClause(), query.genomicFilters(),
+                new ArrayList<>(numericPaths), query.authorizationFilters(), query.userConsents(), query.phenotypicClause(), query.genomicFilters(),
                 ResultType.CONTINUOUS_CROSS_COUNT, query.picsureId(), null
             );
             subQueries.add(new SubQueryDescriptor(numericQuery, ResultType.CONTINUOUS_CROSS_COUNT, DistributionType.CONTINUOUS));

--- a/services/pic-sure-visualization-service/src/main/java/edu/harvard/dbmi/avillach/visualization/service/QueryServiceClient.java
+++ b/services/pic-sure-visualization-service/src/main/java/edu/harvard/dbmi/avillach/visualization/service/QueryServiceClient.java
@@ -84,7 +84,7 @@ public class QueryServiceClient {
         // authorizationFilters are carried through verbatim: PSAMA injects the caller's consent scope and the gateway's
         // BodyMutationFilter swaps it into the body before this service sees it. Auth HPDS rejects an empty list.
         Query subQuery = new Query(
-            query.select(), query.authorizationFilters(), query.phenotypicClause(), query.genomicFilters(), resultType, query.picsureId(),
+            query.select(), query.authorizationFilters(), query.userConsents(), query.phenotypicClause(), query.genomicFilters(), resultType, query.picsureId(),
             query.id()
         );
 

--- a/services/pic-sure-visualization-service/src/test/java/edu/harvard/dbmi/avillach/visualization/service/QueryDecomposerTest.java
+++ b/services/pic-sure-visualization-service/src/test/java/edu/harvard/dbmi/avillach/visualization/service/QueryDecomposerTest.java
@@ -23,7 +23,7 @@ class QueryDecomposerTest {
     void decompose_withCategoricalFilter_returnsCategoricalSubQuery() {
         PhenotypicFilter catFilter =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\demographics\\race\\", Set.of("White", "Black"), null, null, null);
-        Query query = new Query(List.of(), List.of(), catFilter, List.of(), null, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), catFilter, List.of(), null, null, null);
 
         List<QueryDecomposer.SubQueryDescriptor> result = decomposer.decompose(query);
 
@@ -36,7 +36,7 @@ class QueryDecomposerTest {
     @Test
     void decompose_withNumericFilter_returnsContinuousSubQuery() {
         PhenotypicFilter numFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\measurements\\bmi\\", null, 18.0, 40.0, null);
-        Query query = new Query(List.of(), List.of(), numFilter, List.of(), null, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), numFilter, List.of(), null, null, null);
 
         List<QueryDecomposer.SubQueryDescriptor> result = decomposer.decompose(query);
 
@@ -51,7 +51,7 @@ class QueryDecomposerTest {
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\demographics\\race\\", Set.of("White"), null, null, null);
         PhenotypicFilter numFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\measurements\\bmi\\", null, 18.0, 40.0, null);
         PhenotypicSubquery subquery = new PhenotypicSubquery(null, List.of(catFilter, numFilter), Operator.AND);
-        Query query = new Query(List.of(), List.of(), subquery, List.of(), null, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), subquery, List.of(), null, null, null);
 
         List<QueryDecomposer.SubQueryDescriptor> result = decomposer.decompose(query);
 
@@ -60,7 +60,7 @@ class QueryDecomposerTest {
 
     @Test
     void decompose_withNoFilters_returnsEmpty() {
-        Query query = new Query(List.of(), List.of(), null, List.of(), null, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), null, List.of(), null, null, null);
 
         List<QueryDecomposer.SubQueryDescriptor> result = decomposer.decompose(query);
 
@@ -70,7 +70,7 @@ class QueryDecomposerTest {
     @Test
     void decompose_withRequiredFilter_treatsTypeAsUnknown() {
         PhenotypicFilter required = new PhenotypicFilter(PhenotypicFilterType.REQUIRED, "\\demographics\\AGE\\", null, null, null, null);
-        Query query = new Query(List.of(), List.of(), required, List.of(), null, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), required, List.of(), null, null, null);
 
         List<QueryDecomposer.SubQueryDescriptor> result = decomposer.decompose(query);
 
@@ -81,7 +81,7 @@ class QueryDecomposerTest {
 
     @Test
     void decompose_withSelectButNoFilters_fallsBackToSelectAsCategorical() {
-        Query query = new Query(List.of("\\demographics\\race\\", "\\demographics\\sex\\"), List.of(), null, List.of(), null, null, null);
+        Query query = new Query(List.of("\\demographics\\race\\", "\\demographics\\sex\\"), List.of(), Set.of(), null, List.of(), null, null, null);
 
         List<QueryDecomposer.SubQueryDescriptor> result = decomposer.decompose(query);
 
@@ -94,7 +94,7 @@ class QueryDecomposerTest {
     void decompose_withFiltersAndSelect_ignoresSelectFallback() {
         PhenotypicFilter catFilter =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\demographics\\race\\", Set.of("White"), null, null, null);
-        Query query = new Query(List.of("\\some\\other\\path\\"), List.of(), catFilter, List.of(), null, null, null);
+        Query query = new Query(List.of("\\some\\other\\path\\"), List.of(), Set.of(), catFilter, List.of(), null, null, null);
 
         List<QueryDecomposer.SubQueryDescriptor> result = decomposer.decompose(query);
 

--- a/services/pic-sure-visualization-service/src/test/java/edu/harvard/dbmi/avillach/visualization/service/QueryServiceClientTest.java
+++ b/services/pic-sure-visualization-service/src/test/java/edu/harvard/dbmi/avillach/visualization/service/QueryServiceClientTest.java
@@ -72,7 +72,7 @@ class QueryServiceClientTest {
             .andExpect(content().json("{\"resourceCredentials\":{}}"))
             .andRespond(withSuccess(objectMapper.writeValueAsString(expected), MediaType.APPLICATION_JSON));
 
-        Query query = new Query(List.of(), List.of(), null, List.of(), null, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), null, List.of(), null, null, null);
         Map<String, Map<String, Integer>> result =
             client.getAuthCrossCounts(query, ResultType.CATEGORICAL_CROSS_COUNT, IDENTITY, "request-1", DistributionType.CATEGORICAL);
 
@@ -90,7 +90,7 @@ class QueryServiceClientTest {
             .andExpect(header("X-User-Id", "OPEN_ACCESS:predev.example.org"))
             .andRespond(withSuccess(objectMapper.writeValueAsString(expected), MediaType.APPLICATION_JSON));
 
-        Query query = new Query(List.of(), List.of(), null, List.of(), null, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), null, List.of(), null, null, null);
         Map<String, Map<String, ObfuscatedCount>> result =
             client.getOpenCrossCounts(query, ResultType.CATEGORICAL_CROSS_COUNT, OPEN_IDENTITY, "request-2", DistributionType.CATEGORICAL);
 
@@ -104,7 +104,7 @@ class QueryServiceClientTest {
             .andExpect(headerDoesNotExist("X-User-Email")).andExpect(headerDoesNotExist("X-User-Roles"))
             .andExpect(headerDoesNotExist("X-User-Privileges")).andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
 
-        Query query = new Query(List.of(), List.of(), null, List.of(), null, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), null, List.of(), null, null, null);
         client.getOpenCrossCounts(query, ResultType.CATEGORICAL_CROSS_COUNT, OPEN_IDENTITY, "request-3", DistributionType.CATEGORICAL);
 
         mockServer.verify();
@@ -117,7 +117,7 @@ class QueryServiceClientTest {
         mockServer.expect(requestTo(BASE_URL + "/hpds/auth/v3/query/sync")).andExpect(jsonPath("$.resourceUUID").doesNotExist())
             .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
 
-        Query query = new Query(List.of(), List.of(), null, List.of(), null, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), null, List.of(), null, null, null);
         client.getAuthCrossCounts(query, ResultType.CATEGORICAL_CROSS_COUNT, IDENTITY, "request-4", DistributionType.CATEGORICAL);
 
         mockServer.verify();
@@ -134,7 +134,7 @@ class QueryServiceClientTest {
             .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
 
         Query query = new Query(
-            List.of(), List.of(new AuthorizationFilter("\\_consents\\", Set.of("phs000001.c1"))), null, List.of(), null, null, null
+            List.of(), List.of(new AuthorizationFilter("\\_consents\\", Set.of("phs000001.c1"))), Set.of(), null, List.of(), null, null, null
         );
         client.getAuthCrossCounts(query, ResultType.CATEGORICAL_CROSS_COUNT, IDENTITY, "request-5", DistributionType.CATEGORICAL);
 
@@ -149,7 +149,7 @@ class QueryServiceClientTest {
         mockServer.expect(requestTo(BASE_URL + "/hpds/auth/v3/query/sync"))
             .andRespond(withSuccess(objectMapper.writeValueAsString(expected), MediaType.APPLICATION_JSON));
 
-        Query query = new Query(List.of(), List.of(), null, List.of(), null, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), null, List.of(), null, null, null);
         client.getAuthCrossCounts(query, ResultType.CATEGORICAL_CROSS_COUNT, IDENTITY, "request-6", DistributionType.CATEGORICAL);
 
         ArgumentCaptor<LoggingEvent> eventCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
@@ -180,7 +180,7 @@ class QueryServiceClientTest {
             .andExpect(content().json("{\"query\":{\"expectedResultType\":\"CONTINUOUS_CROSS_COUNT\"}}"))
             .andRespond(withSuccess(objectMapper.writeValueAsString(expected), MediaType.APPLICATION_JSON));
 
-        Query query = new Query(List.of("\\Nhanes\\demographics\\AGE\\"), List.of(), null, List.of(), null, null, null);
+        Query query = new Query(List.of("\\Nhanes\\demographics\\AGE\\"), List.of(), Set.of(), null, List.of(), null, null, null);
         Map<String, Map<String, Integer>> result =
             client.getAuthCrossCounts(query, ResultType.CONTINUOUS_CROSS_COUNT, IDENTITY, "request-7", DistributionType.CONTINUOUS);
 

--- a/services/pic-sure-visualization-service/src/test/java/edu/harvard/dbmi/avillach/visualization/service/VisualizationServiceTest.java
+++ b/services/pic-sure-visualization-service/src/test/java/edu/harvard/dbmi/avillach/visualization/service/VisualizationServiceTest.java
@@ -47,7 +47,7 @@ class VisualizationServiceTest {
     void generateDistributions_authorized_categoricalFilter() {
         PhenotypicFilter catFilter =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\demographics\\race\\", Set.of("White", "Black"), null, null, null);
-        Query query = new Query(List.of(), List.of(), catFilter, List.of(), null, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), catFilter, List.of(), null, null, null);
 
         Map<String, Map<String, Integer>> crossCounts = new LinkedHashMap<>();
         crossCounts.put("\\demographics\\race\\", new LinkedHashMap<>(Map.of("White", 45000, "Black", 12000)));
@@ -65,7 +65,7 @@ class VisualizationServiceTest {
     void generateDistributions_open_withObfuscation() {
         PhenotypicFilter catFilter =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\demographics\\race\\", Set.of("White"), null, null, null);
-        Query query = new Query(List.of(), List.of(), catFilter, List.of(), null, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), catFilter, List.of(), null, null, null);
 
         Map<String, Map<String, ObfuscatedCount>> openCrossCounts = new LinkedHashMap<>();
         openCrossCounts.put(
@@ -85,7 +85,7 @@ class VisualizationServiceTest {
     void generateDistributions_open_setsObfuscatedFromAccessTypeRegardlessOfValues() {
         PhenotypicFilter catFilter =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\demographics\\race\\", Set.of("White"), null, null, null);
-        Query query = new Query(List.of(), List.of(), catFilter, List.of(), null, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), catFilter, List.of(), null, null, null);
 
         // All values look like plain integers — no markers at all.
         Map<String, Map<String, ObfuscatedCount>> openCrossCounts = new LinkedHashMap<>();
@@ -105,7 +105,7 @@ class VisualizationServiceTest {
 
     @Test
     void generateDistributions_noFilters_returnsEmptyCharts() {
-        Query query = new Query(List.of(), List.of(), null, List.of(), null, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), null, List.of(), null, null, null);
 
         VisualizationResponse response = service.generateDistributions(query, AccessType.AUTHORIZED, IDENTITY, null);
 
@@ -116,7 +116,7 @@ class VisualizationServiceTest {
     @Test
     void generateDistributions_authorized_continuousFilter_binsData() {
         PhenotypicFilter numFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\measurements\\bmi\\", null, 18.0, 40.0, null);
-        Query query = new Query(List.of(), List.of(), numFilter, List.of(), null, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), numFilter, List.of(), null, null, null);
 
         Map<String, Integer> rawValues = new LinkedHashMap<>();
         rawValues.put("18.0", 100);
@@ -138,7 +138,7 @@ class VisualizationServiceTest {
 
     @Test
     void generateDistributions_selectFallback_whenNoFilters() {
-        Query query = new Query(List.of("\\demographics\\race\\"), List.of(), null, List.of(), null, null, null);
+        Query query = new Query(List.of("\\demographics\\race\\"), List.of(), Set.of(), null, List.of(), null, null, null);
 
         Map<String, Map<String, Integer>> crossCounts = new LinkedHashMap<>();
         crossCounts.put("\\demographics\\race\\", new LinkedHashMap<>(Map.of("White", 100)));
@@ -154,7 +154,7 @@ class VisualizationServiceTest {
     @Test
     void generateDistributions_requiredNumericFilter_skipsEmptyCategoricalAndReturnsHistogram() {
         PhenotypicFilter required = new PhenotypicFilter(PhenotypicFilterType.REQUIRED, "\\demographics\\AGE\\", null, null, null, null);
-        Query query = new Query(List.of(), List.of(), required, List.of(), null, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), required, List.of(), null, null, null);
 
         Map<String, Map<String, Integer>> emptyCategoricalCounts = new LinkedHashMap<>();
         emptyCategoricalCounts.put("\\demographics\\AGE\\", new LinkedHashMap<>());
@@ -176,7 +176,7 @@ class VisualizationServiceTest {
     void generateDistributions_authorized_categoricalWithManyCategories_aggregatesToOther() {
         PhenotypicFilter catFilter =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\demographics\\race\\", Set.of("A", "B"), null, null, null);
-        Query query = new Query(List.of(), List.of(), catFilter, List.of(), null, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), catFilter, List.of(), null, null, null);
 
         Map<String, Integer> manyCategories = new LinkedHashMap<>();
         for (int i = 1; i <= 9; i++) {
@@ -200,7 +200,7 @@ class VisualizationServiceTest {
     void generateDistributions_authorized_nullCountInResponse_skipsNullEntries() {
         PhenotypicFilter catFilter =
             new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\demographics\\race\\", Set.of("White"), null, null, null);
-        Query query = new Query(List.of(), List.of(), catFilter, List.of(), null, null, null);
+        Query query = new Query(List.of(), List.of(), Set.of(), catFilter, List.of(), null, null, null);
 
         Map<String, Integer> values = new LinkedHashMap<>();
         values.put("White", 45000);


### PR DESCRIPTION
* Deprecate `Query.authorizationFilters`
* Add `Query.userConsents`
* Update PSAMA to populate and send consents instead of authorization filters
* Update tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for passing user consent information with queries.
  * Consent data is now preserved across query processing, visualization, and downstream requests.
* **Authorization**
  * Simplified consent handling with a unified consent set.
  * Improved access decisions for harmonized, genomic, TOPMed, and parent-study data.
  * Legacy authorization-filter handling is deprecated.
* **Bug Fixes**
  * Corrected consent propagation during query decomposition and cross-count operations.
  * Updated query processing to consistently preserve authorization context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->